### PR TITLE
Fix deprecated WebGLRenderTarget constructor for Three.js 0.168+

### DIFF
--- a/src/components/WaterReflection.jsx
+++ b/src/components/WaterReflection.jsx
@@ -25,7 +25,9 @@ export default function WaterReflection({
   
   // Create reflection camera and render target
   useEffect(() => {
-    renderTargetRef.current = new THREE.WebGLRenderTarget(resolution, resolution, {
+    renderTargetRef.current = new THREE.WebGLRenderTarget({
+      width: resolution,
+      height: resolution,
       minFilter: THREE.LinearFilter,
       magFilter: THREE.LinearFilter,
       format: THREE.RGBAFormat,

--- a/src/systems/PostProcessing.tsx
+++ b/src/systems/PostProcessing.tsx
@@ -203,8 +203,8 @@ export const PostProcessing: React.FC<PostProcessingProps> = ({
   
   // Create render targets
   useEffect(() => {
-    renderTargetRef.current = new THREE.WebGLRenderTarget(size.width, size.height);
-    bloomTargetRef.current = new THREE.WebGLRenderTarget(size.width / 2, size.height / 2);
+    renderTargetRef.current = new THREE.WebGLRenderTarget({ width: size.width, height: size.height });
+    bloomTargetRef.current = new THREE.WebGLRenderTarget({ width: size.width / 2, height: size.height / 2 });
     
     return () => {
       renderTargetRef.current?.dispose();

--- a/src/systems/volumetric/VolumetricGodRays.tsx
+++ b/src/systems/volumetric/VolumetricGodRays.tsx
@@ -140,7 +140,9 @@ export const VolumetricGodRays: React.FC<VolumetricGodRaysProps> = ({
   
   // Create render target for scene capture
   const renderTarget = useMemo(() => {
-    return new THREE.WebGLRenderTarget(size.width, size.height, {
+    return new THREE.WebGLRenderTarget({
+      width: size.width,
+      height: size.height,
       minFilter: THREE.LinearFilter,
       magFilter: THREE.LinearFilter,
       format: THREE.RGBAFormat,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `WebGLRenderTarget` in Three.js 0.168+ expects a single options object with `width`/`height` inside, rather than positional `(width, height, options)` args
- Fixed in `WaterReflection.jsx`, `PostProcessing.tsx`, and `VolumetricGodRays.tsx`

## Test plan
- [ ] No "deprecated parameters for the initialization function" console warning on load
- [ ] Water reflection, post-processing bloom, and god rays still render correctly

https://claude.ai/code/session_01DaYmTNPJhEq3ptL8yM9PdV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaYmTNPJhEq3ptL8yM9PdV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal rendering systems to use modern API patterns for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->