### PR TITLE
Fix renderer crash: use WebGLRenderer for legacy GLSL materials

### DIFF
--- a/src/materials/RiverNodeMaterial.ts
+++ b/src/materials/RiverNodeMaterial.ts
@@ -237,11 +237,22 @@ export function createRiverNodeMaterial(
     displacementTex
   );
 
+  const textureProps: Partial<THREE.MeshStandardMaterialParameters> = {};
+  if (parameters.map) textureProps.map = parameters.map;
+  if (parameters.normalMap) textureProps.normalMap = parameters.normalMap;
+  if (parameters.roughnessMap) textureProps.roughnessMap = parameters.roughnessMap;
+  if (parameters.aoMap) textureProps.aoMap = parameters.aoMap;
+  if (parameters.displacementMap) textureProps.displacementMap = parameters.displacementMap;
+
   const material = new MeshStandardNodeMaterial({
-    roughness: 0.9,
-    metalness: 0.1,
-    ...parameters,
-    map: parameters.map ?? undefined,
+    roughness: parameters.roughness ?? 0.9,
+    metalness: parameters.metalness ?? 0.1,
+    color: parameters.color,
+    vertexColors: parameters.vertexColors,
+    side: parameters.side,
+    transparent: parameters.transparent,
+    opacity: parameters.opacity,
+    ...textureProps,
   });
 
   material.colorNode = color;

--- a/src/rendering/createRenderer.test.ts
+++ b/src/rendering/createRenderer.test.ts
@@ -1,0 +1,31 @@
+import { createGameRenderer } from './createRenderer';
+
+jest.mock('./cspProbe', () => ({
+  isDataUrlConnectAllowed: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('./rendererConfig', () => ({
+  persistRendererPreference: jest.fn(),
+}));
+
+describe('createGameRenderer', () => {
+  const canvasProps = { canvas: document.createElement('canvas') };
+
+  it('returns WebGLRenderer when preference is webgl', async () => {
+    const renderer = await createGameRenderer(canvasProps, { preference: 'webgl' });
+    expect(renderer.isWebGLRenderer).toBe(true);
+    expect(renderer.isWebGPURenderer).toBeFalsy();
+    renderer.dispose();
+  });
+
+  it('falls back to WebGLRenderer when preference is webgpu (legacy materials)', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const renderer = await createGameRenderer(canvasProps, { preference: 'webgpu' });
+    expect(renderer.isWebGLRenderer).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Legacy GLSL materials are incompatible with WebGPURenderer')
+    );
+    warnSpy.mockRestore();
+    renderer.dispose();
+  });
+});

--- a/src/rendering/createRenderer.ts
+++ b/src/rendering/createRenderer.ts
@@ -12,14 +12,13 @@ export interface GameRendererOptions {
 /**
  * Creates the Three.js renderer for the game Canvas.
  *
- * - `webgl`:  WebGPURenderer with WebGL2 backend (NodeMaterial + legacy GLSL).
- * - `webgpu`: WebGPURenderer (lazy-loaded). Falls back to WebGLRenderer when
- *   CSP blocks data: WGSL loads or initialization fails.
+ * - `webgl`:  THREE.WebGLRenderer — production path for legacy GLSL materials.
+ * - `webgpu`: Falls back to WebGLRenderer until legacy materials migrate to
+ *   NodeMaterial/TSL (WebGPURenderer rejects onBeforeCompile + ShaderMaterial).
  *
- * River + Canyon materials are migrated to NodeMaterial/TSL. Native WebGPU is
- * still blocked by remaining legacy materials (EnhancedSky, Fish, Dragonflies,
- * VegetationShader, RockShader, TreeShader, FlowingWater ShaderMaterial,
- * post-processing GLSL).
+ * Legacy materials (RiverShader onBeforeCompile, FlowingWater ShaderMaterial,
+ * post-processing GLSL) are incompatible with WebGPURenderer's NodeMaterial
+ * pipeline even when `forceWebGL: true`.
  */
 export async function createGameRenderer(
   canvasProps: THREE.WebGLRendererParameters,
@@ -38,6 +37,11 @@ export async function createGameRenderer(
       powerPreference,
     });
 
+  // Production path: custom GLSL shaders require the classic WebGLRenderer.
+  if (preference === 'webgl') {
+    return createWebGLRenderer();
+  }
+
   // WebGPURenderer ships WGSL as data:text/wgsl;base64,... internal modules.
   // Strict CSP (connect-src without data:) blocks those fetches and leaves a
   // blank canvas with shader validation errors in the console.
@@ -51,20 +55,12 @@ export async function createGameRenderer(
     return createWebGLRenderer();
   }
 
-  try {
-    const { WebGPURenderer } = await import('three/webgpu');
-    // Native WebGPU rejects legacy ShaderMaterial / onBeforeCompile materials.
-    // Force WebGL2 backend until the remaining materials migrate to NodeMaterial.
-    const renderer = new WebGPURenderer({
-      ...canvasProps,
-      antialias,
-      forceWebGL: true,
-    });
-    await renderer.init();
-    return renderer as unknown as THREE.WebGLRenderer;
-  } catch (error) {
-    console.warn('[Renderer] WebGPURenderer init failed — using WebGLRenderer:', error);
-    persistRendererPreference('webgl');
-    return createWebGLRenderer();
-  }
+  // forceWebGL still routes materials through NodeMaterial, which rejects
+  // legacy MeshStandardMaterial.onBeforeCompile and ShaderMaterial.
+  console.warn(
+    '[Renderer] Legacy GLSL materials are incompatible with WebGPURenderer — using WebGLRenderer. ' +
+      'Use ?renderer=webgl or wait for NodeMaterial migration.'
+  );
+  persistRendererPreference('webgl');
+  return createWebGLRenderer();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Loading the game produced a cascade of console errors:

- `NodeMaterial: Material "MeshStandardMaterial" is not compatible`
- `NodeMaterial: Material "ShaderMaterial" is not compatible`
- `Uncaught TypeError: c is not a constructor` in `setupLightsNode`
- Repeated `THREE.Material: parameter 'map' has value of undefined` warnings
- WebGL framebuffer errors (`Attachment has zero size`)

## Root cause

`createGameRenderer()` **ignored** the `webgl` renderer preference and always instantiated `WebGPURenderer` (with `forceWebGL: true`). Even with the WebGL2 backend, `WebGPURenderer` routes materials through the NodeMaterial pipeline, which rejects legacy GLSL materials (`RiverShader`, `FlowingWater`, post-processing, `onBeforeCompile` hooks).

## Fix

1. **`?renderer=webgl` (default)** now returns a plain `THREE.WebGLRenderer` — the production path for custom GLSL shaders.
2. **`?renderer=webgpu`** falls back to `WebGLRenderer` with a console warning until remaining scene materials migrate to NodeMaterial/TSL.
3. **`RiverNodeMaterial`** omits undefined texture map properties instead of passing them explicitly, eliminating the `parameter 'map' has value of undefined` spam.

## Verification

- `pnpm build` succeeds
- Headless browser test on production preview (`?renderer=webgl`):
  - **0** NodeMaterial errors
  - **0** undefined texture map warnings
  - No error boundary crash on load

## Note for deployed users

If you previously selected WebGPU in the debug panel, clear `localStorage` key `watershed.renderer.preference` or add `?renderer=webgl` to the URL to force the stable path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-980dc8b9-f95e-44d0-bc92-afc80d7c48d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-980dc8b9-f95e-44d0-bc92-afc80d7c48d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

