### PR TITLE
feat: toggleable WebGPU/WebGL2 renderer with debug helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ The title has a double meaning:
 
 | File | Purpose |
 |------|---------|
-| `vite.config.ts` | Primary build config. Dev server on port 3000, `base: './'`, manual chunks for `vendor-three`, `vendor-post`, `vendor-rapier`. Output dir: `build/`. |
+| `vite.config.ts` | Primary build config. Dev server on port 3000, `base: './'`, manual chunks for `vendor-three`, `vendor-webgpu`, `vendor-post`, `vendor-rapier`. Output dir: `build/`. |
 | `tsconfig.json` | TypeScript config: `target: es5`, `jsx: react-jsx`, `strict: true`, includes `src/`. |
 | `package.json` | Dependencies and npm scripts. Uses pnpm. |
 | `webpack.config.js` | **Legacy/unused.** Leftover from earlier toolchain; Vite is the active bundler. |
@@ -655,6 +655,33 @@ playwright install chromium
 
 ---
 
+## Renderer Toggle (WebGPU / WebGL2 Fallback)
+
+Watershed supports a toggleable renderer for visual debugging while sharing the same game state, level data, camera, and entities. See **[`docs/RENDERER.md`](./docs/RENDERER.md)** for full details.
+
+| Mode | URL | Renderer |
+|------|-----|----------|
+| Default | `?renderer=webgpu` | `WebGPURenderer` (lazy-loaded from `three/webgpu`; auto-falls back to WebGL2 when WebGPU unavailable) |
+| Debug / GLSL parity | `?renderer=webgl` | `WebGLRenderer` — use for shader tuning, post-processing, and environments |
+
+**Debug helpers** (enable with `?debug=1`):
+
+- **Renderer buttons** in `DebugPanel` — switch WebGPU ↔ WebGL2 (remounts Canvas via `key`)
+- **Wireframe overlay** — `?wireframe=1` or press `G` (`WireframeDebug.tsx`)
+- **Physics colliders** — `?physicsDebug=1` or press `F` (`PhysicsDebugOverlay.tsx`)
+
+**Key files:**
+
+| File | Purpose |
+|------|---------|
+| `src/rendering/createRenderer.ts` | Async R3F `gl` factory |
+| `src/rendering/rendererConfig.ts` | URL param + localStorage preference |
+| `src/rendering/rendererState.ts` | Active backend diagnostics store |
+| `src/App.tsx` | Canvas wiring, keyboard shortcuts |
+| `src/components/DebugPanel.tsx` | Debug UI controls |
+
+---
+
 ## Browser Requirements
 
 - **Chrome 90+** (recommended)
@@ -692,7 +719,10 @@ Planned for:
 
 | File | Purpose |
 |------|---------|
-| `src/App.tsx` | Canvas configuration, error boundaries, progress tracking |
+| `src/App.tsx` | Canvas configuration, renderer toggle, error boundaries, progress tracking |
+| `src/rendering/createRenderer.ts` | WebGPU/WebGL2 renderer factory for R3F Canvas |
+| `src/rendering/WireframeDebug.tsx` | Scene-wide wireframe debug overlay |
+| `docs/RENDERER.md` | Renderer toggle documentation |
 | `src/Experience.jsx` | Scene composition, keyboard controls setup, lighting, biome/LOD providers |
 | `src/components/Player.jsx` | First-person controls, camera, physics |
 | `src/components/TrackManager.jsx` | Procedural generation orchestration |

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -18,6 +18,9 @@ This directory contains comprehensive documentation from the Watershed startup i
 ### Building New Features?
 👉 **[CODE_HEALTH_GUIDE.md](./CODE_HEALTH_GUIDE.md)** - Best practices and patterns
 
+### Debugging Rendering / Shaders?
+👉 **[RENDERER.md](./RENDERER.md)** - WebGPU / WebGL2 renderer toggle and debug helpers
+
 ---
 
 ## 📚 Document Descriptions

