### PR TITLE
fix: Rapier borrow aliasing error and pointer lock unhandled rejections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,9 @@ function App() {
     if (!window.location.search.includes('no-pointer-lock')) {
       const canvas = document.querySelector('canvas');
       if (canvas) {
-        canvas.requestPointerLock();
+        canvas.requestPointerLock().catch((err) => {
+          console.warn('[App] Pointer lock failed:', err);
+        });
       }
     }
   }, []);
@@ -60,7 +62,9 @@ function App() {
     if (!window.location.search.includes('no-pointer-lock')) {
       const canvas = document.querySelector('canvas');
       if (canvas) {
-        canvas.requestPointerLock();
+        canvas.requestPointerLock().catch((err) => {
+          console.warn('[App] Pointer lock failed:', err);
+        });
       }
     }
   }, []);

--- a/src/components/Environment/FloatingObjectManager.tsx
+++ b/src/components/Environment/FloatingObjectManager.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useMemo, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { InstancedRigidBodies } from '@react-three/rapier';
+import { InstancedRigidBodies, useRapier } from '@react-three/rapier';
 import {
   calculateBuoyancyForce,
   calculateDragForce,
@@ -78,6 +78,7 @@ export default function FloatingObjectManager({
 }: FloatingObjectManagerProps) {
   const bodiesRef = useRef<(any | null)[]>([]);
   const timeRef = useRef(0);
+  const { world } = useRapier();
 
   // Generate object instances deterministically
   const instances = useMemo(() => {
@@ -182,13 +183,26 @@ export default function FloatingObjectManager({
 
     if (!path) return;
 
+    // Step 1: collect handles only — calling translation()/linvel() inside
+    // bodiesRef.current.forEach triggers world.forEachRigidBody internally,
+    // and any borrow of the body inside that callback causes a Rapier WASM
+    // "recursive use / unsafe aliasing" error.
+    const entries: Array<{ handle: number; index: number }> = [];
     bodiesRef.current.forEach((api, i) => {
-      if (!api) return;
+      if (api?.handle !== undefined) {
+        entries.push({ handle: api.handle, index: i });
+      }
+    });
+
+    // Step 2: query and mutate each body outside the forEach callback
+    for (const { handle, index: i } of entries) {
+      const body = world.getRigidBody(handle);
+      if (!body) continue;
 
       try {
-        const pos = api.translation();
-        const vel = api.linvel();
-        if (!pos || !vel) return;
+        const pos = body.translation();
+        const vel = body.linvel();
+        if (!pos || !vel) continue;
 
         // === BUOYANCY ===
         const submergedDepth = waterLevel - pos.y;
@@ -200,7 +214,7 @@ export default function FloatingObjectManager({
             1000,
             9.80665
           );
-          api.applyImpulse({ x: 0, y: buoyancy * dt, z: 0 }, true);
+          body.applyImpulse({ x: 0, y: buoyancy * dt, z: 0 }, true);
         }
 
         // === DRAG ===
@@ -211,7 +225,7 @@ export default function FloatingObjectManager({
           FLOATING_OBJECT.DRAG_AREA,
           1000
         );
-        api.applyImpulse(
+        body.applyImpulse(
           {
             x: dragForce.x * dt,
             y: dragForce.y * dt,
@@ -233,7 +247,7 @@ export default function FloatingObjectManager({
           },
           timeRef.current
         );
-        api.applyImpulse(
+        body.applyImpulse(
           {
             x: flowForce.x * dt,
             y: flowForce.y * dt,
@@ -250,12 +264,12 @@ export default function FloatingObjectManager({
         const distFromCenter = Math.sqrt(toCenter.x * toCenter.x + toCenter.z * toCenter.z);
         if (distFromCenter > waterWidth * 0.4) {
           toCenter.normalize().multiplyScalar(2.0 * dt);
-          api.applyImpulse({ x: toCenter.x, y: 0, z: toCenter.z }, true);
+          body.applyImpulse({ x: toCenter.x, y: 0, z: toCenter.z }, true);
         }
       } catch (e) {
         // Ignore physics errors for individual instances
       }
-    });
+    }
   });
 
   if (!path || instances.length === 0) return null;

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -43,7 +43,9 @@ const Player = forwardRef((props, ref) => {
   }, []);
 
   useEffect(() => {
-    const onClick = () => gl.domElement.requestPointerLock();
+    const onClick = () => gl.domElement.requestPointerLock().catch((err) => {
+      console.warn('[Player] Pointer lock failed:', err);
+    });
     gl.domElement.addEventListener('click', onClick);
     return () => gl.domElement.removeEventListener('click', onClick);
   }, [gl]);

--- a/src/components/UI.tsx
+++ b/src/components/UI.tsx
@@ -94,7 +94,9 @@ export const UI = () => {
     } else {
       const canvas = document.querySelector('canvas');
       if (canvas) {
-        canvas.requestPointerLock();
+        canvas.requestPointerLock().catch((err) => {
+          console.warn('[UI] Pointer lock failed:', err);
+        });
       }
     }
   };


### PR DESCRIPTION
## Summary

- **Bug 1 (Rapier borrow aliasing)**: `FloatingObjectManager` called `api.translation()` / `api.linvel()` inside `bodiesRef.current.forEach`, which in `@react-three/rapier`'s `InstancedRigidBodies` internally maps to `world.forEachRigidBody`. Rapier's WASM bindings forbid borrowing any body while the world is being iterated, causing ~1000+ "recursive use / unsafe aliasing" errors per session. Fixed by collecting body handles first (safe — only reads `.handle`), then querying `world.getRigidBody(handle)` and applying forces outside the callback.
- **Bug 2 (Pointer lock rejections)**: `requestPointerLock()` returns a Promise in modern browsers. All three call sites (`App.tsx` `handleStart`/`handleResume`, `Player.jsx` canvas click, `UI.tsx` `handleStart`) were calling it without `.catch()`, producing unhandled rejections logged as "THREE.PointerLockControls: Unable to use Pointer Lock API". All sites now chain `.catch(err => console.warn(...))`.

## Test plan

- [ ] Launch game — no "recursive use of an object detected" errors in console
- [ ] Click START RUN — no "Unable to use Pointer Lock API" unhandled rejection in console
- [ ] Floating debris objects still move/bob on water correctly
- [ ] Pointer lock engages normally on game start and resume

https://claude.ai/code/session_01KWUEqNYDKTr32EMgEgTZW7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWUEqNYDKTr32EMgEgTZW7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error handling for pointer lock requests with informative console warnings when lock failures occur across multiple application entry points.

* **Refactor**
  * Optimized floating object physics simulation to improve how forces and movements are calculated during each frame update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Watershed/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->