### PR TITLE
fix: align player spawn with first canyon chunk

### DIFF
--- a/src/constants/game.ts
+++ b/src/constants/game.ts
@@ -22,7 +22,7 @@ export const GRAVITY = 9.80665;
 
 export const PLAYER_SPAWN = {
     position: [0, -4, -10] as const,
-    fallbackCamera: [0, 10, -10] as const,
+    fallbackCamera: [0, -3.2, -10] as const,
 };
 
 export const GENERATION = {

--- a/src/systems/ChunkManager.ts
+++ b/src/systems/ChunkManager.ts
@@ -79,11 +79,15 @@ const MAX_ACTIVE_SEGMENTS = GENERATION.MAX_ACTIVE_SEGMENTS;
 const GENERATION_THRESHOLD = GENERATION.THRESHOLD;
 const RECYCLE_MARGIN = GENERATION.RECYCLE_MARGIN;
 
+// Seed points used to derive the direction of segment 0. The LAST point becomes
+// segment 0's starting position, so it must sit at/near the player spawn (0, -4, -10)
+// — earlier values placed the first chunk ~50m downstream, leaving the player floating
+// in empty space behind the canyon.
 const INITIAL_POINTS = [
-  new THREE.Vector3(0, -6, 30),
-  new THREE.Vector3(0, -6, 5),
-  new THREE.Vector3(2, -8, -25),
-  new THREE.Vector3(8, -12, -60),
+  new THREE.Vector3(0, -6, 80),
+  new THREE.Vector3(0, -6, 50),
+  new THREE.Vector3(0, -6, 20),
+  new THREE.Vector3(0, -6, 0),
 ];
 
 // =============================================================================


### PR DESCRIPTION
## Root cause

`ChunkManager.INITIAL_POINTS` seeded segment 0 from `(8, -12, -60)`, so the canyon mesh didn't begin until z ≈ -60. The player spawns at `(0, -4, -10)` — ~50m **behind** the start of the geometry, in empty space. That matches the screenshot: a small canyon visible far ahead in white fog.

Note: `DefaultMapManager.generateChunk()` in `MapSystem.ts` is **not** the active code path — `TrackManager` uses `ChunkManager.buildSegment` → `createSegmentData`, which seeds from `INITIAL_POINTS`. The previous fix only touched `MapSystem.ts` and had no effect.

## Fix

- `src/systems/ChunkManager.ts`: move `INITIAL_POINTS` so segment 0's first path point lands at `(0, -6, 0)`. Player spawn at z=-10 is now 10m inside the channel.
- `src/constants/game.ts`: sync `fallbackCamera` Y with the new spawn so the pre-physics frame doesn't render a high overhead view.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR1wYB3em9tBimneVnekeD)_