--- a/docs/RENDERER.md
+++ b/docs/RENDERER.md
@@ -1,0 +1,67 @@
+# Renderer Toggle — WebGPU / WebGL2 Fallback
+
+Watershed supports two rendering backends for visual debugging and broader browser coverage. Game state, level data, camera, physics, and entities are shared — only the Three.js renderer changes.
+
+## Quick Start
+
+| URL param | Backend | Use case |
+|-----------|---------|----------|
+| `?renderer=webgpu` (default) | `WebGPURenderer` | Production path; auto-falls back to WebGL2 when WebGPU is unavailable |
+| `?renderer=webgl` | `WebGLRenderer` | Shader debugging, GLSL post-processing parity, environments without WebGPU |
+
+Examples:
+
+```
+http://localhost:3000/?renderer=webgl
+http://localhost:3000/?debug=1&renderer=webgl&wireframe=1&physicsDebug=1
+```
+
+## Debug UI
+
+Enable the debug panel with `?debug=1`, then use:
+
+- **Renderer buttons** — switch between WebGPU and WebGL2 (remounts the Canvas)
+- **Wireframe overlay (G)** — scene-wide geometry wireframe for mesh inspection
+- **Physics colliders (F)** — Rapier debug wireframes + HUD snapshot (P to log)
+
+## Architecture
+
+```
+App.tsx
+  └─ Canvas (key=renderer preference)
+       └─ createGameRenderer()  ← async gl factory
+            ├─ webgl  → THREE.WebGLRenderer
+            └─ webgpu → THREE.WebGPURenderer (lazy import three/webgpu)
+       └─ Experience (shared scene graph)
+            ├─ RendererDiagnosticsMonitor → rendererState store
+            └─ WireframeDebug / PhysicsDebugOverlay
+```
+
+Module-level stores cross the Canvas boundary:
+
+- `src/rendering/rendererState.ts` — active backend name (read by DebugPanel)
+- `src/debug/perfMetrics.ts` — draw calls, FPS, heap
+
+## Visual Parity Notes
+
+- **WebGL2 (`?renderer=webgl`)** is the reference path for custom GLSL shaders (`RiverShader.js`, `PostProcessingPipeline`, `FlowingWater.jsx`).
+- **WebGPU** uses Three.js `WebGPURenderer`, which falls back to an internal WebGL2 backend when `navigator.gpu` is missing. Custom WGSL compute (e.g. `HeightmapFlow.ts`) still runs on a separate WebGPU device when available.
+- Post-processing may behave differently under native WebGPU; use `?renderer=webgl` when tuning bloom, vignette, or chromatic aberration.
+
+## Keyboard Shortcuts (debug mode)
+
+| Key | Action |
+|-----|--------|
+| `F` | Toggle physics collider debug |
+| `G` | Toggle wireframe geometry overlay |
+| `P` | Log physics debug snapshot to console |
+
+## Related Files
+
+| File | Purpose |
+|------|---------|
+| `src/rendering/createRenderer.ts` | Async renderer factory |
+| `src/rendering/rendererConfig.ts` | URL param + localStorage parsing |
+| `src/rendering/WireframeDebug.tsx` | Scene wireframe helper |
+| `src/components/DebugPanel.tsx` | Debug UI controls |
+| `src/App.tsx` | Canvas wiring + keyboard shortcuts |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,12 @@ import DebugPanel from './components/DebugPanel';
 import { useDebugStages } from './debug/debugStages';
 import ErrorBoundary from './components/ErrorBoundary';
 import meadowToWaterfall from './maps/meander_to_waterfall.json';
+import {
+  createGameRenderer,
+  parseRendererPreference,
+  persistRendererPreference,
+  type RendererPreference,
+} from './rendering';
 import './style.css';
 
 // ---------------------------------------------------------------------------
@@ -58,6 +64,14 @@ function App() {
     const raw = params.get('physicsDebug');
     return raw === '1' || raw === 'true';
   });
+  const [rendererPreference, setRendererPreference] = useState<RendererPreference>(() =>
+    parseRendererPreference()
+  );
+  const [wireframeDebug, setWireframeDebug] = useState(() => {
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get('wireframe');
+    return raw === '1' || raw === 'true';
+  });
 
   // Dynamic import for editor — keeps LevelEditor out of the production bundle.
   const [EditorComponent, setEditorComponent] =
