### PR TITLE
Fall back to WebGL when CSP blocks WebGPU data: shader loads

### DIFF
--- a/docs/RENDERER.md
+++ b/docs/RENDERER.md
@@ -48,6 +48,19 @@ Module-level stores cross the Canvas boundary:
 - **WebGPU** (`?renderer=webgpu`) currently forces the WebGL2 backend inside `WebGPURenderer` because legacy materials are incompatible with native WebGPU NodeMaterial. Custom WGSL compute (e.g. `HeightmapFlow.ts`) still runs on a separate WebGPU device when available.
 - Post-processing may behave differently under native WebGPU; use `?renderer=webgl` when tuning bloom, vignette, or chromatic aberration.
 
+### Strict CSP / deployed hosts
+
+Some hosts set `Content-Security-Policy: connect-src 'self' blob: https: wss:` without `data:`.
+Three.js `WebGPURenderer` loads internal WGSL via `data:text/wgsl;base64,...` fetches, which CSP blocks and produces a blank canvas with shader errors in the console.
+
+`createGameRenderer()` probes `data:` fetch support and **automatically falls back to `WebGLRenderer`**, persisting `webgl` preference. Force the safe path with:
+
+```
+?renderer=webgl
+```
+
+If you control the host CSP headers, add `data:` to `connect-src` to allow the experimental WebGPU renderer path.
+
 ## Keyboard Shortcuts (debug mode)
 
 | Key | Action |

--- a/src/components/Environment/Wildflowers.jsx
+++ b/src/components/Environment/Wildflowers.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import { useFrame } from '@react-three/fiber';
 import { Instances, Instance } from '@react-three/drei';

--- a/src/rendering/createRenderer.ts
+++ b/src/rendering/createRenderer.ts
@@ -1,5 +1,7 @@
 import * as THREE from 'three';
 import type { RendererPreference } from './types';
