### PR TITLE
Fix blank canvas caused by TrackSegment material gate

### DIFF
--- a/src/components/TrackManager.jsx
+++ b/src/components/TrackManager.jsx
@@ -321,6 +321,7 @@ const TrackManager = forwardRef(function TrackManager({
                 <TrackSegment
                     key={slotIndex}
                     active={active}
+                    segmentId={segment?.id}
                     rockMaterial={rockMaterial}
                     rockNormalMap={normalMap}
                     raftRef={raftRef}

--- a/src/components/TrackSegment/index.jsx
+++ b/src/components/TrackSegment/index.jsx
@@ -32,8 +32,6 @@ export default function TrackSegment({
     weatherWetnessRef,
     usePooledStaticObstacles = false,
 }) {
-    if (!active) return null;
-
     const biomeProfile = useMemo(() => getTrackBiomeProfile(biome), [biome]);
 
     const pathLength = useMemo(() => {
@@ -98,7 +96,7 @@ export default function TrackSegment({
         canyonWidth, waterWidth, biome,
     });
 
-    if (!rockMaterial || !canyonGeometry || !wallShellGeometry || !waterGeometry) {
+    if (!active || !rockMaterial || !canyonGeometry || !wallShellGeometry || !waterGeometry) {
         return null;
     }
 

--- a/src/components/TrackSegment/index.jsx
+++ b/src/components/TrackSegment/index.jsx
@@ -1,7 +1,5 @@
 import React, { useMemo } from 'react';
 import * as THREE from 'three';
-import { extendRiverMaterial } from '../../utils/RiverShader';
-import { createCanyonMaterial } from '../../materials/CanyonMaterial';
 import { WATER_LEVEL } from '../../constants/game';
 import { getTrackBiomeProfile } from '../../configs/TrackBiomes';
 import { smoothNoise } from './utils';
@@ -100,15 +98,7 @@ export default function TrackSegment({
         canyonWidth, waterWidth, biome,
     });
 
-    const localRockMaterial = useMemo(() => {
-        if (!rockMaterial) return null;
-        if (biome === 'slotCanyon') {
-            return createCanyonMaterial(rockMaterial);
-        }
-        return extendRiverMaterial(rockMaterial, false, biome);
-    }, [rockMaterial, biome]);
-
-    if (!localRockMaterial || !canyonGeometry || !wallShellGeometry || !waterGeometry) {
+    if (!rockMaterial || !canyonGeometry || !wallShellGeometry || !waterGeometry) {
         return null;
     }
 
@@ -121,7 +111,7 @@ export default function TrackSegment({
             canyonWidth={canyonWidth}
             waterWidth={waterWidth}
             active={active}
-            rockMaterial={localRockMaterial}
+            rockMaterial={rockMaterial}
             biome={biome}
             waterMaterial={waterMaterial}
             flowSpeed={flowSpeed}

--- a/src/utils/RiverShader.js
+++ b/src/utils/RiverShader.js
@@ -364,6 +364,8 @@ export function extendRiverMaterial(material, options = {}) {
         // Fallback to property-based approach
         fallbackExtend(material);
     }
+
+    return material;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The 3D canvas crashed on load with `ReferenceError: debris is not defined`, caught by ErrorBoundary — leaving a blank/broken view after TrackManager initialized.

Additional issues on deployed hosts: WebGPURenderer WGSL loads blocked by strict CSP, and TrackSegment segments returned null due to a broken material gate.

## Root causes

### 1. `debris is not defined` (fatal crash)

`populateSidePart1.js` calls `debris.push(...)` but `debris` was never passed through the placement pipeline (`usePlacementData` → `populateZSteps` → `populateSide` → `populateSidePart1`).

### 2. TrackSegment material gate (blank geometry)

`extendRiverMaterial()` did not return the material, so `localRockMaterial` was always `undefined` for non-slot-canyon biomes.

### 3. CSP blocks WebGPU shader loads (deployed hosts)

`WebGPURenderer` fetches bundled WGSL via `data:` URLs blocked when `connect-src` lacks `data:`.

## Fix

- Thread `debris` through the full placement call chain and return payload
- Remove broken `localRockMaterial` gate; pass `rockMaterial` to `TrackSegmentMeshes`
- CSP probe + auto-fallback to `WebGLRenderer`
- Pass `segmentId={segment?.id}` from `TrackManager`
- Fix missing `useRef` import in `Wildflowers.jsx`

## Notes on console messages

| Message | Action |
|---------|--------|
| `debris is not defined` | Fixed in this PR |
| CSP `data:text/wgsl` blocked | Auto-fallback; or `?renderer=webgl` |
| Rapier deprecated init params | Upstream warning; non-fatal |
| favicon 404 | Harmless |
| WebGL Context Lost | Follow-on from uncaught error; should stop after fix |

## Test plan

- [x] `pnpm build` succeeds
- [ ] Deployed build loads without ErrorBoundary crash
- [ ] Canyon + water visible after START RUN
- [ ] `?renderer=webgl` works on strict CSP hosts

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-307de1fc-62be-403a-93ad-828b54896808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-307de1fc-62be-403a-93ad-828b54896808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