@@ -91,11 +105,30 @@ function App() {
   }, [physicsDebug]);
 
   useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (wireframeDebug) {
+      params.set('wireframe', '1');
+    } else {
+      params.delete('wireframe');
+    }
+    const next = params.toString();
+    window.history.replaceState({}, '', `${window.location.pathname}${next ? `?${next}` : ''}`);
+  }, [wireframeDebug]);
+
+  const handleRendererPreferenceChange = useCallback((next: RendererPreference) => {
+    persistRendererPreference(next);
+    setRendererPreference(next);
+  }, []);
+
+  useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (isTypingTarget(e.target)) return;
       if (e.repeat) return;
       if (e.code === 'KeyF') {
         setPhysicsDebug((prev) => !prev);
+      }
+      if (e.code === 'KeyG') {
+        setWireframeDebug((prev) => !prev);
       }
       if (e.code === 'KeyP') {
         const snapshot = (window as any).__watershedPhysicsDebug;
@@ -184,10 +217,14 @@ function App() {
       ) : (
         <>
           <Canvas
-            gl={{
-              powerPreference: 'high-performance',
-              antialias: true,
-            }}
+            key={`renderer-${rendererPreference}`}
+            gl={async (props) =>
+              createGameRenderer(props, {
+                preference: rendererPreference,
+                antialias: true,
+                powerPreference: 'high-performance',
+              })
+            }
             camera={{ position: [0, 10, -10], fov: 75 }}
             shadows
             frameloop="always"
@@ -196,7 +233,12 @@ function App() {
             }}
           >
             <React.Suspense fallback={null}>
-              <Experience debug={debug} physicsDebug={physicsDebug} />
+              <Experience
+                debug={debug}
+                physicsDebug={physicsDebug}
+                rendererPreference={rendererPreference}
+                wireframeDebug={wireframeDebug}
+              />
             </React.Suspense>
           </Canvas>
 
@@ -214,7 +256,15 @@ function App() {
               onQuit={handleQuit}
             />
           )}
-          <DebugPanel debug={debug} physicsDebug={physicsDebug} onTogglePhysicsDebug={setPhysicsDebug} />
+          <DebugPanel
+            debug={debug}
+            physicsDebug={physicsDebug}
+            onTogglePhysicsDebug={setPhysicsDebug}
+            rendererPreference={rendererPreference}
+            onRendererPreferenceChange={handleRendererPreferenceChange}
+            wireframeDebug={wireframeDebug}
+            onToggleWireframeDebug={setWireframeDebug}
+          />
         </>
       )}
     </ErrorBoundary>

--- a/src/Experience.jsx
+++ b/src/Experience.jsx
@@ -33,6 +33,8 @@ import AudioDiagnosticsOverlay from "./components/AudioDiagnosticsOverlay";
 import PhysicsDebugOverlay from "./components/PhysicsDebugOverlay";
 import { DEBUG_STAGES } from "./debug/debugStages";
 import PerfCheckpointMonitor from "./debug/PerfCheckpointMonitor";
+import RendererDiagnosticsMonitor from "./rendering/RendererDiagnosticsMonitor";
+import WireframeDebug from "./rendering/WireframeDebug";
 import { tickScoreSystem, awardDodgeBonus, awardWaterfallBonus, resetScoreSystemState } from "./systems/ScoreSystem";
 
 // Goal 1: Zustand game state
