### PR TITLE
fix(physics): use index access instead of .forEach on InstancedRigidB…

### DIFF
--- a/src/components/Environment/FloatingObjectManager.tsx
+++ b/src/components/Environment/FloatingObjectManager.tsx
@@ -168,12 +168,18 @@ export default function FloatingObjectManager({
   }, [instances]);
 
   useFrame(() => {
-    bodiesRef.current.forEach((api) => {
+    // Discover newly-available handles via plain index access — calling
+    // bodiesRef.current.forEach internally invokes world.forEachRigidBody,
+    // which borrows the Rapier RigidBodySet and races with translation()
+    // calls from sibling FOM instances ("recursive use of an object" panic).
+    const arr = bodiesRef.current;
+    for (let i = 0; i < instances.length; i += 1) {
+      const api = arr[i];
       if (api && api.handle !== undefined && !registeredHandlesRef.current.has(api.handle)) {
         registerFloatingPlatform(api.handle);
         registeredHandlesRef.current.add(api.handle);
       }
-    });
+    }
   });
 
   // Per-frame physics: buoyancy, drag, flow force


### PR DESCRIPTION
…odies ref

bodiesRef.current.forEach is implemented by @react-three/rapier as a wrapper that invokes world.forEachRigidBody, which borrows the Rapier RigidBodySet for the duration of the callback. With 7 active FloatingObjectManager instances each running this in useFrame, the borrows interleave with sibling instances' translation() calls and trip Rapier's 'recursive use of an object' panic.

Plain index access on the ref array does not invoke world.forEachRigidBody and avoids the borrow.