### PR TITLE
fix: stop Rapier BVH panic at startup by disabling tree hull colliders

### DIFF
--- a/src/components/Environment/Vegetation.jsx
+++ b/src/components/Environment/Vegetation.jsx
@@ -74,7 +74,7 @@ export default function Vegetation({ transforms, biome = 'summer' }) {
       <InstancedRigidBodies
         instances={instances}
         type="fixed"
-        colliders="hull"
+        colliders={false}
       >
         <Instances range={instances.length} geometry={trunkGeometry} material={trunkMaterial} castShadow receiveShadow>
           {instances.map((t) => (


### PR DESCRIPTION
## Problem

Game failed to start past the menu. Headless puppeteer run showed:

```
PAGEERR: unreachable
  RuntimeError: unreachable
    at $func1156 (wasm)            ← Rapier BVH traversal
    at $func1720 ... $func58 ...
    at $rawphysicspipeline_stepWithEvents

PAGEERR: recursive use of an object detected which would lead to unsafe aliasing in rust
    at rbTranslation
    at forEachRigidBody              (@react-three/rapier)
```

The wasm trap fires inside Rapier's BVH/trimesh traversal during `world.step()`. After that the wasm `RefCell` is poisoned, so every subsequent `rb.translation()` call from `forEachRigidBody` throws "recursive use of an object" — flooding the console.

## Cause

`src/components/Environment/Vegetation.jsx` mounts every tree in `InstancedRigidBodies` with `colliders="hull"`. With many instances at varying scales, hull computation/BVH traversal panics inside Rapier.

## Fix

Set `colliders={false}` on the tree `InstancedRigidBodies`. Trees don't need physical collision for the river-runner gameplay — the player traverses the river channel, not the forest banks.

## Verification

Headless puppeteer run with `--use-gl=swiftshader` after the fix:

```
--- UNIQUE ERRORS ---
Failed to load resource: the server responded with a status of 404 (Not Found)   # favicon.ico only
```

No more wasm traps, no rbTranslation aliasing errors, scene mounts cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3WP3BUqQnBDm449Q8JV31)_