@@ -87,7 +89,7 @@ const NOOP_DEBUG = {
  * InnerExperience - The actual game scene
  * Wrapped in providers for context access
  */
-const InnerExperience = ({ debug = NOOP_DEBUG, physicsDebug = false }) => {
+const InnerExperience = ({ debug = NOOP_DEBUG, physicsDebug = false, wireframeDebug = false }) => {
   const [vehicleType, setVehicleTypeLocal] = useState(() => {
     const params = new URLSearchParams(window.location.search);
     return params.get('vehicle') === 'raft' ? 'raft' : 'runner';
@@ -545,6 +547,7 @@ const InnerExperience = ({ debug = NOOP_DEBUG, physicsDebug = false }) => {
           {physicsDebugEnabled && (
             <PhysicsDebugOverlay enabled={physicsDebugEnabled} vehicleRef={vehicleRef} />
           )}
+          {wireframeDebug && <WireframeDebug enabled={wireframeDebug} />}
 
           {/* Splash system for water interactions */}
           {debug.isStageEnabled('worldSystems') && (
@@ -721,7 +724,7 @@ const InnerExperience = ({ debug = NOOP_DEBUG, physicsDebug = false }) => {
  *
  * Wraps the game in provider contexts for biome and LOD management
  */
-const Experience = ({ debug = NOOP_DEBUG, physicsDebug = false }) => {
+const Experience = ({ debug = NOOP_DEBUG, physicsDebug = false, rendererPreference = 'webgpu', wireframeDebug = false }) => {
   // Check for debug flag in URL
   const isDebug = typeof window !== 'undefined' && window.location.search.includes('debug=true');
   
@@ -744,8 +747,9 @@ const Experience = ({ debug = NOOP_DEBUG, physicsDebug = false }) => {
         <BiomeProvider initialBiome="canyonSummer" enableTimeOfDay={false}>
           <SunPositionProvider>
             <BiomeTransition />
-            <InnerExperience debug={debug} physicsDebug={physicsDebug} />
+            <InnerExperience debug={debug} physicsDebug={physicsDebug} wireframeDebug={wireframeDebug} />
             <PerformanceMonitor visible={import.meta.env.DEV} />
+            <RendererDiagnosticsMonitor preference={rendererPreference} />
             {debug.debugEnabled && <PerfCheckpointMonitor />}
           </SunPositionProvider>
         </BiomeProvider>

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useSyncExternalStore } from 'react';
 import { DebugStageController, DebugStageId, DebugStageStatus } from '../debug/debugStages';
 import { getPerfMetrics, subscribePerfMetrics } from '../debug/perfMetrics';
+import { getRendererDiagnostics, subscribeRendererDiagnostics } from '../rendering/rendererState';
+import type { RendererPreference } from '../rendering/types';
 
 // ─── Shared styles ────────────────────────────────────────────────────────────
 
@@ -97,15 +99,28 @@ export interface DebugPanelProps {
   debug: DebugStageController;
   physicsDebug?: boolean;
   onTogglePhysicsDebug?: (val: boolean) => void;
+  rendererPreference?: RendererPreference;
+  onRendererPreferenceChange?: (preference: RendererPreference) => void;
+  wireframeDebug?: boolean;
+  onToggleWireframeDebug?: (val: boolean) => void;
 }
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
-export function DebugPanel({ debug, physicsDebug = false, onTogglePhysicsDebug }: DebugPanelProps) {
+export function DebugPanel({
+  debug,
+  physicsDebug = false,
+  onTogglePhysicsDebug,
+  rendererPreference = 'webgpu',
+  onRendererPreferenceChange,
+  wireframeDebug = false,
+  onToggleWireframeDebug,
+}: DebugPanelProps) {
   const [stagesOpen, setStagesOpen] = useState(false);
 
   // Subscribe to live perf metrics from PerfCheckpointMonitor (inside Canvas)
   const metrics = useSyncExternalStore(subscribePerfMetrics, getPerfMetrics);
+  const rendererDiagnostics = useSyncExternalStore(subscribeRendererDiagnostics, getRendererDiagnostics);
 
   if (!debug.debugEnabled) return null;
 
@@ -173,6 +188,43 @@ export function DebugPanel({ debug, physicsDebug = false, onTogglePhysicsDebug }
 
       <Divider />
 
+      {/* ── Renderer backend toggle ─────────────────────────────────────── */}
+      <SectionTitle>Renderer — WebGPU / WebGL2</SectionTitle>
+      <div style={{ marginBottom: 6, color: '#d0d0d0' }}>
+        Active: <span style={{ color: '#9fd6ff' }}>{rendererDiagnostics.rendererName}</span>
+      </div>
+      <div style={{ display: 'flex', gap: 6, marginBottom: 6 }}>
+        {(['webgpu', 'webgl'] as RendererPreference[]).map((mode) => (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => onRendererPreferenceChange?.(mode)}
+            style={{
+              flex: 1,
+              padding: '4px 6px',
+              borderRadius: 4,
+              border: rendererPreference === mode
+                ? '1px solid #6dde7a'
+                : '1px solid rgba(255,255,255,0.18)',
+              background: rendererPreference === mode
+                ? 'rgba(109,222,122,0.15)'
+                : 'rgba(255,255,255,0.04)',
+              color: rendererPreference === mode ? '#6dde7a' : '#ccc',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              fontSize: 11,
+            }}
+          >
+            {mode === 'webgpu' ? 'WebGPU' : 'WebGL2'}
+          </button>
+        ))}
+      </div>
+      <div style={{ color: '#888', fontSize: 10, marginBottom: 4 }}>
+        URL: <code>?renderer=webgl</code> or <code>?renderer=webgpu</code>
+      </div>
+
+      <Divider />
+
       {/* ── CP2: Physics debug ──────────────────────────────────────────── */}
       <SectionTitle>CP2 · CPU — Physics Colliders</SectionTitle>
       <label style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4, cursor: 'pointer' }}>
@@ -190,6 +242,16 @@ export function DebugPanel({ debug, physicsDebug = false, onTogglePhysicsDebug }
           ↳ Press P to log current physics snapshot in the console
         </div>
       )}
+      <label style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 6, marginBottom: 4, cursor: 'pointer' }}>
+        <input
+          type="checkbox"
+          checked={wireframeDebug}
+          onChange={(e) => onToggleWireframeDebug?.(e.target.checked)}
+        />
+        <span style={{ color: wireframeDebug ? '#6dde7a' : '#d0d0d0' }}>
+          Wireframe geometry overlay (G)
+        </span>
+      </label>
 
       <Divider />
 

--- a/src/rendering/RendererDiagnosticsMonitor.tsx
+++ b/src/rendering/RendererDiagnosticsMonitor.tsx
@@ -1,0 +1,34 @@
+/**
+ * Reports active renderer backend to the module-level rendererState store.
+ * Must live inside <Canvas>.
+ */
+
+import { useEffect } from 'react';
+import { useThree } from '@react-three/fiber';
+import {
+  detectActiveBackend,
+  getRendererDisplayName,
+  isWebGpuNavigatorAvailable,
+  updateRendererDiagnostics,
+} from './rendererState';
+import type { RendererPreference } from './types';
+
+export interface RendererDiagnosticsMonitorProps {
+  preference: RendererPreference;
+}
+
+export default function RendererDiagnosticsMonitor({ preference }: RendererDiagnosticsMonitorProps) {
+  const { gl } = useThree();
+
+  useEffect(() => {
+    const activeBackend = detectActiveBackend(gl);
+    updateRendererDiagnostics({
+      preference,
+      activeBackend,
+      rendererName: getRendererDisplayName(preference, activeBackend),
+      webgpuAvailable: isWebGpuNavigatorAvailable(),
+    });
+  }, [gl, preference]);
+
+  return null;
+}

--- a/src/rendering/WireframeDebug.tsx
+++ b/src/rendering/WireframeDebug.tsx
@@ -1,0 +1,68 @@
+/**
+ * Scene-wide wireframe overlay for geometry debugging.
+ * Restores original material wireframe flags when disabled.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+
+type MaterialSnapshot = { wireframe: boolean };
+
+function snapshotMaterial(mat: THREE.Material): MaterialSnapshot {
+  return { wireframe: 'wireframe' in mat ? !!(mat as THREE.MeshStandardMaterial).wireframe : false };
+}
+
+function applyWireframe(mat: THREE.Material, enabled: boolean): void {
+  if ('wireframe' in mat) {
+    (mat as THREE.MeshStandardMaterial).wireframe = enabled;
+    mat.needsUpdate = true;
+  }
+}
+
+function forEachMaterial(
+  material: THREE.Material | THREE.Material[],
+  fn: (mat: THREE.Material) => void
+): void {
+  if (Array.isArray(material)) {
+    material.forEach(fn);
+  } else {
+    fn(material);
+  }
+}
+
+export interface WireframeDebugProps {
+  enabled: boolean;
+}
+
+export default function WireframeDebug({ enabled }: WireframeDebugProps) {
+  const { scene } = useThree();
+  const snapshots = useRef(new WeakMap<THREE.Material, MaterialSnapshot>());
+
+  useEffect(() => {
+    const touched = new Set<THREE.Material>();
+
+    scene.traverse((object) => {
+      const mesh = object as THREE.Mesh;
+      if (!mesh.isMesh || !mesh.material) return;
+
+      forEachMaterial(mesh.material, (mat) => {
+        if (!snapshots.current.has(mat)) {
+          snapshots.current.set(mat, snapshotMaterial(mat));
+        }
+        applyWireframe(mat, enabled);
+        touched.add(mat);
+      });
+    });
+
+    return () => {
+      if (!enabled) return;
+      touched.forEach((mat) => {
+        const original = snapshots.current.get(mat);
+        if (original) applyWireframe(mat, original.wireframe);
+      });
+    };
+  }, [enabled, scene]);
+
+  return null;
+}

--- a/src/rendering/createRenderer.ts
+++ b/src/rendering/createRenderer.ts
@@ -1,0 +1,42 @@
+import * as THREE from 'three';
+import type { RendererPreference } from './types';
+
+export interface GameRendererOptions {
+  preference: RendererPreference;
+  antialias?: boolean;
+  powerPreference?: WebGLPowerPreference;
+}
+
+/**
+ * Creates the Three.js renderer for the game Canvas.
+ *
+ * - `webgpu`: WebGPURenderer (lazy-loaded); falls back to WebGL2 internally when WebGPU is unavailable.
+ * - `webgl`:  Pure WebGLRenderer for shader/debug parity and visual inspection.
+ */
+export async function createGameRenderer(
+  canvasProps: THREE.WebGLRendererParameters,
+  options: GameRendererOptions
+): Promise<THREE.WebGLRenderer> {
+  const {
+    preference,
+    antialias = true,
+    powerPreference = 'high-performance',
+  } = options;
+
+  if (preference === 'webgl') {
+    return new THREE.WebGLRenderer({
+      ...canvasProps,
+      antialias,
+      powerPreference,
+    });
+  }
+
+  const { WebGPURenderer } = await import('three/webgpu');
+  const renderer = new WebGPURenderer({
+    ...canvasProps,
+    antialias,
+    forceWebGL: false,
+  });
+  await renderer.init();
+  return renderer as unknown as THREE.WebGLRenderer;
+}

--- a/src/rendering/index.ts
+++ b/src/rendering/index.ts
@@ -1,0 +1,6 @@
+export { createGameRenderer } from './createRenderer';
+export { parseRendererPreference, persistRendererPreference, syncRendererPreferenceToUrl } from './rendererConfig';
+export { getRendererDiagnostics, subscribeRendererDiagnostics } from './rendererState';
+export type { ActiveRendererBackend, RendererDiagnostics, RendererPreference } from './types';
+export { default as RendererDiagnosticsMonitor } from './RendererDiagnosticsMonitor';
+export { default as WireframeDebug } from './WireframeDebug';

--- a/src/rendering/rendererConfig.test.ts
+++ b/src/rendering/rendererConfig.test.ts
@@ -1,0 +1,50 @@
+import {
+  isRendererPreference,
+  parseRendererPreference,
+  syncRendererPreferenceToUrl,
+} from './rendererConfig';
+
+const STORAGE_KEY = 'watershed.renderer.preference';
+
+describe('rendererConfig', () => {
+  const originalUrl = window.location.href;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', originalUrl);
+  });
+
+  it('defaults to webgpu when no URL or storage override exists', () => {
+    expect(parseRendererPreference('')).toBe('webgpu');
+  });
+
+  it('reads renderer preference from URL params', () => {
+    expect(parseRendererPreference('?renderer=webgl')).toBe('webgl');
+    expect(parseRendererPreference('?renderer=webgpu')).toBe('webgpu');
+  });
+
+  it('falls back to stored preference when URL param is absent', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'webgl');
+    expect(parseRendererPreference('')).toBe('webgl');
+  });
+
+  it('prefers URL param over stored preference', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'webgl');
+    expect(parseRendererPreference('?renderer=webgpu')).toBe('webgpu');
+  });
+
+  it('syncs renderer preference into the URL', () => {
+    syncRendererPreferenceToUrl('webgl');
+    expect(window.location.search).toContain('renderer=webgl');
+  });
+
+  it('validates renderer preference strings', () => {
+    expect(isRendererPreference('webgl')).toBe(true);
+    expect(isRendererPreference('webgpu')).toBe(true);
+    expect(isRendererPreference('d3d11')).toBe(false);
+  });
+});

--- a/src/rendering/rendererConfig.ts
+++ b/src/rendering/rendererConfig.ts
@@ -1,0 +1,43 @@
+import type { RendererPreference } from './types';
+
+const STORAGE_KEY = 'watershed.renderer.preference';
+const VALID: RendererPreference[] = ['webgl', 'webgpu'];
+
+export function parseRendererPreference(search = window.location.search): RendererPreference {
+  const raw = new URLSearchParams(search).get('renderer');
+  if (raw === 'webgl' || raw === 'webgpu') return raw;
+
+  if (typeof window !== 'undefined') {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored === 'webgl' || stored === 'webgpu') return stored;
+    } catch {
+      // ignore storage failures
+    }
+  }
+
+  // Default: WebGPU path (auto-falls back to WebGL2 when unavailable).
+  return 'webgpu';
+}
+
+export function isRendererPreference(value: string): value is RendererPreference {
+  return (VALID as string[]).includes(value);
+}
+
+export function syncRendererPreferenceToUrl(preference: RendererPreference): void {
+  if (typeof window === 'undefined') return;
+  const params = new URLSearchParams(window.location.search);
+  params.set('renderer', preference);
+  const next = params.toString();
+  window.history.replaceState({}, '', `${window.location.pathname}?${next}`);
+}
+
+export function persistRendererPreference(preference: RendererPreference): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, preference);
+  } catch {
+    // ignore storage failures
+  }
+  syncRendererPreferenceToUrl(preference);
+}

