### PR TITLE
Fix ReferenceError: debris is not defined in TrackSegment placement

### DIFF
--- a/src/components/TrackSegment/hooks/populateSidePart1.js
+++ b/src/components/TrackSegment/hooks/populateSidePart1.js
@@ -6,7 +6,7 @@ export function populateSidePart1(args) {
     const {
         side, t, zLocal, geoLength, segmentPath, channelShape, bankStart, canyonWidth, waterWidth, waterLevel,
         biome, segmentId, rng, type, config, flowSpeed, isSlotCanyon, biomeProfile,
-        trees, rocks, scatterRocks, cactus, desertSage, grass, canyonGrass,
+        trees, rocks, scatterRocks, cactus, desertSage, debris, grass, canyonGrass,
         wildflowers, reeds, driftwood, leaves, floatingLeaves, fireflies,
         birds, bats, fish, pebbles, sandBars, mist, waterLilies, sunShafts,
         ferns, rapids, dragonflies, pinecones, mushrooms, rimTrees, rockFoam, canyonDust,

--- a/src/components/TrackSegment/hooks/populateZSteps.js
+++ b/src/components/TrackSegment/hooks/populateZSteps.js
@@ -8,7 +8,7 @@ export function populateZSteps(args) {
         zSteps, geoLength, segmentPath, channelShapeFn,
         bankStart, canyonWidth, waterWidth, biome, segmentId, rng,
         type, config, flowSpeed, isSlotCanyon, biomeProfile,
-        trees, rocks, scatterRocks, cactus, desertSage, grass, canyonGrass,
+        trees, rocks, scatterRocks, cactus, desertSage, debris, grass, canyonGrass,
         wildflowers, reeds, driftwood, leaves, floatingLeaves, fireflies,
         birds, bats, fish, pebbles, sandBars, mist, waterLilies, sunShafts,
         ferns, rapids, dragonflies, pinecones, mushrooms, rimTrees, rockFoam, canyonDust
@@ -43,7 +43,7 @@ export function populateZSteps(args) {
                 populateSide({
                     side, t, zLocal, geoLength, segmentPath, channelShape, bankStart, canyonWidth, waterWidth, waterLevel,
                     biome, segmentId, rng, type, config, flowSpeed, isSlotCanyon, biomeProfile,
-                    trees, rocks, scatterRocks, cactus, desertSage, grass, canyonGrass,
+                    trees, rocks, scatterRocks, cactus, desertSage, debris, grass, canyonGrass,
                     wildflowers, reeds, driftwood, leaves, floatingLeaves, fireflies,
                     birds, bats, fish, pebbles, sandBars, mist, waterLilies, sunShafts,
                     ferns, rapids, dragonflies, pinecones, mushrooms, rimTrees, rockFoam, canyonDust,

--- a/src/components/TrackSegment/hooks/usePlacementData.js
+++ b/src/components/TrackSegment/hooks/usePlacementData.js
@@ -186,7 +186,7 @@ export function usePlacementData({
             bankStart, canyonWidth, waterWidth, biome, segmentId, rng,
             type, config, flowSpeed, isSlotCanyon, biomeProfile,
             // Mutating lists:
-            trees, rocks, scatterRocks, cactus, desertSage, grass, canyonGrass,
+            trees, rocks, scatterRocks, cactus, desertSage, debris, grass, canyonGrass,
             wildflowers, reeds, driftwood, leaves, floatingLeaves, fireflies,
             birds, bats, fish, pebbles, sandBars, mist, waterLilies, sunShafts,
             ferns, rapids, dragonflies, pinecones, mushrooms, rimTrees, rockFoam, canyonDust
@@ -194,7 +194,7 @@ export function usePlacementData({
 
 
 
-        return { rocks, scatterRocks, trees, cactus, desertSage, grass, canyonGrass, wildflowers, reeds, driftwood, leaves, floatingLeaves, fireflies, birds, bats, fish, pebbles, sandBars, mist, waterLilies, sunShafts, ferns, rapids, dragonflies, pinecones, mushrooms, rimTrees, rockFoam, canyonDust };
+        return { rocks, scatterRocks, trees, cactus, desertSage, debris, grass, canyonGrass, wildflowers, reeds, driftwood, leaves, floatingLeaves, fireflies, birds, bats, fish, pebbles, sandBars, mist, waterLilies, sunShafts, ferns, rapids, dragonflies, pinecones, mushrooms, rimTrees, rockFoam, canyonDust };
     }, [segmentId, pathLength, segmentPath, canyonWidth, waterWidth, WATER_LEVEL, biome, type, flowSpeed, config, isSlotCanyon, biomeProfile]);
 
     return placementData;


### PR DESCRIPTION
populateSidePart1 pushes to debris but the array was never threaded through populateZSteps → populateSide. Pass debris from usePlacementData and include it in the returned placement payload.