### PR TITLE
fix: runtime errors — camera NaN guard, RenderTarget constructor, positional audio

### DIFF
--- a/src/components/ReactiveAudio.tsx
+++ b/src/components/ReactiveAudio.tsx
@@ -161,7 +161,7 @@ export default function ReactiveAudio({
         if (tSeg?.segmentPath) {
           const center = tSeg.segmentPath.getPoint(0.5);
           const tBuf = resolveAudioBuffer(reachId, 'sfx_transition', AUDIO_CONFIG.defaultSfxTracks.transition);
-          if (tBuf) {
+          if (tBuf && isFinite(center.x) && isFinite(center.y) && isFinite(center.z)) {
             posTransitionRef.current = new THREE.PositionalAudio(listener);
             posTransitionRef.current.setBuffer(tBuf);
             posTransitionRef.current.setLoop(true);

--- a/src/components/WaterReflection.jsx
+++ b/src/components/WaterReflection.jsx
@@ -25,9 +25,7 @@ export default function WaterReflection({
   
   // Create reflection camera and render target
   useEffect(() => {
-    renderTargetRef.current = new THREE.WebGLRenderTarget({
-      width: resolution,
-      height: resolution,
+    renderTargetRef.current = new THREE.WebGLRenderTarget(resolution, resolution, {
       minFilter: THREE.LinearFilter,
       magFilter: THREE.LinearFilter,
       format: THREE.RGBAFormat,

--- a/src/vehicles/RunnerVehicle.tsx
+++ b/src/vehicles/RunnerVehicle.tsx
@@ -717,8 +717,11 @@ const RunnerVehicle = forwardRef((props, forwardedRef) => {
     }
 
     // Camera follow (first-person, smooth)
-    const targetPos = new THREE.Vector3(pos.x, pos.y + 1.65, pos.z);
-    camera.position.lerp(targetPos, 0.12);
+    // Guard against NaN from Rapier during physics init — lerping NaN permanently corrupts camera matrix
+    if (isFinite(pos.x) && isFinite(pos.y) && isFinite(pos.z)) {
+      const targetPos = new THREE.Vector3(pos.x, pos.y + 1.65, pos.z);
+      camera.position.lerp(targetPos, 0.12);
+    }
   });
 
   // Remove completed particles


### PR DESCRIPTION
## Summary

- **RunnerVehicle.tsx**: Guard `camera.position.lerp()` against NaN from Rapier physics during initialization. When `body.translation()` briefly returns NaN at startup, lerping it into `camera.position` permanently corrupts the camera's world matrix. This was the root cause of `AudioListener.linearRampToValueAtTime` throwing a DOMException every frame (the listener decomposed the NaN world matrix and tried to upload `NaN` as the audio position).
- **WaterReflection.jsx**: Fix deprecated `new THREE.WebGLRenderTarget({ width, height, ... })` object-form constructor. Three.js 0.168+ requires `(width, height, options)` positional args; passing an object as `width` was silently creating a zero-size render target.
- **ReactiveAudio.tsx**: Add `isFinite` guard on the spline center point before calling `scene.add(posTransitionAudio)` — prevents a NaN panner position if `segmentPath.getPoint(0.5)` ever returns a degenerate vector.

## Test plan

- [ ] Launch game, open browser console — confirm `linearRampToValueAtTime` DOMException no longer fires every frame
- [ ] Confirm player spawns and camera follows correctly
- [ ] Confirm water reflection renders (no zero-size render target console warning)
- [ ] Check no new console errors on startup

https://claude.ai/code/session_01X7MnX892jxGfSXCV6665Zy

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7MnX892jxGfSXCV6665Zy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved audio positioning issues that could become unstable during reactive audio initialization, ensuring consistent and reliable audio playback
  * Resolved camera tracking instability that could occur during vehicle physics initialization, providing a more stable viewing experience

* **Refactor**
  * Updated render target configuration code structure for improved code maintainability and organization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Watershed/pull/134)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->