--- a/src/rendering/rendererState.test.ts
+++ b/src/rendering/rendererState.test.ts
@@ -1,0 +1,31 @@
+import { detectActiveBackend, getRendererDisplayName } from './rendererState';
+
+describe('rendererState', () => {
+  it('detects pure WebGL renderer', () => {
+    expect(detectActiveBackend({ isWebGLRenderer: true })).toBe('webgl');
+  });
+
+  it('detects native WebGPU backend', () => {
+    expect(
+      detectActiveBackend({
+        isWebGPURenderer: true,
+        backend: { isWebGPUBackend: true },
+      })
+    ).toBe('webgpu');
+  });
+
+  it('detects WebGPURenderer WebGL2 fallback backend', () => {
+    expect(
+      detectActiveBackend({
+        isWebGPURenderer: true,
+        backend: { isWebGPUBackend: false },
+      })
+    ).toBe('webgl2-fallback');
+  });
+
+  it('formats renderer display names', () => {
+    expect(getRendererDisplayName('webgpu', 'webgpu')).toBe('WebGPURenderer');
+    expect(getRendererDisplayName('webgpu', 'webgl2-fallback')).toBe('WebGPURenderer (WebGL2 fallback)');
+    expect(getRendererDisplayName('webgl', 'webgl')).toBe('WebGLRenderer');
+  });
+});

