### PR TITLE
Downhill creek run + second waterfall (segments 23–30)

### DIFF
--- a/src/Experience.jsx
+++ b/src/Experience.jsx
@@ -26,7 +26,7 @@ import WaterInteraction from "./components/WaterInteraction";
 import { PostProcessingPipeline } from "./components/PostProcessingPipeline";
 import { useCameraShake } from "./hooks/useCameraShake";
 import { useSegmentAudio } from "./hooks/useSegmentAudio";
-import { initAudio } from "./systems/AudioSystem";
+import { initAudio, getAudioManager } from "./systems/AudioSystem";
 import AudioDiagnosticsOverlay from "./components/AudioDiagnosticsOverlay";
 import { DEBUG_STAGES } from "./debug/debugStages";
 import PerfCheckpointMonitor from "./debug/PerfCheckpointMonitor";
@@ -154,6 +154,22 @@ const InnerExperience = ({ debug = NOOP_DEBUG, physicsDebug = false }) => {
         } else if (index === 15) {
           // Reset gravity after waterfall
           setWaterfallGravityMultiplier(1.0);
+        }
+
+        // Audio cues for the downhill-creek → waterfall progression (segments 23–30)
+        const audio = getAudioManager();
+        if (audio) {
+          if (index >= 23 && index <= 27) {
+            audio.setAmbient('ambient_water', 1500);
+          } else if (index === 28) {
+            audio.playSound('rapids_roar', 0.8);
+            audio.playSound('water_crash', 0.3);
+          } else if (index === 29) {
+            audio.playSound('water_crash', 1.0);
+            window.dispatchEvent(new CustomEvent('camera-shake', { detail: { intensity: 0.7 } }));
+          } else if (index === 30) {
+            audio.setAmbient('ambient_water', 1500);
+          }
         }
       };
 

--- a/src/components/Environment/WaterfallParticles.jsx
+++ b/src/components/Environment/WaterfallParticles.jsx
@@ -18,7 +18,9 @@ export default function WaterfallParticles({
     height = 25,
     playerVelocity = 0,
     particleDensity = 1.0, // 0.0-1.0 from segment config
+    fanAngle = 0, // degrees of horizontal spread; 0 = straight down
 }) {
+    const fanSpreadRad = (fanAngle * Math.PI) / 180;
     const { config: lodConfig } = useLOD();
     const meshRef = useRef();
     const lightRef = useRef();
@@ -71,13 +73,18 @@ export default function WaterfallParticles({
             const speed = 0.2 + Math.random() * 0.3;
             const scale = 0.5 + Math.random() * 0.5;
 
-            temp.push({ 
-                x, y, z, speed, scale, initialY: y,
+            // Fan spread: assign each particle a randomised lateral velocity
+            const randomAngle = (Math.random() - 0.5) * fanSpreadRad;
+            const vx = fanSpreadRad > 0 ? Math.sin(randomAngle) * speed * 1.5 : 0;
+            const vz = fanSpreadRad > 0 ? Math.cos(randomAngle) * speed * 0.3 : 0;
+
+            temp.push({
+                x, y, z, speed, scale, initialY: y, vx, vz,
                 active: i < baseCount // Only active particles are rendered
             });
         }
         return temp;
-    }, [width, height, baseCount]);
+    }, [width, height, baseCount, fanSpreadRad]);
 
     // Reusable dummy object for matrix calculations
     const dummy = useMemo(() => new THREE.Object3D(), []);
