### PR TITLE
fix: three load-time errors — moss uniforms, parallax scope, audio NaN

### DIFF
--- a/src/components/ReactiveAudio.tsx
+++ b/src/components/ReactiveAudio.tsx
@@ -224,9 +224,12 @@ export default function ReactiveAudio({
 
     const body = targetRef.current;
     const vel = body.linvel();
-    const playerSpeed = Math.sqrt(vel.x * vel.x + vel.z * vel.z);
-    const flowSpeed = flowRef.current.flowSpeed;
-    const turbulence = flowRef.current.turbulence;
+    const velX = isFinite(vel.x) ? vel.x : 0;
+    const velZ = isFinite(vel.z) ? vel.z : 0;
+    const playerSpeed = Math.sqrt(velX * velX + velZ * velZ);
+    const rawFlowSpeed = flowRef.current.flowSpeed;
+    const flowSpeed = isFinite(rawFlowSpeed) ? rawFlowSpeed : 1;
+    const turbulence = isFinite(flowRef.current.turbulence) ? flowRef.current.turbulence : 0;
 
     // Compute overall intensity 0-1
     const rawIntensity =

--- a/src/utils/RiverShader.js
+++ b/src/utils/RiverShader.js
@@ -144,6 +144,9 @@ export function extendRiverMaterial(material, options = {}) {
                     'uniform vec3 uWarmColor;',
                     'uniform vec3 uCoolColor;',
                     'uniform float uColorVariationStrength;',
+                    enableMoss ? 'uniform vec3 uMossColor;' : '',
+                    enableMoss ? 'uniform vec3 uLichenColor;' : '',
+                    enableMoss ? 'uniform float uMossIntensity;' : '',
                     'varying float vHeightAboveWater;',
                     enableMoss ? 'varying float vMossMask;' : '',
                     enableMoss ? 'varying vec3 vWorldNormal;' : '',
@@ -180,14 +183,11 @@ export function extendRiverMaterial(material, options = {}) {
                 `,
                 ].filter(Boolean).join('\n') + '\n';
 
-                // Parallax offset is computed once at the top of the fragment shader
-                const parallaxPreamble = `
-                // Cheap parallax offset using displacement map or fallback hash height
+                const mapFragmentReplacement = `
+                // Parallax offset — computed once inside void main() where texture2D() is valid
                 float dispHeight = texture2D(uDisplacementMap, vMapUv).r;
                 vec2 parallaxOffset = vViewDir.xy * dispHeight * uDisplacementScale;
-                `;
 
-                const mapFragmentReplacement = `
                 #ifdef USE_MAP
                     vec4 sampledDiffuseColor = texture2D( map, vMapUv + parallaxOffset );
                     #ifdef DECODE_VIDEO_TEXTURE
@@ -211,7 +211,7 @@ export function extendRiverMaterial(material, options = {}) {
                 `;
 
                 let nextFragmentShader = injectShaderChunk(
-                    fragmentPreamble + parallaxPreamble + shader.fragmentShader,
+                    fragmentPreamble + shader.fragmentShader,
                     '#include <map_fragment>',
                     mapFragmentReplacement,
                     'fragment shader'


### PR DESCRIPTION
RiverShader.js:
- Add missing GLSL uniform declarations for uMossColor, uLichenColor, uMossIntensity to fragmentPreamble; they were in shader.uniforms but never declared in the GLSL source, causing Shader Error 1282
- Move parallaxOffset computation from global scope into the map_fragment replacement (inside void main()) where texture2D() and varyings are valid GLSL; previously at global scope which is invalid and caused program VALIDATE_STATUS false

ReactiveAudio.tsx:
- Guard body.linvel() components with isFinite() before computing playerSpeed and intensity; NaN velocity during Rapier startup cascaded into setVolume(NaN), throwing non-finite AudioParam error

https://claude.ai/code/session_01X7MnX892jxGfSXCV6665Zy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio stability by implementing defensive handling of numerical edge cases, preventing audio glitches and playback issues.
  * Optimized shader rendering through streamlined parallax displacement logic and enhanced conditional feature compilation for better performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Watershed/pull/133)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->