--- a/src/rendering/rendererState.ts
+++ b/src/rendering/rendererState.ts
@@ -1,0 +1,56 @@
+/**
+ * Module-level renderer diagnostics store.
+ * Crosses the R3F Canvas boundary (same pattern as perfMetrics.ts).
+ */
+
+import type { ActiveRendererBackend, RendererDiagnostics, RendererPreference } from './types';
+
+const _diagnostics: RendererDiagnostics = {
+  preference: 'webgpu',
+  activeBackend: 'webgl',
+  rendererName: 'WebGLRenderer',
+  webgpuAvailable: false,
+};
+
+type Listener = () => void;
+const _listeners = new Set<Listener>();
+
+export function getRendererDiagnostics(): Readonly<RendererDiagnostics> {
+  return _diagnostics;
+}
+
+export function updateRendererDiagnostics(partial: Partial<RendererDiagnostics>): void {
+  Object.assign(_diagnostics, partial);
+  _listeners.forEach((fn) => fn());
+}
+
+export function subscribeRendererDiagnostics(fn: Listener): () => void {
+  _listeners.add(fn);
+  return () => _listeners.delete(fn);
+}
+
+export function detectActiveBackend(renderer: {
+  isWebGLRenderer?: boolean;
+  isWebGPURenderer?: boolean;
+  backend?: { isWebGPUBackend?: boolean };
+}): ActiveRendererBackend {
+  if (renderer.isWebGLRenderer) return 'webgl';
+  if (renderer.isWebGPURenderer) {
+    return renderer.backend?.isWebGPUBackend ? 'webgpu' : 'webgl2-fallback';
+  }
+  return 'webgl';
+}
+
+export function isWebGpuNavigatorAvailable(): boolean {
+  return typeof navigator !== 'undefined' && 'gpu' in navigator && !!navigator.gpu;
+}
+
+export function getRendererDisplayName(
+  preference: RendererPreference,
+  activeBackend: ActiveRendererBackend
+): string {
+  if (activeBackend === 'webgpu') return 'WebGPURenderer';
+  if (activeBackend === 'webgl2-fallback') return 'WebGPURenderer (WebGL2 fallback)';
+  if (preference === 'webgpu') return 'WebGLRenderer (forced debug)';
+  return 'WebGLRenderer';
+}

