### PR TITLE
fix(physics): add XY variation to INITIAL_POINTS seed

### DIFF
--- a/src/systems/ChunkManager.ts
+++ b/src/systems/ChunkManager.ts
@@ -80,13 +80,13 @@ const GENERATION_THRESHOLD = GENERATION.THRESHOLD;
 const RECYCLE_MARGIN = GENERATION.RECYCLE_MARGIN;
 
 // Seed points used to derive the direction of segment 0. The LAST point becomes
-// segment 0's starting position, so it must sit at/near the player spawn (0, -4, -10)
-// — earlier values placed the first chunk ~50m downstream, leaving the player floating
-// in empty space behind the canyon.
+// segment 0's starting position, so it must sit near the player spawn (0, -4, -10).
+// XY must vary across the seeds — perfectly collinear seeds produced a numerically
+// degenerate path that crashed Rapier's trimesh collider during world.step.
 const INITIAL_POINTS = [
-  new THREE.Vector3(0, -6, 80),
-  new THREE.Vector3(0, -6, 50),
-  new THREE.Vector3(0, -6, 20),
+  new THREE.Vector3(-4, -8, 90),
+  new THREE.Vector3(-2, -7, 60),
+  new THREE.Vector3(-1, -6.5, 30),
   new THREE.Vector3(0, -6, 0),
 ];
 


### PR DESCRIPTION
Perfectly collinear seed points (all y=-6, all x=0) produced a numerically unstable initial path tangent, which downstream made the canyon trimesh collider degenerate enough that Rapier's WASM step panicked with 'unreachable'. Restore XY variation across the seeds (the pre-bug values had it too) while keeping the last point at (0,-6,0) so segment 0 still begins at the player spawn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved path generation quality by updating seed geometry configuration to prevent numerically degenerate paths through varied coordinate specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Watershed/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->