### PR TITLE
fix: resolve Emscripten RTTI/Embind conflict (-fno-rtti + --bind)

### DIFF
--- a/emscripten/CMakeLists.txt
+++ b/emscripten/CMakeLists.txt
@@ -46,6 +46,7 @@ if(EMSCRIPTEN)
         -ffast-math
         -fno-exceptions
         -fno-rtti
+        -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0
         -funroll-loops
         -mbulk-memory
     )

--- a/emscripten/build.sh
+++ b/emscripten/build.sh
@@ -82,7 +82,7 @@ INITIAL_MEMORY_BYTES=67108864  # 64 * 1024 * 1024
 if [ "$DEBUG_BUILD" -eq 1 ]; then
     COMPILE_FLAGS="-O0 -g3 -msimd128 -mbulk-memory"
 else
-    COMPILE_FLAGS="-O3 -msimd128 -ffast-math -fno-exceptions -fno-rtti -funroll-loops -mbulk-memory"
+    COMPILE_FLAGS="-O3 -msimd128 -ffast-math -fno-exceptions -fno-rtti -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0 -funroll-loops -mbulk-memory"
 fi
 
 if [ "$USE_THREADS" -eq 1 ]; then


### PR DESCRIPTION
## Summary

- Adds `-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0` to both `emscripten/CMakeLists.txt` and `emscripten/build.sh`
- Fixes the 7 static assertion errors in `emscripten/wire.h` caused by using `-fno-rtti` together with Emscripten's `--bind` (Embind)

## Root cause

Emscripten's Embind (`--bind`) uses `LightTypeID<T>::get()` to register type names at runtime. With RTTI disabled (`-fno-rtti`), those type name lookups are illegal — the assert fires at compile time. The define `-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0` switches Embind to integer-based type IDs instead of string names, making it compatible with `-fno-rtti`.

## Test plan

- [ ] Run `./emscripten/build.sh` — should complete without errors
- [ ] Confirm `public/watershed_native.js` and `public/watershed_native.wasm` are produced
- [ ] Verify WASM module loads in browser (`npm start`)

https://claude.ai/code/session_01BEdTRAzwyxTjUpxJvXpapq

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEdTRAzwyxTjUpxJvXpapq)_