--- a/src/rendering/types.ts
+++ b/src/rendering/types.ts
@@ -1,0 +1,12 @@
+/** Requested renderer backend via URL param or debug UI. */
+export type RendererPreference = 'webgl' | 'webgpu';
+
+/** Actual GPU backend after initialization (WebGPURenderer may fall back to WebGL2). */
+export type ActiveRendererBackend = 'webgl' | 'webgl2-fallback' | 'webgpu';
+
+export interface RendererDiagnostics {
+  preference: RendererPreference;
+  activeBackend: ActiveRendererBackend;
+  rendererName: string;
+  webgpuAvailable: boolean;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       output: {
         manualChunks: {
           'vendor-three':  ['three', '@react-three/fiber', '@react-three/drei'],
+          'vendor-webgpu': ['three/webgpu'],
           'vendor-post':   ['postprocessing', '@react-three/postprocessing'],
           'vendor-rapier': ['@dimforge/rapier3d-compat'],
         },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a toggleable renderer system following the WebGL2 fallback initiative pattern (Tetris_WebGPU, power_gen). Game state, level data, camera, physics, and entities are unchanged — only the Three.js renderer backend switches.

## Changes

- **`src/rendering/`** — renderer config (URL + localStorage), async factory, diagnostics store, wireframe helper
- **`App.tsx`** — async R3F `gl` factory, Canvas remount on preference change, `G` wireframe shortcut
- **`DebugPanel`** — WebGPU/WebGL2 toggle buttons, active backend display, wireframe checkbox
- **`Experience.jsx`** — wires `RendererDiagnosticsMonitor` and `WireframeDebug`
- **`docs/RENDERER.md`** — full usage guide
- **`AGENTS.md`** — renderer section + key file references
- **Tests** — `rendererConfig.test.ts`, `rendererState.test.ts` (10 passing)
- **Vite** — lazy `vendor-webgpu` chunk for tree-shaking

## Usage

| Param | Backend |
|-------|---------|
| `?renderer=webgpu` (default) | `WebGPURenderer` (auto-falls back to WebGL2) |
| `?renderer=webgl` | `WebGLRenderer` for GLSL/shader debugging |

Debug helpers (`?debug=1`):
- **F** — physics collider wireframes
- **G** — scene wireframe overlay
- Debug panel renderer buttons

## Testing

- `npm test -- --testPathPattern=rendering/` — 10 tests pass
- `npm run build` — succeeds; `vendor-webgpu` chunk split correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e5b9dec-5b25-4af5-b139-554d51382340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e5b9dec-5b25-4af5-b139-554d51382340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