+import { isDataUrlConnectAllowed } from './cspProbe';
+import { persistRendererPreference } from './rendererConfig';
 
 export interface GameRendererOptions {
   preference: RendererPreference;
@@ -10,8 +12,9 @@ export interface GameRendererOptions {
 /**
  * Creates the Three.js renderer for the game Canvas.
  *
- * - `webgpu`: WebGPURenderer (lazy-loaded); falls back to WebGL2 internally when WebGPU is unavailable.
- * - `webgl`:  Pure WebGLRenderer for shader/debug parity and visual inspection.
+ * - `webgl`:  Pure WebGLRenderer — production path for custom GLSL shaders.
+ * - `webgpu`: WebGPURenderer (lazy-loaded). Falls back to WebGLRenderer when
+ *   CSP blocks data: WGSL loads or initialization fails.
  */
 export async function createGameRenderer(
   canvasProps: THREE.WebGLRendererParameters,
@@ -23,22 +26,44 @@ export async function createGameRenderer(
     powerPreference = 'high-performance',
   } = options;
 
-  if (preference === 'webgl') {
-    return new THREE.WebGLRenderer({
+  const createWebGLRenderer = () =>
+    new THREE.WebGLRenderer({
       ...canvasProps,
       antialias,
       powerPreference,
     });
+
+  if (preference === 'webgl') {
+    return createWebGLRenderer();
   }
 
-  const { WebGPURenderer } = await import('three/webgpu');
-  // Native WebGPU rejects legacy ShaderMaterial / onBeforeCompile materials used
-  // throughout Watershed. Force the WebGL2 backend until materials migrate to NodeMaterial.
-  const renderer = new WebGPURenderer({
-    ...canvasProps,
-    antialias,
-    forceWebGL: true,
-  });
-  await renderer.init();
-  return renderer as unknown as THREE.WebGLRenderer;
+  // WebGPURenderer ships WGSL as data:text/wgsl;base64,... internal modules.
+  // Strict CSP (connect-src without data:) blocks those fetches and leaves a
+  // blank canvas with shader validation errors in the console.
+  const dataUrlsAllowed = await isDataUrlConnectAllowed();
+  if (!dataUrlsAllowed) {
+    console.warn(
+      '[Renderer] CSP blocks data: URLs required by WebGPURenderer — using WebGLRenderer. ' +
+        'Add data: to connect-src or use ?renderer=webgl.'
+    );
+    persistRendererPreference('webgl');
+    return createWebGLRenderer();
+  }
+
+  try {
+    const { WebGPURenderer } = await import('three/webgpu');
+    // Native WebGPU rejects legacy ShaderMaterial / onBeforeCompile materials used
+    // throughout Watershed. Force the WebGL2 backend until materials migrate to NodeMaterial.
+    const renderer = new WebGPURenderer({
+      ...canvasProps,
+      antialias,
+      forceWebGL: true,
+    });
+    await renderer.init();
+    return renderer as unknown as THREE.WebGLRenderer;
+  } catch (error) {
+    console.warn('[Renderer] WebGPURenderer init failed — using WebGLRenderer:', error);
+    persistRendererPreference('webgl');
+    return createWebGLRenderer();
+  }
 }

--- a/src/rendering/cspProbe.test.ts
+++ b/src/rendering/cspProbe.test.ts
@@ -1,0 +1,28 @@
+import { isDataUrlConnectAllowed, resetDataUrlConnectProbe } from './cspProbe';
+
+describe('isDataUrlConnectAllowed', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    resetDataUrlConnectProbe();
+    global.fetch = originalFetch;
+  });
+
+  it('returns true when data: fetch succeeds', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+    await expect(isDataUrlConnectAllowed()).resolves.toBe(true);
+  });
+
+  it('returns false when data: fetch is blocked by CSP', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+    await expect(isDataUrlConnectAllowed()).resolves.toBe(false);
+  });
+
+  it('memoizes the probe result', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock;
+    await isDataUrlConnectAllowed();
+    await isDataUrlConnectAllowed();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/rendering/cspProbe.ts
+++ b/src/rendering/cspProbe.ts
@@ -1,0 +1,31 @@
+/**
+ * Detect whether fetch() to data: URLs is permitted by the page CSP.
+ * Three.js WebGPURenderer loads bundled WGSL via data:text/wgsl;base64,...
+ * which requires `data:` in connect-src on strict hosts.
+ */
+let cachedDataUrlConnectAllowed: boolean | null = null;
+
+export async function isDataUrlConnectAllowed(): Promise<boolean> {
+  if (cachedDataUrlConnectAllowed !== null) {
+    return cachedDataUrlConnectAllowed;
+  }
+
+  if (typeof window === 'undefined' || typeof fetch !== 'function') {
+    cachedDataUrlConnectAllowed = false;
+    return false;
+  }
+
+  try {
+    const response = await fetch('data:text/plain;base64,dGVzdA==');
+    cachedDataUrlConnectAllowed = response.ok;
+  } catch {
+    cachedDataUrlConnectAllowed = false;
+  }
+
+  return cachedDataUrlConnectAllowed;
+}
+
+/** Test helper — reset memoized probe result. */
+export function resetDataUrlConnectProbe(): void {
+  cachedDataUrlConnectAllowed = null;
+}

--- a/src/rendering/rendererState.ts
+++ b/src/rendering/rendererState.ts
@@ -6,7 +6,7 @@
 import type { ActiveRendererBackend, RendererDiagnostics, RendererPreference } from './types';
 
 const _diagnostics: RendererDiagnostics = {
-  preference: 'webgpu',
+  preference: 'webgl',
   activeBackend: 'webgl',
   rendererName: 'WebGLRenderer',
   webgpuAvailable: false,


### PR DESCRIPTION
WebGPURenderer fetches internal WGSL via data:text/wgsl;base64 URLs. Deployed hosts with connect-src lacking data: block those fetches and produce blank canvas / shader validation errors.

- Probe data: fetch support before initializing WebGPURenderer
- On CSP block or init failure, use WebGLRenderer and persist webgl pref
- Fix missing useRef import in Wildflowers.jsx (segment decoration crash)