### PR TITLE
fix: harden startup against NaN propagation and deprecated APIs

### DIFF
--- a/src/Experience.jsx
+++ b/src/Experience.jsx
@@ -173,15 +173,19 @@ const InnerExperience = () => {
       const vel = vehicleRef.current.linvel?.();
       const pos = vehicleRef.current.translation?.();
 
-      if (vel) {
+      // Guard against NaN from Rapier during physics init — NaN here
+      // propagates into Zustand, PostProcessingPipeline uniforms, and HUD.
+      const velOk = vel && isFinite(vel.x) && isFinite(vel.z);
+      const posOk = pos && isFinite(pos.x) && isFinite(pos.y) && isFinite(pos.z);
+
+      if (velOk) {
         const speed = Math.sqrt(vel.x * vel.x + vel.z * vel.z);
         playerVelocityRef.current = speed;
 
-        // Throttled batch update into Zustand (position + speed + distance)
-        const downstream = pos ? Math.abs(pos.z) : 0;
+        const downstream = posOk ? Math.abs(pos.z) : 0;
         const meters = Math.floor(downstream * 0.5);
         batchFrameUpdate(
-          { x: pos?.x ?? 0, y: pos?.y ?? 0, z: pos?.z ?? 0 },
+          { x: posOk ? pos.x : 0, y: posOk ? pos.y : 0, z: posOk ? pos.z : 0 },
           speed,
           useGameStore.getState().currentSegmentIndex
         );
@@ -190,7 +194,7 @@ const InnerExperience = () => {
       }
 
       // Minimal wipeout detection
-      if (pos && pos.y < -80 && !isWipeout) {
+      if (posOk && pos.y < -80 && !isWipeout) {
         setIsWipeout(true);
       }
     }

--- a/src/components/PostProcessingPipeline.jsx
+++ b/src/components/PostProcessingPipeline.jsx
@@ -165,8 +165,10 @@ export function PostProcessingPipeline({
     boostRef.current.active = Math.max(0, boostRef.current.active - delta * 1.2);
     const boostScale = boostRef.current.active > 0 ? boostRef.current.intensity : 0;
 
-    // Read velocity
-    const velocity = velocityRef?.current ?? 0;
+    // Read velocity — guard NaN (?? only catches null/undefined) so the
+    // smoothed lerps below don't get stuck at NaN forever.
+    const rawVel = velocityRef?.current;
+    const velocity = isFinite(rawVel) ? rawVel : 0;
     const speedFactor = Math.min(1, velocity / 25);
 
     // Chromatic aberration target

--- a/src/systems/PostProcessing.tsx
+++ b/src/systems/PostProcessing.tsx
@@ -203,8 +203,8 @@ export const PostProcessing: React.FC<PostProcessingProps> = ({
   
   // Create render targets
   useEffect(() => {
-    renderTargetRef.current = new THREE.WebGLRenderTarget({ width: size.width, height: size.height });
-    bloomTargetRef.current = new THREE.WebGLRenderTarget({ width: size.width / 2, height: size.height / 2 });
+    renderTargetRef.current = new THREE.WebGLRenderTarget(size.width, size.height);
+    bloomTargetRef.current = new THREE.WebGLRenderTarget(size.width / 2, size.height / 2);
     
     return () => {
       renderTargetRef.current?.dispose();

--- a/src/systems/volumetric/VolumetricGodRays.tsx
+++ b/src/systems/volumetric/VolumetricGodRays.tsx
@@ -140,9 +140,7 @@ export const VolumetricGodRays: React.FC<VolumetricGodRaysProps> = ({
   
   // Create render target for scene capture
   const renderTarget = useMemo(() => {
-    return new THREE.WebGLRenderTarget({
-      width: size.width,
-      height: size.height,
+    return new THREE.WebGLRenderTarget(size.width, size.height, {
       minFilter: THREE.LinearFilter,
       magFilter: THREE.LinearFilter,
       format: THREE.RGBAFormat,


### PR DESCRIPTION
- Experience.jsx useFrame: isFinite guards on Rapier vel/pos before they flow into playerVelocityRef (PostProcessingPipeline) and Zustand (HUD, distance). Previously ?? only caught null/undefined, letting NaN cascade and lock smoothed lerps at NaN.
- PostProcessingPipeline.jsx: isFinite guard on velocityRef.current so the chromatic/saturation/vignette smoothing lerps recover when the source briefly produces NaN.
- PostProcessing.tsx, VolumetricGodRays.tsx: fix deprecated WebGLRenderTarget({width,height,...}) object form (Three.js 0.168 requires positional args). Neither is mounted today, but the bug would surface immediately if they were enabled.

https://claude.ai/code/session_01X7MnX892jxGfSXCV6665Zy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability by validating physics calculations and falling back to safe defaults when invalid values occur.
  * Improved post-processing effects reliability by properly handling non-finite velocity values.
  * Fixed render target initialization for more stable visual effects rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Watershed/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->