### PR TITLE
chore(plan): weekly routine update 2026-05-27

### DIFF
--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,9 +1,9 @@
 # Watershed — Weekly Plan
 
 ## Today's focus
-<!-- Routine writes here each run. You can delete after day ends, or keep as history. -->
-**2026-05-20 — Complete reactive audio validation: synthesize valid PCM tones for all 23 public/sounds/ stubs + add dev-mode AudioDiagnosticsOverlay**
-All 23 `public/sounds/` files remain 477-byte ID3v2 stubs. ReactiveAudio NaN volume is fixed (PR #144), spawn/physics are stable (PRs #145–147), and the AudioSystem init → crossfade chain is wired. Today: generate minimal valid MP3/WAV files for each sound slot (synthesized tones via ffmpeg or pure Python) so the audio pipeline can be smoke-tested in-game, then add `AudioDiagnosticsOverlay.tsx` gated behind `import.meta.env.DEV` showing AudioContext state, buffer load status, active sounds, and crossfade volumes.
+**2026-05-27 — Fix broken production build + integrate WatershedWasm buoyancy into FloatingObjectManager**
+
+`npm run build` is broken: the build script unconditionally chains `npm run build:wasm && npm run build:wasm:threads && vite build`, but Emscripten (`emcc`) is not installed in the dev environment and `public/watershed_native.wasm` does not exist. Fix: make `build:wasm` skip gracefully when `emcc` is not in PATH (add early-exit to `emscripten/build.sh`, no WASM compile attempted unless toolchain present). Second: `WatershedWasm.ts` is fully unintegrated — no game component imports it. Begin integration by wiring buoyancy (`computeBuoyancy`) into `FloatingObjectManager.ts`, which already has NaN guards from last week's physics fixes — a natural hook point. Acceptance: `npm run build` exits 0 without Emscripten installed; `FloatingObjectManager` uses `WatershedWasm.computeBuoyancy` for upward force when the WASM module is loaded, falls back to JS formula otherwise.
 
 ## Ideas
 <!--
@@ -14,25 +14,32 @@ Routine will mark picked items as "[in progress — YYYY-MM-DD]".
 -->
 - [x] Wire GameHUD into Experience.jsx — done 2026-05-06; all acceptance criteria met per .swarm-state.md
 - [x] Author segments 0–12 waypoints in meander_to_waterfall.json — done 2026-05-13; PR #130 merged (deterministic decoration placement + authored waypoints)
-- [in progress — 2026-05-20] Reactive audio validation — all 23 public/sounds/ stubs still 477 bytes; ReactiveAudio NaN volume fixed (PR #144), spawn/physics bugs fixed (PRs #143–147); pipeline now stable enough to synthesize PCM tones and smoke-test full audio chain; diagnostics overlay still needed
-- [ ] In-scene Level Editor — wire LevelEditor scaffold (PathVisualizer, SegmentInspector, BiomeSelector in src/components/LevelEditor/) into dev-mode; LevelEditor.tsx currently has its own standalone Canvas — needs architectural decision (overlay on game Canvas vs. full editor mode swap); PathVisualizer already implements CatmullRom line + difficulty gradient; SegmentInspector has full property editor; BiomeSelector has biome grid; just needs wiring + dev gate + JSON export textarea
+- [x] Reactive audio validation — done 2026-05-27: all 23 MP3 stubs replaced with valid 1-second sine tones (17,180 bytes each), AudioDiagnosticsOverlay.tsx wired into Experience.jsx behind DEV gate, AudioSystem.ts updated with getLoadStatus/getActiveSounds diagnostics APIs; confirmed by .swarm-state.md
+- [x] In-scene Level Editor — done 2026-05-20: PR #151 merged; LevelEditor wired via ?editor=1, useLevelEditor.ts hook + levelEditorValidator.ts added; Option A (overlay on game Canvas) selected
 
 ## Backlog
 <!--
 Unfinished items, known bugs, deferred ideas.
 Routine maintains this automatically — you can add items too.
 -->
+- [ ] **CRITICAL:** `npm run build` broken — emcc not found, build:wasm fails; `public/watershed_native.wasm` missing; WatershedWasm.ts unintegrated (no game component imports it)
 - [ ] Verify RiverShader.js moss effect receives correct world normals from TrackSegment.jsx terrain mesh (visual check needed)
-- [ ] Replace stub MP3s in public/sounds/ with real foley/audio assets (current files may be silent 477-byte placeholders — verify first)
 - [ ] ReachManager architecture not documented in CLAUDE.md — significant new systems (ReachStreamer, ReachNormalizer, BiomeSystem, LODManager, SplashSystem, WaterReflection, WaterInteraction) need doc pass before onboarding new contributors
+- [ ] WatershedWasm.ts not wired into any game component — TypeScript bindings + Jest tests exist but `getWasm()` is never called from live code; buoyancy/drag/SWE grid unused
+- [ ] WASM build requires Emscripten SDK at `/content/buil*/emsdk/` (hardcoded path in build.sh) — needs portable emsdk_env.sh discovery or CI matrix
 
 ## Done
 <!--
 Completed items, routine archives here with date.
 Prune occasionally when this gets long.
 -->
+- [x] 2026-05-27 — Reactive audio validation: all 23 MP3 stubs replaced with valid 1-second sine tones (17,180 bytes); AudioDiagnosticsOverlay.tsx DEV-gated overlay; AudioSystem.ts diagnostics APIs (getLoadStatus, getActiveSounds, getAudioContextState); confirmed by .swarm-state.md
+- [x] 2026-05-27 — In-scene Level Editor wiring: PR #151 merged; LevelEditor overlay via ?editor=1, useLevelEditor.ts hook + levelEditorValidator.ts
+- [x] 2026-05-27 — Downhill creek → second waterfall (segments 23–30): PR #153 merged; meander_to_waterfall.ts extended, RunnerVehicle updated, WaterfallParticles + FlowingWater tuned
+- [x] 2026-05-27 — Physics stability: PRs #154–156 — NaN guards on FloatingObjectManager impulses, Set iteration fix on InstancedRigidBodies, XY spawn variation in INITIAL_POINTS
+- [x] 2026-05-27 — WASM module (partial): C++/Emscripten module authored in emscripten/ + WatershedWasm.ts bindings + Jest tests; RTTI/Embind conflict resolved (PR #159); binary not yet compiled
 - [x] 2026-05-20 — ReactiveAudio NaN volume fix: comprehensive isFinite guards on all volume paths (PR #144)
-- [x] 2026-05-20 — R3F Html namespace fix: LoadingDisplay/ErrorDisplay wrapped with drei `<Html>` to prevent "Div is not part of THREE namespace" error (PR #143)
+- [x] 2026-05-20 — R3F Html namespace fix: LoadingDisplay/ErrorDisplay wrapped with drei <Html> to prevent "Div is not part of THREE namespace" error (PR #143)
 - [x] 2026-05-20 — Player spawn alignment: spawn position aligned to first canyon chunk, strafe keys mapped to KeyboardControls leftward/rightward, Rapier handle Set iteration fixed (PRs #145–147)
 - [x] 2026-05-13 — GameHUD wiring: speedometer, distance counter, wipeout overlay, respawn handler — all criteria met per .swarm-state.md; Experience.jsx renders GameHUD via vehicleRef + isWipeout
 - [x] 2026-05-13 — Author segments 0–12: deterministic decoration placement + authored waypoints in meander_to_waterfall.json (PR #130 merged)
@@ -51,7 +58,7 @@ Prune occasionally when this gets long.
 
 ## Last run
 <!-- Routine writes summary here each run. Overwrites previous. -->
-Date: 2026-05-20
-Mode: User Idea — audio validation item still in progress (stubs unresolved, pipeline fixed); audio picked as primary kimi-cli target; Level Editor wiring added to Ideas as routine-generated parallel idea for Copilot
-Focus: Synthesize valid PCM tones for 23 public/sounds/ stubs; add AudioDiagnosticsOverlay; smoke-test full audio pipeline in-game
-Outcome: Dispatch produced. Done section updated with PRs #143–147. Audio validation re-dated + clarified in Ideas. Level Editor wiring added to Ideas. weekly_plan.md updated.
+Date: 2026-05-27
+Mode: Fix First — `npm run build` unconditionally chains build:wasm which requires Emscripten; emcc not in PATH; public/watershed_native.wasm missing; build is broken
+Focus: Fix build:wasm graceful skip + begin WatershedWasm buoyancy integration into FloatingObjectManager
+Outcome: Dispatch produced. Done section updated with PRs #151, #153–156, #158–159 + audio validation confirmation. Backlog updated with WASM build debt. Today's focus set.


### PR DESCRIPTION
## Summary
- Weekly plan file updated for 2026-05-27 routine run
- Done section: archived audio validation, level editor wiring, creek/waterfall (segments 23–30), physics stability PRs #153–159
- Backlog updated: WASM build debt flagged as CRITICAL (emcc not found, `npm run build` broken)
- Today's focus set: Fix First mode — graceful `build:wasm` skip + WatershedWasm buoyancy integration into FloatingObjectManager

## Mode
**Fix First** — `npm run build` unconditionally chains `build:wasm && build:wasm:threads`, but `emcc` is not in PATH and `public/watershed_native.wasm` does not exist. Build is broken.

https://claude.ai/code/session_01SW1aQS5NCugzTaoLaF3Hp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01SW1aQS5NCugzTaoLaF3Hp7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal project planning and tracking documentation to reflect current development priorities and completed work items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Watershed/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->