### PR TITLE
fix: update pthread worker check for modern Emscripten embedded-worke…

### DIFF
--- a/emscripten/build.sh
+++ b/emscripten/build.sh
@@ -144,10 +144,13 @@ if [ -f "$OUTPUT_JS" ]; then
         echo "  WASM size: ${WASM_SIZE} bytes"
     fi
     if [ "$USE_THREADS" -eq 1 ]; then
-        if [ -f "$REPO_ROOT/public/watershed_native.worker.js" ]; then
-            echo "  → $REPO_ROOT/public/watershed_native.worker.js (pthread worker shim)"
+        WORKER_JS="$REPO_ROOT/public/watershed_native.worker.js"
+        if [ -f "$WORKER_JS" ]; then
+            echo "  → $WORKER_JS (pthread worker shim)"
+        elif grep -q "PThread\|postMessage\|new Blob" "$OUTPUT_JS" 2>/dev/null; then
+            echo "  pthread worker shim embedded in watershed_native.js (modern Emscripten)"
         else
-            echo "  WARNING: watershed_native.worker.js not found — pthread worker shim may be missing."
+            echo "  WARNING: pthread worker shim not found in output — check Emscripten version"
         fi
     fi
 else


### PR DESCRIPTION
…r output

Emscripten 3.1+ embeds the pthread worker shim directly into the main JS output via Blob URLs when MODULARIZE=1 is set — no separate .worker.js file is produced. The post-build check now detects the embedded case via grep instead of always warning when the standalone file is absent.

https://claude.ai/code/session_01BEdTRAzwyxTjUpxJvXpapq