@@ -114,13 +121,16 @@ export default function WaterfallParticles({
         particles.forEach((p, i) => {
             // Only process active particles
             if (i < currentCount) {
-                // Move particle down
+                // Move particle down (and outward for fan-shaped falls)
                 p.y -= p.speed;
+                if (p.vx) p.x += p.vx;
+                if (p.vz) p.z += p.vz;
 
                 // Reset to top if it hits bottom
                 if (p.y < 0) {
                     p.y = height;
                     p.x = (Math.random() - 0.5) * width;
+                    p.z = (Math.random() - 0.5) * 5;
                 }
 
                 // Update transform

--- a/src/components/FlowingWater.jsx
+++ b/src/components/FlowingWater.jsx
@@ -30,6 +30,7 @@ export default function FlowingWater({
   vehicleVelocity = null,
   weatherRipple = 0,
   wetness = 0,
+  waterSurfaceOffset = 0,
 }) {
   const materialRef = useRef(null);
   const { camera } = useThree();
@@ -392,9 +393,9 @@ export default function FlowingWater({
 
   return (
     <>
-      <mesh geometry={geometry} material={material} />
+      <mesh geometry={geometry} material={material} position={[0, -waterSurfaceOffset, 0]} />
       {shaderLoading && effectiveShaderId && (
-        <mesh geometry={geometry}>
+        <mesh geometry={geometry} position={[0, -waterSurfaceOffset, 0]}>
           <meshBasicMaterial color="#1a6b8a" transparent opacity={0.35} side={THREE.DoubleSide} />
         </mesh>
       )}

--- a/src/components/TrackManager.jsx
+++ b/src/components/TrackManager.jsx
@@ -189,7 +189,11 @@ export default function TrackManager({ onBiomeChange, raftRef, forecastSamples =
                 onBiomeChange?.(biome, segmentIndex);
             },
             onSegmentEnter: (index) => {
-                window.dispatchEvent(new CustomEvent('segment-enter', { detail: { segmentIndex: index } }));
+                const activeSegments = chunkManagerRef.current?.getActiveSegments?.() ?? [];
+                const entered = activeSegments.find((s) => s?.id === index);
+                const flowSpeed = entered?.flowSpeed ?? 1.0;
+                window.__watershedFlowSpeed = flowSpeed;
+                window.dispatchEvent(new CustomEvent('segment-enter', { detail: { segmentIndex: index, flowSpeed } }));
             },
         };
 

--- a/src/components/TrackSegment.jsx
+++ b/src/components/TrackSegment.jsx
@@ -106,6 +106,7 @@ export default function TrackSegment({
     particleCount = 0,
     particleDensity = 1.0, // 0.0-1.0 for E4 scaling
     flowSpeed = 1.0,
+    verticalBias = 0,
     treeDensity = 1.0,
     rockDensity = 'low',
     rockMaterial,
@@ -1192,6 +1193,7 @@ export default function TrackSegment({
             raftRef={raftRef}
             isNight={isNight}
             flowMap={flowMap}
+            verticalBias={verticalBias}
             weatherWetnessRef={weatherWetnessRef}
         />
     );
@@ -1219,8 +1221,11 @@ function TrackSegmentMeshes({
     raftRef,
     isNight = false,
     flowMap,
+    verticalBias = 0,
     weatherWetnessRef,
 }) {
+    const waterSurfaceOffset = (segmentState === 'downhill' || verticalBias <= -1.2) ? 0.6 : 0;
+    const waterfallFanAngle = (type === 'waterfall' && (particleCount || 0) >= 500) ? 60 : 0;
     const biomeProfile = useMemo(() => getTrackBiomeProfile(biome), [biome]);
     // Clone material for wall to apply RiverShader effects
     const wallMaterialRef = useRef(null);
@@ -1338,6 +1343,7 @@ function TrackSegmentMeshes({
                 flowMap={flowMap}
                 vehiclePos={vehiclePos}
                 vehicleVelocity={vehicleVelocity}
+                waterSurfaceOffset={waterSurfaceOffset}
             />
 
             {/* Vegetation - Trees with Sway (ref for draw-distance culling) */}
@@ -1426,6 +1432,7 @@ function TrackSegmentMeshes({
                         height={20}
                         playerVelocity={playerVelocity}
                         particleDensity={particleDensity}
+                        fanAngle={waterfallFanAngle}
                     />
                 </group>
             )}

--- a/src/maps/meander_to_waterfall.ts
+++ b/src/maps/meander_to_waterfall.ts
@@ -74,7 +74,72 @@ export const MEANDER_TO_WATERFALL_PROGRESSION: SegmentRange[] = [
             rockDensity: 'high',
         },
     },
-    // Segments 19+ catch-all — Autumn Rapids (open-ended, covers 19 and 23+)
+    // Segments 23–27 — Downhill Creek Run (fast mossy slot creek)
+    {
+        indexFrom: 23,
+        indexTo: 27,
+        config: {
+            biome: 'summer',
+            type: 'normal',
+            width: 28,
+            waterWidth: 9,
+            verticalBias: -1.5,
+            meanderStrength: 0.6,
+            flowSpeed: 1.4,
+            treeDensity: 0.6,
+            rockDensity: 'high',
+        },
+    },
+    // Segment 28 — Drop-off Ledge (pre-waterfall steepening)
+    {
+        indexFrom: 28,
+        indexTo: 28,
+        config: {
+            biome: 'summer',
+            type: 'normal',
+            width: 22,
+            waterWidth: 7,
+            verticalBias: -2.2,
+            meanderStrength: 0.1,
+            flowSpeed: 1.5,
+            rockDensity: 'high',
+            cameraShake: 0.2,
+        },
+    },
+    // Segment 29 — Second Waterfall (wide fanning curtain)
+    {
+        indexFrom: 29,
+        indexTo: 29,
+        config: {
+            biome: 'summer',
+            type: 'waterfall',
+            width: 40,
+            waterWidth: 14,
+            verticalBias: -3.0,
+            meanderStrength: 0,
+            forwardMomentum: 0.12,
+            particleCount: 600,
+            cameraShake: 0.7,
+            flowSpeed: 2.0,
+        },
+    },
+    // Segment 30 — Plunge Pool (autumn transition, calm swirl)
+    {
+        indexFrom: 30,
+        indexTo: 30,
+        config: {
+            biome: 'autumn',
+            type: 'splash',
+            width: 75,
+            waterWidth: 22,
+            verticalBias: -0.1,
+            meanderStrength: 0.4,
+            flowSpeed: 0.25,
+            treeDensity: 0.8,
+            rockDensity: 'low',
+        },
+    },
+    // Segments 19+ catch-all — Autumn Rapids (open-ended, covers 19 and 31+)
     {
         indexFrom: 19,
         config: {

--- a/src/vehicles/RunnerVehicle.tsx
+++ b/src/vehicles/RunnerVehicle.tsx
@@ -597,7 +597,7 @@ const RunnerVehicle = forwardRef((props, forwardedRef) => {
           
           // Determine material and wetness
           const material = collisionState.current.currentBiome.includes('autumn') ? 'moss' : 'rock';
-          const isWet = pos.y < WATER_LEVEL + 0.5;
+          const isWet = pos.y < WATER_LEVEL + 1.0;
           
           playFootstep(material, isWet);
         }
@@ -714,6 +714,29 @@ const RunnerVehicle = forwardRef((props, forwardedRef) => {
         y: (pVel.y - vel.y) * transfer * 0.5, // Less vertical transfer
         z: (pVel.z - vel.z) * transfer
       }, true);
+    }
+
+    // === IN-WATER PHYSICS ===
+    // Shallow-water running: lower damping, lateral current push.
+    const inShallowWater = pos.y < WATER_LEVEL + 1.0;
+    if (inShallowWater) {
+      try {
+        body.setLinearDamping(0.35 * 0.85);
+      } catch (_e) { /* damping setter unavailable */ }
+      const w = window as unknown as { __watershedFlowSpeed?: number };
+      const segFlow = (typeof window !== 'undefined' && Number.isFinite(w.__watershedFlowSpeed))
+        ? (w.__watershedFlowSpeed as number)
+        : 1.0;
+      const currentPush = 0.3 * segFlow * dt;
+      body.applyImpulse({
+        x: forwardDir.x * currentPush,
+        y: 0,
+        z: forwardDir.z * currentPush,
+      }, true);
+    } else {
+      try {
+        body.setLinearDamping(0.35);
+      } catch (_e) { /* damping setter unavailable */ }
     }
 
     // Camera follow (first-person, smooth)


### PR DESCRIPTION
## Summary
Adds a new scripted progression after the Pond: a fast downhill creek run, a drop-off ledge, a second (wider) waterfall, and a plunge pool. Plus the supporting in-water physics, water-surface offset, fan-shaped waterfall particles, and audio cues.

## Changes
- **`src/maps/meander_to_waterfall.ts`** — four new `SegmentRange` entries (23–27, 28, 29, 30) inserted before the `indexFrom: 19` catch-all.
- **`src/components/FlowingWater.jsx`** — new `waterSurfaceOffset` prop (lowers the water mesh on steep segments so the runner appears to be in shin-deep water).
- **`src/components/TrackSegment.jsx`** — accepts `verticalBias`, computes `waterSurfaceOffset = 0.6` when `segmentState === 'downhill'` or `verticalBias <= -1.2`, and passes `fanAngle={60}` to `WaterfallParticles` when `type === 'waterfall'` and `particleCount >= 500`.
- **`src/components/Environment/WaterfallParticles.jsx`** — new `fanAngle` prop that randomises XZ velocity so particles fan outward. Default `0` (straight down) keeps segment 14 behaviour.
- **`src/components/TrackManager.jsx`** — publishes the active segment's `flowSpeed` to `window.__watershedFlowSpeed` and on the `segment-enter` event.
- **`src/vehicles/RunnerVehicle.tsx`** — when `pos.y < WATER_LEVEL + 1.0`, reduces linear damping by 15%, applies a small forward current push scaled by `flowSpeed`, and uses the same threshold for the wet-footstep sound.
- **`src/Experience.jsx`** — audio cues on `segment-enter` for 23–27 (creek ambient), 28 (rapids roar + crash sting), 29 (full water crash + camera shake), 30 (back to ambient water).

## Test plan
- [ ] `npm run build` succeeds (verified locally).
- [ ] Run forward from spawn through the level; segments 23–30 generate in order without errors.
- [ ] On segment 23 the player visibly accelerates downhill without input.
- [ ] On segment 29 the waterfall particles visibly fan out wider than segment 14.
- [ ] `footstep_wet` is the only footstep audio heard when `Y < WATER_LEVEL + 1.0`.
- [ ] No new debug meshes or console errors.

https://claude.ai/code/session_01Tzx59KaMuQJJ2oWDRvygQJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tzx59KaMuQJJ2oWDRvygQJ)_