### PR TITLE
Fix WebGL shader crash: restore GLSL river/canyon materials

### DIFF
--- a/src/components/TrackSegment/TrackSegmentMeshes.jsx
+++ b/src/components/TrackSegment/TrackSegmentMeshes.jsx
@@ -299,7 +299,6 @@ export function TrackSegmentMeshes({
             });
         }
 
-        // Factory returns a new RiverNodeMaterial (does not mutate the clone).
         return extendRiverMaterial(rockMaterial.clone(), {
             enableWetness: true,
             enableMoss: true,
@@ -313,7 +312,7 @@ export function TrackSegmentMeshes({
 
     // Update shader uniforms each frame
     useFrame((state) => {
-        if (isSlotCanyon && wallMaterialRef.current?.userData?.canyonUniforms) {
+        if (isSlotCanyon && wallMaterialRef.current?.uniforms) {
             updateCanyonMaterial(wallMaterialRef.current, {
                 flowSpeed,
                 mossCoverage: 1.0,

--- a/src/materials/CanyonMaterial.js
+++ b/src/materials/CanyonMaterial.js
@@ -1,20 +1,462 @@
 /**
- * CanyonMaterial facade — factory API backed by CanyonNodeMaterial (TSL / NodeMaterial).
+ * CanyonMaterial - Multi-layered geological shader with parallax mapping
+ * 
+ * Implements:
+ * - 5-layer geological strata (bedrock → sedimentary → granite → moss → soil)
+ * - Weathering patterns (water streaks, moss coverage, cracks)
+ * - Parallax mapping for depth
+ * - Height-based roughness and metalness variation
+ * - Biome-aware color adaptation
  */
-import {
-  createCanyonNodeMaterial,
-  updateCanyonNodeMaterial,
-  createFallbackCanyonMaterial,
-} from './CanyonNodeMaterial';
 
+import * as THREE from 'three';
+
+// Geological layer definitions
+const GEOLOGICAL_LAYERS = {
+  bedrock: {
+    color: new THREE.Color('#3d3530'),
+    roughness: 0.85,
+    metalness: 0.05,
+    heightRange: [0, 0.5],
+  },
+  sedimentary: {
+    color: new THREE.Color('#5c5048'),
+    roughness: 0.75,
+    metalness: 0.08,
+    heightRange: [0.5, 0.7],
+  },
+  granite: {
+    color: new THREE.Color('#7a7068'),
+    roughness: 0.65,
+    metalness: 0.12,
+    heightRange: [0.7, 0.85],
+  },
+  moss: {
+    color: new THREE.Color('#4a5a40'),
+    roughness: 0.9,
+    metalness: 0.02,
+    heightRange: [0.85, 0.95],
+  },
+  soil: {
+    color: new THREE.Color('#5a5040'),
+    roughness: 0.95,
+    metalness: 0.0,
+    heightRange: [0.95, 1.0],
+  },
+};
+
+// Biome color adaptations
+const BIOME_ADAPTATIONS = {
+  summer: {
+    mossColor: new THREE.Color('#587248'),
+    soilColor: new THREE.Color('#5a5040'),
+    weatheringIntensity: 0.8,
+  },
+  autumn: {
+    mossColor: new THREE.Color('#7a6640'),
+    soilColor: new THREE.Color('#6a5848'),
+    weatheringIntensity: 0.9,
+  },
+  alpine: {
+    mossColor: new THREE.Color('#4a5a50'),
+    soilColor: new THREE.Color('#505850'),
+    weatheringIntensity: 0.6,
+  },
+  sunset: {
+    mossColor: new THREE.Color('#6a5840'),
+    soilColor: new THREE.Color('#705848'),
+    weatheringIntensity: 0.85,
+  },
+  midnight: {
+    mossColor: new THREE.Color('#3a4a40'),
+    soilColor: new THREE.Color('#3a4038'),
+    weatheringIntensity: 0.7,
+  },
+  slotCanyon: {
+    mossColor: new THREE.Color('#5a3a1a'),       // dark iron-oxide staining
+    soilColor: new THREE.Color('#c87840'),       // warm sandstone rim
+    weatheringIntensity: 1.0,
+    bedrockColor: new THREE.Color('#5c2a1a'),    // deep red-brown bedrock
+    sedimentaryColor: new THREE.Color('#a85a30'),// warm orange sandstone
+    graniteColor: new THREE.Color('#d4884c'),    // light tan-orange band
+  },
+};
+
+const VERTEX_SHADER = `
+  varying vec2 vUv;
+  varying vec3 vWorldPos;
+  varying vec3 vNormal;
+  varying vec3 vColor;
+  varying float vHeight;
+  varying vec3 vViewDir;
+  varying float vMossMask;
+  varying float vHighWaterMask;
+  
+  uniform float time;
+  uniform float wallHeight;
+  attribute vec3 color;
+  attribute float mossMask;
+  attribute float highWaterMask;
+  
+  // Simplex noise for surface variation
+  vec3 mod289(vec3 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+  vec2 mod289(vec2 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+  vec3 permute(vec3 x) { return mod289(((x*34.0)+1.0)*x); }
+  
+  float snoise(vec2 v) {
+    const vec4 C = vec4(0.211324865405187, 0.366025403784439,
+             -0.577350269189626, 0.024390243902439);
+    vec2 i  = floor(v + dot(v, C.yy));
+    vec2 x0 = v - i + dot(i, C.xx);
+    vec2 i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+    vec4 x12 = x0.xyxy + C.xxzz;
+    x12.xy -= i1;
+    i = mod289(i);
+    vec3 p = permute(permute(i.y + vec3(0.0, i1.y, 1.0))
+      + i.x + vec3(0.0, i1.x, 1.0));
+    vec3 m = max(0.5 - vec3(dot(x0,x0), dot(x12.xy,x12.xy),
+      dot(x12.zw,x12.zw)), 0.0);
+    m = m*m; m = m*m;
+    vec3 x = 2.0 * fract(p * C.www) - 1.0;
+    vec3 h = abs(x) - 0.5;
+    vec3 ox = floor(x + 0.5);
+    vec3 a0 = x - ox;
+    m *= 1.79284291400159 - 0.85373472095314 * (a0*a0 + h*h);
+    vec3 g;
+    g.x  = a0.x  * x0.x  + h.x  * x0.y;
+    g.yz = a0.yz * x12.xz + h.yz * x12.yw;
+    return 130.0 * dot(m, g);
+  }
+  
+  void main() {
+    vUv = uv;
+    vColor = color;
+    vWorldPos = (modelMatrix * vec4(position, 1.0)).xyz;
+    vNormal = normalize(normalMatrix * normal);
+    
+    // Calculate height normalized to wall (0 = base, 1 = top)
+    vHeight = (vWorldPos.y + 5.0) / wallHeight;
+    
+    // Add surface variation noise
+    float surfaceNoise = snoise(vWorldPos.xz * 0.15) * 0.3 
+                       + snoise(vWorldPos.xz * 0.5) * 0.1;
+    vHeight += surfaceNoise * 0.05;
+    vHeight = clamp(vHeight, 0.0, 1.0);
+    
+    // View direction for parallax
+    vec4 worldPos = modelMatrix * vec4(position, 1.0);
+    vViewDir = normalize(cameraPosition - worldPos.xyz);
+    vMossMask = mossMask;
+    vHighWaterMask = highWaterMask;
+    
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const FRAGMENT_SHADER = `
+  varying vec2 vUv;
+  varying vec3 vWorldPos;
+  varying vec3 vNormal;
+  varying vec3 vColor;
+  varying float vHeight;
+  varying vec3 vViewDir;
+  varying float vMossMask;
+  varying float vHighWaterMask;
+  
+  uniform float time;
+  uniform vec3 bedrockColor;
+  uniform vec3 sedimentaryColor;
+  uniform vec3 graniteColor;
+  uniform vec3 mossColor;
+  uniform vec3 soilColor;
+  uniform float roughness;
+  uniform float metalness;
+  uniform float weatheringIntensity;
+  uniform vec3 sunDirection;
+  uniform float parallaxScale;
+  uniform float flowSpeed;
+  uniform float mossCoverage;
+  uniform float highWaterMark;
+  uniform float highWaterIntensity;
+  
+  // Noise functions
+  float hash(vec2 p) { return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453); }
+  
+  float noise(vec2 p) {
+    vec2 i = floor(p); vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    return mix(mix(hash(i), hash(i + vec2(1,0)), f.x),
+               mix(hash(i + vec2(0,1)), hash(i + vec2(1,1)), f.x), f.y);
+  }
+  
+  float fbm(vec2 p) {
+    float value = 0.0;
+    float amp = 0.5;
+    for(int i = 0; i < 4; i++) {
+      value += noise(p) * amp;
+      p *= 2.0;
+      amp *= 0.5;
+    }
+    return value;
+  }
+  
+  // Smooth step function for geological layers
+  float smoothLayer(float h, float min1, float max1, float min2, float max2) {
+    float inLayer1 = smoothstep(min1, max1, h);
+    float inLayer2 = smoothstep(min2, max2, h);
+    return inLayer1 * (1.0 - inLayer2);
+  }
+  
+  // Weathering streaks (water channels)
+  float weatheringStreaks(vec2 uv, float h) {
+    float streaks = 0.0;
+    float freq = 0.3;
+    float flowAnim = time * (0.03 + flowSpeed * 0.02);
+    
+    // Vertical water channels
+    for(int i = 0; i < 3; i++) {
+      float offset = float(i) * 10.0;
+      float x = uv.x * freq + sin(uv.y * 0.5 + offset + flowAnim) * 0.3;
+      float streak = smoothstep(0.6, 0.9, noise(vec2(x * 3.0, uv.y * 0.2 - flowAnim)));
+      streaks += streak * 0.3;
+    }
+    
+    // Height-based intensity band with adjustable high-water mark
+    float lowerBand = max(0.0, highWaterMark - 0.14);
+    float upperBand = min(1.0, highWaterMark + 0.26);
+    float streakBand = 1.0 - smoothstep(lowerBand, upperBand, h);
+    streaks *= streakBand * weatheringIntensity;
+    
+    return streaks;
+  }
+
+  float seepStreaks(vec3 worldPos, vec2 uv, float h) {
+    float crackSeed = noise(vec2(worldPos.x * 0.08 + worldPos.z * 0.04, worldPos.z * 0.09));
+    float anchor = smoothstep(0.62, 0.92, crackSeed);
+    float verticalRun = smoothstep(0.2, 0.95, 1.0 - h);
+    float waviness = noise(vec2(worldPos.x * 0.12, worldPos.y * 0.08 - time * 0.04));
+    float stripe = smoothstep(0.58, 0.86, waviness);
+    return anchor * verticalRun * stripe * weatheringIntensity;
+  }
+  
+  // Moss coverage (authored mask + procedural variation)
+  float computeMossCoverage(float h, vec2 uv, float authoredMask) {
+    float baseCoverage = smoothstep(0.8, 0.95, h);
+    float noiseVar = fbm(uv * 2.0 + time * 0.01) * 0.4 + 0.6;
+    float proceduralCoverage = baseCoverage * noiseVar * weatheringIntensity;
+    float authoredCoverage = authoredMask * mossCoverage;
+    return max(proceduralCoverage * 0.4, authoredCoverage);
+  }
+  
+  // Crack patterns for realism
+  float crackPattern(vec2 uv) {
+    float cracks = 0.0;
+    float n = fbm(uv * 4.0 + vec2(time * 0.02 + flowSpeed * 0.03, -time * 0.01));
+    cracks = smoothstep(0.7, 0.75, n) * 0.3;
+    return cracks;
+  }
+  
+  void main() {
+    // Parallax offset for depth
+    vec2 parallaxOffset = vViewDir.xy * parallaxScale * (1.0 - dot(vNormal, vec3(0,1,0)));
+    vec2 uv = vUv + parallaxOffset;
+    
+    float h = vHeight;
+    
+    // Geological layer blending
+    vec3 color = bedrockColor;
+    float layerMix = 0.0;
+    
+    // Layer 1: Bedrock (0-50%)
+    layerMix = smoothstep(0.0, 0.5, h) - smoothstep(0.5, 0.7, h);
+    color = mix(color, sedimentaryColor, layerMix);
+    
+    // Layer 2: Sedimentary (50-70%)
+    layerMix = smoothstep(0.5, 0.7, h) - smoothstep(0.7, 0.85, h);
+    color = mix(color, graniteColor, layerMix);
+    
+    // Layer 3: Granite (70-85%)
+    layerMix = smoothstep(0.7, 0.85, h) - smoothstep(0.85, 0.95, h);
+    
+    // Layer 4: Moss (85-95%)
+    float mossAmt = computeMossCoverage(h, uv, vMossMask);
+    color = mix(color, mossColor, mossAmt * 0.7);
+    
+    // Layer 5: Soil (95-100%)
+    layerMix = smoothstep(0.95, 1.0, h);
+    color = mix(color, soilColor, layerMix);
+    
+    // Macro variation - large-scale tint that breaks tiling across hundreds of meters
+    float macroNoise = fbm(vWorldPos.xz * 0.012 + vec2(91.0, 47.0));
+    vec3 macroWarm = vec3(1.05, 0.97, 0.9);
+    vec3 macroCool = vec3(0.92, 0.97, 1.04);
+    color *= mix(macroWarm, macroCool, macroNoise);
+    color *= 0.9 + macroNoise * 0.2;
+
+    // Shadow pockets - deep crevices the river carved over millennia
+    float pocketNoise = fbm(vWorldPos.xz * 0.22 + vec2(vWorldPos.y * 0.05 + 7.0, 3.0));
+    float shadowPocket = smoothstep(0.6, 0.85, pocketNoise) * (1.0 - smoothstep(0.85, 1.0, pocketNoise));
+    color *= 1.0 - shadowPocket * 0.6;
+
+    // Mineral veins - bright quartz/iron seams that catch the eye at speed
+    float veinNoise = fbm(vWorldPos.xz * 0.55 + vec2(vWorldPos.y * 0.35 + 31.0, -17.0));
+    float vein = 1.0 - abs(veinNoise * 2.0 - 1.0);
+    vein = smoothstep(0.965, 0.99, vein) * smoothstep(0.3, 0.55, macroNoise);
+    vec3 veinColor = mix(vec3(0.92, 0.8, 0.5), vec3(0.85, 0.92, 0.95), step(0.5, macroNoise));
+    color = mix(color, veinColor, vein * 0.85);
+
+    // Moss "explosion" - vivid surprise growth patches independent of height bands
+    float explosionNoise = fbm(vWorldPos.xz * 0.07 + vec2(13.7, -8.2));
+    float mossExplosion = smoothstep(0.74, 0.9, explosionNoise) * smoothstep(0.05, 0.4, h);
+    color = mix(color, mossColor * 1.6, mossExplosion * 0.5);
+
+    // Near-water caustic shimmer - walls reflect the river's dance
+    float causticPattern = sin(vWorldPos.x * 0.6 + time * 1.3) * sin(vWorldPos.z * 0.6 - time * 1.0);
+    float causticBand = (1.0 - smoothstep(0.0, 0.18, h)) * smoothstep(0.0, 0.05, h);
+    color += causticPattern * causticBand * 0.05 * weatheringIntensity;
+
+    // Apply weathering streaks
+    float streaks = weatheringStreaks(uv, h);
+    color = mix(color, color * 0.7, streaks); // Darken where water runs
+
+    // Dark seep channels and mineral staining below ledges/cracks
+    float seeps = seepStreaks(vWorldPos, uv, h);
+    vec3 mineralTint = mix(vec3(0.28, 0.22, 0.16), vec3(0.48, 0.34, 0.22), smoothstep(0.1, 0.75, h));
+    color = mix(color, color * 0.58, seeps * 0.55);
+    color = mix(color, mineralTint, seeps * 0.16);
+    
+    // Apply crack patterns (darker in cracks)
+    float cracks = crackPattern(uv);
+    color = mix(color, color * 0.6, cracks);
+
+    // Authored flood scar band from geometry (historical high-water line)
+    float floodStripe = clamp(vHighWaterMask * highWaterIntensity, 0.0, 1.0);
+    float luma = dot(color, vec3(0.299, 0.587, 0.114));
+    vec3 floodDesat = mix(color, vec3(luma), floodStripe * 0.55);
+    color = mix(color, floodDesat * 0.82, floodStripe);
+    
+    // Surface detail noise
+    float detailNoise = fbm(uv * 8.0) * 0.1 - 0.05;
+    color += detailNoise;
+    
+    // Height-based roughness variation
+    float heightRoughness = mix(0.85, 0.45, h); // Smoother at top
+    heightRoughness = mix(heightRoughness, 0.3, mossAmt); // Moss is rough
+    
+    // Metalness variation (minerals in cracks, wet patches)
+    float heightMetalness = mix(0.05, 0.15, streaks + cracks * 0.5);
+    
+    // Rim lighting for visual appeal
+    float rim = 1.0 - dot(vNormal, normalize(vViewDir));
+    rim = smoothstep(0.4, 0.8, rim);
+    vec3 rimColor = vec3(0.3, 0.25, 0.2) * rim * 0.3;
+    color += rimColor;
+
+    // Heat glow - dramatic warm rim light on iron-stained, sun-baked walls
+    vec3 heatGlow = vec3(1.0, 0.45, 0.15) * rim * weatheringIntensity * 0.4;
+    color += heatGlow;
+    
+    // Blend authored geological vertex color bands with procedural strata
+    color *= vColor;
+
+    // Output
+    gl_FragColor = vec4(color, 1.0);
+    
+    // Store material properties in additional buffers (if using MRT)
+    // gl_FragData[1] = vec4(heightRoughness, heightMetalness, 0.0, 1.0);
+  }
+`;
+
+/**
+ * Create enhanced canyon material with geological layering
+ */
 export function createCanyonMaterial(options = {}) {
-  return createCanyonNodeMaterial(options);
+  const {
+    biome = 'summer',
+    wallHeight = 15,
+    parallaxScale,
+    time = 0,
+    flowSpeed = 1.0,
+    mossCoverage = 0.85,
+    highWaterMark = 0.15,
+    highWaterIntensity = 0.35,
+    strata = {},
+  } = options;
+
+  const biomeAdapt = BIOME_ADAPTATIONS[biome] || BIOME_ADAPTATIONS.summer;
+  const defaultParallaxScale = biome === 'slotCanyon' ? 0.025 : 0.012;
+  const clampedHighWaterMark = Math.min(0.4, Math.max(0.0, highWaterMark));
+  const clampedMossCoverage = Math.max(0.0, mossCoverage);
+
+  const material = new THREE.ShaderMaterial({
+    uniforms: {
+      time: { value: time },
+      wallHeight: { value: wallHeight },
+      bedrockColor: { value: biomeAdapt.bedrockColor || GEOLOGICAL_LAYERS.bedrock.color },
+      sedimentaryColor: { value: biomeAdapt.sedimentaryColor || GEOLOGICAL_LAYERS.sedimentary.color },
+      graniteColor: { value: biomeAdapt.graniteColor || GEOLOGICAL_LAYERS.granite.color },
+      mossColor: { value: biomeAdapt.mossColor },
+      soilColor: { value: biomeAdapt.soilColor },
+      roughness: { value: 0.75 },
+      metalness: { value: 0.08 },
+      weatheringIntensity: { value: biomeAdapt.weatheringIntensity },
+      sunDirection: { value: new THREE.Vector3(0.5, 1, 0.3).normalize() },
+      parallaxScale: { value: parallaxScale ?? defaultParallaxScale },
+      flowSpeed: { value: flowSpeed },
+      mossCoverage: { value: clampedMossCoverage },
+      highWaterMark: { value: clampedHighWaterMark },
+      highWaterIntensity: { value: Math.max(0.0, highWaterIntensity) },
+    },
+    vertexShader: VERTEX_SHADER,
+    fragmentShader: FRAGMENT_SHADER,
+    side: THREE.DoubleSide,
+  });
+
+  return material;
 }
 
+/**
+ * Create fallback MeshStandardMaterial for compatibility
+ */
+export function createFallbackCanyonMaterial(options = {}) {
+  const { biome = 'summer' } = options;
+  
+  const baseColor = biome === 'autumn' 
+    ? new THREE.Color('#9c7850') 
+    : new THREE.Color('#888880');
+
+  return new THREE.MeshStandardMaterial({
+    color: baseColor,
+    roughness: 0.8,
+    metalness: 0.1,
+    side: THREE.DoubleSide,
+  });
+}
+
+/**
+ * Update material uniforms (call in useFrame)
+ */
 export function updateCanyonMaterial(material, deltaTime, elapsedTime) {
-  return updateCanyonNodeMaterial(material, deltaTime, elapsedTime);
-}
+  if (!material || !material.uniforms) return;
 
-export { createFallbackCanyonMaterial };
+  material.uniforms.time.value = elapsedTime;
+
+  const options = (typeof deltaTime === 'object' && deltaTime !== null)
+    ? deltaTime
+    : {};
+
+  if (options.flowSpeed !== undefined && material.uniforms.flowSpeed) {
+    material.uniforms.flowSpeed.value = options.flowSpeed;
+  }
+  if (options.mossCoverage !== undefined && material.uniforms.mossCoverage) {
+    material.uniforms.mossCoverage.value = Math.max(0.0, options.mossCoverage);
+  }
+  if (options.highWaterMark !== undefined && material.uniforms.highWaterMark) {
+    material.uniforms.highWaterMark.value = Math.min(0.4, Math.max(0.0, options.highWaterMark));
+  }
+  if (options.highWaterIntensity !== undefined && material.uniforms.highWaterIntensity) {
+    material.uniforms.highWaterIntensity.value = Math.max(0.0, options.highWaterIntensity);
+  }
+}
 
 export default createCanyonMaterial;

--- a/src/systems/WatershedWasm.ts
+++ b/src/systems/WatershedWasm.ts
@@ -164,7 +164,9 @@ export async function getWasm(): Promise<WatershedNativeModule> {
     // Use eval-like dynamic import to prevent bundlers from trying to resolve
     // the WASM glue JS at build time (the file is produced by Emscripten).
     const dynamicImport = new Function('url', 'return import(url)') as (url: string) => Promise<unknown>;
-    const mod = await dynamicImport('/watershed_native.js') as {
+    const wasmBase = import.meta.env.BASE_URL || '/';
+    const wasmJsUrl = new URL('watershed_native.js', wasmBase.endsWith('/') ? wasmBase : `${wasmBase}/`).href;
+    const mod = await dynamicImport(wasmJsUrl) as {
       default: WatershedNativeFactory;
     };
 
@@ -173,7 +175,8 @@ export async function getWasm(): Promise<WatershedNativeModule> {
       locateFile: (path: string, _prefix: string) => {
         // Direct the glue JS to load all auxiliary files (including .wasm)
         // from the public root, regardless of the Vite base path.
-        return `/${path}`;
+        const assetBase = import.meta.env.BASE_URL || '/';
+        return new URL(path, assetBase.endsWith('/') ? assetBase : `${assetBase}/`).href;
       },
     });
   })();

--- a/src/utils/RiverShader.js
+++ b/src/utils/RiverShader.js
@@ -1,64 +1,430 @@
-/**
- * RiverShader facade — factory API backed by RiverNodeMaterial (TSL / NodeMaterial).
- */
 import * as THREE from 'three';
-import {
-  createRiverNodeMaterial,
-  copyStandardPropsToRiverMaterial,
-  updateRiverNodeMaterial,
-} from '../materials/RiverNodeMaterial';
-
-export { MOSS_HEIGHT_FADE, MOSS_NORMAL_MASK, mossNormalFactor } from '../materials/tsl/riverConstants';
+import { WALL_WATERLINE_Y, SHADERS, ROCK_SHADER } from '../constants/game';
 
 /**
- * Create a new river-aware NodeMaterial (does not mutate the input).
+ * RiverShader - Enhanced wetness, moss, triplanar texture, parallax, cracks, and weather effects
+ *
+ * This version uses shader injection via onBeforeCompile for:
+ *   - Wetness: Darkens surfaces near water (Y=13), reduces roughness
+ *   - Weather wetness: Shares uWeatherWetness with the water shader for seamless blending
+ *   - Moss/Lichen: Uses vertex color mossMask for organic growth bands, faded by height
+ *   - Triplanar blending: Mixes primary and secondary UVs for texture variety
+ *   - Cheap parallax offset: Uses displacement map for depth on near walls
+ *   - Procedural cracks: FBM-based dark fissures
+ *   - Stratification & color variation: Horizontal bands and height-based tint (secondary)
+ *
+ * Effects are driven by vertex attributes:
+ *   - color: Base vertex colors with gradient from waterline to rim
+ *   - mossMask: 0-1 mask for moss/lichen intensity
+ *   - uv2: Secondary triplanar UV coordinates
+ */
+
+// Wetness parameters
+const WETNESS_DARKEN_FACTOR = 0.70; // aligns with ROCK_SHADER.WETNESS_DARKEN = 0.30
+const WETNESS_ROUGHNESS_REDUCTION = 0.30;
+const WATER_LEVEL_Y = WALL_WATERLINE_Y;
+const WETNESS_RANGE = 4.0;
+
+// Moss/Lichen colors
+const MOSS_COLOR = new THREE.Color(SHADERS.MOSS_COLOR);      // Deep moss green
+const LICHEN_COLOR = new THREE.Color(SHADERS.LICHEN_COLOR);    // Lighter lichen
+const MOSS_INTENSITY = 0.6;
+
+// Shared 1x1 white texture for missing displacement maps
+const WHITE_TEXTURE = (() => {
+    const tex = new THREE.DataTexture(new Uint8Array([255, 255, 255, 255]), 1, 1, THREE.RGBAFormat);
+    tex.needsUpdate = true;
+    return tex;
+})();
+
+function injectShaderChunk(source, marker, replacement, label) {
+    if (!source.includes(marker)) {
+        throw new Error(`RiverShader: Missing shader marker "${marker}" in ${label}`);
+    }
+
+    return source.replace(marker, replacement);
+}
+
+/**
+ * Extends a material with river-aware shader effects
+ * @param {THREE.Material} material - The material to extend
+ * @param {Object} options - Optional configuration
  */
 export function extendRiverMaterial(material, options = {}) {
-  if (!material) return material;
+    if (!material) return;
 
-  if (material.isNodeMaterial && material.userData?.riverUniforms) {
+    const {
+        enableWetness = true,
+        enableMoss = true,
+        enableTriplanar = true,
+        waterLevel = WATER_LEVEL_Y,
+        wetnessRange = WETNESS_RANGE
+    } = options;
+
+    try {
+        // Store shader reference for updates
+        material.userData.riverShader = {
+            waterLevel,
+            wetnessRange,
+            time: 0
+        };
+
+        material.onBeforeCompile = (shader) => {
+            try {
+                shader.uniforms.uWaterLevel = { value: waterLevel };
+                shader.uniforms.uWetnessRange = { value: wetnessRange };
+                shader.uniforms.uTime = { value: 0 };
+                shader.uniforms.uWeatherWetness = { value: 0 };
+                shader.uniforms.uDisplacementMap = { value: material.displacementMap || WHITE_TEXTURE };
+                shader.uniforms.uDisplacementScale = { value: ROCK_SHADER.DISPLACEMENT_SCALE };
+                shader.uniforms.uCrackIntensity = { value: ROCK_SHADER.CRACK_INTENSITY };
+                shader.uniforms.uCrackScale = { value: ROCK_SHADER.CRACK_SCALE };
+                shader.uniforms.uStratificationStrength = { value: ROCK_SHADER.STRATIFICATION_STRENGTH };
+                shader.uniforms.uStratificationScale = { value: ROCK_SHADER.STRATIFICATION_SCALE };
+                shader.uniforms.uWarmColor = { value: new THREE.Color(ROCK_SHADER.WARM_COLOR) };
+                shader.uniforms.uCoolColor = { value: new THREE.Color(ROCK_SHADER.COOL_COLOR) };
+                shader.uniforms.uColorVariationStrength = { value: ROCK_SHADER.COLOR_VARIATION_STRENGTH };
+
+                if (enableMoss) {
+                    shader.uniforms.uMossColor = { value: MOSS_COLOR };
+                    shader.uniforms.uLichenColor = { value: LICHEN_COLOR };
+                    shader.uniforms.uMossIntensity = { value: MOSS_INTENSITY };
+                }
+
+                // Build vertex shader preamble conditionally to avoid declaring
+                // attributes that are not present on every geometry.
+                const vertexPreamble = [
+                    enableMoss ? 'attribute float mossMask;' : '',
+                    enableMoss ? 'attribute float highWaterMask;' : '',
+                    enableTriplanar ? `
+                #if !defined( USE_LIGHTMAP ) && !defined( USE_AOMAP )
+                attribute vec2 uv2;
+                varying vec2 vUv2;
+                #endif` : '',
+                    enableMoss ? 'varying float vMossMask;' : '',
+                    'varying float vHighWaterMask;',
+                    (enableMoss || enableTriplanar) ? 'varying vec3 vWorldNormal;' : '',
+                    'varying float vHeightAboveWater;',
+                    'varying vec3 vWorldPos;',
+                    'varying vec3 vViewDir;',
+                    'uniform float uWaterLevel;',
+                ].filter(Boolean).join('\n') + '\n';
+
+                const nextVertexShader = injectShaderChunk(
+                    vertexPreamble + shader.vertexShader,
+                    '#include <begin_vertex>',
+                    `
+                #include <begin_vertex>
+                
+                // Calculate height above water for wetness / moss gradients
+                vWorldPos = (modelMatrix * vec4(position, 1.0)).xyz;
+                vHeightAboveWater = vWorldPos.y - uWaterLevel;
+                vViewDir = normalize(cameraPosition - vWorldPos);
+                ${(enableMoss || enableTriplanar) ? 'vWorldNormal = normalize((modelMatrix * vec4(normal, 0.0)).xyz);' : ''}
+                
+                ${enableMoss ? 'vMossMask = mossMask;' : ''}
+                ${enableMoss ? 'vHighWaterMask = highWaterMask;' : 'vHighWaterMask = 0.0;'}
+                ${enableTriplanar ? `
+                #if !defined( USE_LIGHTMAP ) && !defined( USE_AOMAP )
+                vUv2 = uv2;
+                #endif` : ''}
+                `,
+                    'vertex shader'
+                );
+
+                // Build fragment shader preamble conditionally.
+                const fragmentPreamble = [
+                    'uniform float uWaterLevel;',
+                    'uniform float uWetnessRange;',
+                    'uniform float uTime;',
+                    'uniform float uWeatherWetness;',
+                    'uniform sampler2D uDisplacementMap;',
+                    'uniform float uDisplacementScale;',
+                    'uniform float uCrackIntensity;',
+                    'uniform float uCrackScale;',
+                    'uniform float uStratificationStrength;',
+                    'uniform float uStratificationScale;',
+                    'uniform vec3 uWarmColor;',
+                    'uniform vec3 uCoolColor;',
+                    'uniform float uColorVariationStrength;',
+                    enableMoss ? 'uniform vec3 uMossColor;' : '',
+                    enableMoss ? 'uniform vec3 uLichenColor;' : '',
+                    enableMoss ? 'uniform float uMossIntensity;' : '',
+                    'varying float vHeightAboveWater;',
+                    enableMoss ? 'varying float vMossMask;' : '',
+                    'varying float vHighWaterMask;',
+                    (enableMoss || enableTriplanar) ? 'varying vec3 vWorldNormal;' : '',
+                    enableTriplanar ? `
+                #if !defined( USE_LIGHTMAP ) && !defined( USE_AOMAP )
+                varying vec2 vUv2;
+                #endif` : '',
+                    'varying vec3 vWorldPos;',
+                    'varying vec3 vViewDir;',
+                    enableMoss ? `
+                // Noise helper for organic moss variation
+                float riverNoise(vec2 p) {
+                    return sin(p.x * 3.0) * sin(p.y * 3.0) * 0.5 + 0.5;
+                }` : '',
+                    `
+                // Fast hash/noise for cracks, stratification, and fallback height
+                float hash(vec2 p) { return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453); }
+                float noise(vec2 p) {
+                    vec2 i = floor(p); vec2 f = fract(p);
+                    f = f * f * (3.0 - 2.0 * f);
+                    return mix(mix(hash(i), hash(i + vec2(1.0, 0.0)), f.x),
+                               mix(hash(i + vec2(0.0, 1.0)), hash(i + vec2(1.0, 1.0)), f.x), f.y);
+                }
+                float fbm2(vec2 p) {
+                    float value = 0.0;
+                    float amp = 0.5;
+                    for(int i = 0; i < 2; i++) {
+                        value += noise(p) * amp;
+                        p *= 2.0;
+                        amp *= 0.5;
+                    }
+                    return value;
+                }
+                `,
+                ].filter(Boolean).join('\n') + '\n';
+
+                const mapFragmentReplacement = `
+                // Parallax offset — vMapUv is only defined when USE_MAP is active, so
+                // we initialise parallaxOffset here and compute it inside the #ifdef block.
+                vec2 parallaxOffset = vec2(0.0);
+
+                #ifdef USE_MAP
+                    float dispHeight = texture2D(uDisplacementMap, vMapUv).r;
+                    parallaxOffset = vViewDir.xy * dispHeight * uDisplacementScale;
+                    vec4 sampledDiffuseColor = texture2D( map, vMapUv + parallaxOffset );
+                    #ifdef DECODE_VIDEO_TEXTURE
+                        // sRGB EOTF (Electro-Optical Transfer Function) constants from
+                        // Three.js map_fragment chunk – decode video textures from sRGB.
+                        sampledDiffuseColor = vec4( mix(
+                            pow( sampledDiffuseColor.rgb * 0.9478672986 + vec3( 0.0521327014 ), vec3( 2.4 ) ),
+                            sampledDiffuseColor.rgb * 0.0773993808,
+                            vec3( lessThanEqual( sampledDiffuseColor.rgb, vec3( 0.04045 ) ) )
+                        ), sampledDiffuseColor.w );
+                    #endif
+                    ${enableTriplanar ? `
+                    #if !defined( USE_LIGHTMAP ) && !defined( USE_AOMAP )
+                        // Blend in secondary projection aggressively on cliffs to break tiling.
+                        vec4 triplanarSample = texture2D( map, vUv2 + parallaxOffset );
+                        float triplanarBlend = smoothstep( 3.0, 12.0, vHeightAboveWater );
+                        float cliffBlend = pow(1.0 - abs(dot(normalize(vWorldNormal), vec3(0.0, 1.0, 0.0))), 1.35);
+                        float projectionBlend = clamp(max(triplanarBlend, cliffBlend * 0.85), 0.0, 1.0);
+                        sampledDiffuseColor = mix( sampledDiffuseColor, triplanarSample, projectionBlend * 0.85 );
+                    #endif` : ''}
+                    diffuseColor *= sampledDiffuseColor;
+                #endif
+                `;
+
+                let nextFragmentShader = injectShaderChunk(
+                    fragmentPreamble + shader.fragmentShader,
+                    '#include <map_fragment>',
+                    mapFragmentReplacement,
+                    'fragment shader'
+                );
+
+                nextFragmentShader = injectShaderChunk(
+                    nextFragmentShader,
+                    '#include <color_fragment>',
+                    `
+                #include <color_fragment>
+
+                // Macro variation - large-scale tint that breaks tiling across hundreds of meters
+                float macroNoise = fbm2(vWorldPos.xz * 0.01 + vec2(91.0, 47.0));
+                vec3 macroWarm = vec3(1.05, 0.97, 0.9);
+                vec3 macroCool = vec3(0.92, 0.97, 1.04);
+                diffuseColor.rgb *= mix(macroWarm, macroCool, macroNoise);
+                diffuseColor.rgb *= 0.9 + macroNoise * 0.2;
+
+                // Shadow pockets - deep crevices the river carved over millennia
+                float pocketNoise = fbm2(vWorldPos.xz * 0.2 + vec2(vWorldPos.y * 0.05 + 11.0, -4.0));
+                float shadowPocket = smoothstep(0.6, 0.85, pocketNoise) * (1.0 - smoothstep(0.85, 1.0, pocketNoise));
+                diffuseColor.rgb *= 1.0 - shadowPocket * 0.55;
+
+                // Mineral veins - bright quartz/iron seams discovered while moving at speed
+                float veinNoise = fbm2(vWorldPos.xz * 0.5 + vec2(vWorldPos.y * 0.3 + 33.0, -19.0));
+                float vein = 1.0 - abs(veinNoise * 2.0 - 1.0);
+                vein = smoothstep(0.96, 0.99, vein) * smoothstep(0.3, 0.55, macroNoise);
+                vec3 veinColor = mix(vec3(0.92, 0.8, 0.5), vec3(0.85, 0.92, 0.95), step(0.5, macroNoise));
+                diffuseColor.rgb = mix(diffuseColor.rgb, veinColor, vein * 0.85);
+
+                // Near-water caustic shimmer - walls "talk" to the river beside them
+                float causticPattern = sin(vWorldPos.x * 0.6 + uTime * 1.3) * sin(vWorldPos.z * 0.6 - uTime * 1.0);
+                float causticBand = smoothstep(uWetnessRange, 0.0, abs(vHeightAboveWater));
+                diffuseColor.rgb += causticPattern * causticBand * 0.04;
+
+                ${enableMoss ? `
+                // Moss "explosion" - vivid surprise growth patches independent of height bands
+                float explosionNoise = riverNoise(vWorldPos.xz * 0.06 + 13.7);
+                float mossExplosion = smoothstep(0.74, 0.9, explosionNoise)
+                    * smoothstep(-1.0, 2.0, vHeightAboveWater) * (1.0 - smoothstep(3.0, 6.0, vHeightAboveWater));
+                diffuseColor.rgb = mix(diffuseColor.rgb, uMossColor * 1.7, mossExplosion * 0.45);
+
+                // Moss/Lichen bands using vertex color mask
+                if (max(vMossMask, vHighWaterMask) > 0.08) {
+                    // Organic variation based on world position
+                    float mossNoise = riverNoise(vWorldPos.xz * 0.5 + uTime * 0.05);
+                    float mossNoise2 = riverNoise(vWorldPos.xz * 1.2 - uTime * 0.03);
+                    
+                    // Blend between moss and lichen based on height
+                    float heightFactor = smoothstep(0.0, 3.0, vHeightAboveWater);
+                    vec3 growthColor = mix(uMossColor, uLichenColor, heightFactor);
+                    
+                    // Modulate intensity with noise
+                    float floodBand = clamp(vHighWaterMask * 1.15, 0.0, 1.0);
+                    float intensity = max(vMossMask, floodBand * 0.65) * uMossIntensity * (0.7 + mossNoise * 0.3);
+                    intensity *= (0.8 + mossNoise2 * 0.2);
+                    
+                    // Height-based fade: tight band above waterline with extra flood-mark carry.
+                    float mossHeightFade = 1.0 - smoothstep(2.0, 4.5, vHeightAboveWater);
+                    intensity *= mossHeightFade;
+                    
+                    // Normal-based mask: prefer upward-facing ledges and broken shelves near water.
+                    float normalFactor = smoothstep(0.15, 0.82, dot(normalize(vWorldNormal), vec3(0.0, 1.0, 0.0)));
+                    intensity *= normalFactor;
+                    
+                    // Apply moss color
+                    diffuseColor.rgb = mix(diffuseColor.rgb, growthColor, intensity);
+                }
+                ` : ''}
+                
+                ${enableWetness ? `
+                // Wetness effect - darker near waterline, boosted by weather.
+                // The wet/dry boundary is perturbed by noise so it climbs
+                // unevenly up rocks and canyon walls instead of forming a
+                // perfectly flat waterline.
+                float wetnessNoise = fbm2(vWorldPos.xz * 0.3 + vec2(vWorldPos.y * 0.15, 0.0)) * 1.6 - 0.8;
+                float wetRange = max(0.05, uWetnessRange + wetnessNoise);
+                float baseWetness = 1.0 - smoothstep(0.0, wetRange, vHeightAboveWater);
+                float weatherWetnessFactor = uWeatherWetness * (1.0 - smoothstep(0.0, wetRange * 1.5, vHeightAboveWater));
+                float combinedWetness = clamp(baseWetness + weatherWetnessFactor, 0.0, 1.0);
+                
+                // Darken wet areas
+                float wetDarken = 1.0 - (combinedWetness * ${(1.0 - ROCK_SHADER.WETNESS_DARKEN).toFixed(2)});
+                diffuseColor.rgb *= wetDarken;
+                ` : ''}
+                
+                // Procedural cracks
+                float crackNoise = fbm2(vWorldPos.xz * uCrackScale + parallaxOffset * 2.0);
+                float crackMask = smoothstep(0.55, 0.65, crackNoise);
+                diffuseColor.rgb *= (1.0 - crackMask * uCrackIntensity);
+                
+                // Stratification (secondary)
+                float stratWarp = fbm2(vWorldPos.xz * (uStratificationScale * 0.35) + vec2(4.1, -2.7));
+                float strat = sin(vWorldPos.y * uStratificationScale + stratWarp * 4.5 + hash(vWorldPos.xz) * 2.0) * 0.5 + 0.5;
+                float stratContrast = smoothstep(0.18, 0.82, strat);
+                diffuseColor.rgb = mix(diffuseColor.rgb, diffuseColor.rgb * (0.78 + stratContrast * 0.32), uStratificationStrength * 0.7);
+                
+                // Color variation (secondary)
+                float heightRatio = clamp(vHeightAboveWater / 12.0, 0.0, 1.0);
+                vec3 heightTint = mix(uWarmColor, uCoolColor, heightRatio);
+                diffuseColor.rgb = mix(diffuseColor.rgb, heightTint, uColorVariationStrength * (0.35 + heightRatio * 0.65));
+                diffuseColor.rgb *= 1.0 - clamp(vHighWaterMask, 0.0, 1.0) * 0.08;
+                `,
+                    'fragment shader'
+                );
+
+                // Roughness reduction in wet areas
+                if (nextFragmentShader.includes('#include <roughnessmap_fragment>')) {
+                    nextFragmentShader = injectShaderChunk(
+                        nextFragmentShader,
+                        '#include <roughnessmap_fragment>',
+                        `
+                    #include <roughnessmap_fragment>
+                    float baseWetnessR = 1.0 - smoothstep(0.0, uWetnessRange, vHeightAboveWater);
+                    float weatherWetnessR = uWeatherWetness * (1.0 - smoothstep(0.0, uWetnessRange * 1.5, vHeightAboveWater));
+                    float combinedWetnessR = clamp(baseWetnessR + weatherWetnessR, 0.0, 1.0);
+                    roughnessFactor *= 1.0 - (combinedWetnessR * 0.35);
+                    `,
+                        'fragment shader roughness'
+                    );
+                }
+
+                shader.vertexShader = nextVertexShader;
+                shader.fragmentShader = nextFragmentShader;
+                material.userData.shader = shader;
+                material.userData.shaderFailed = false;
+            } catch (error) {
+                material.userData.shader = null;
+                material.userData.shaderFailed = true;
+                console.error('RiverShader: Error compiling shader injection:', error);
+                console.error('RiverShader: Vertex shader:', shader?.vertexShader?.substring?.(0, 500));
+                console.error('RiverShader: Fragment shader:', shader?.fragmentShader?.substring?.(0, 500));
+                fallbackExtend(material);
+            }
+        };
+
+        // Mark material for updates
+        material.needsUpdate = true;
+
+    } catch (e) {
+        console.warn('RiverShader: Error setting up shader injection:', e);
+        // Fallback to property-based approach
+        fallbackExtend(material);
+    }
+
     return material;
-  }
-
-  if (material.isMeshStandardMaterial || material instanceof THREE.MeshStandardMaterial) {
-    return copyStandardPropsToRiverMaterial(material, options);
-  }
-
-  return createRiverNodeMaterial(
-    {
-      color: material.color?.clone?.() ?? new THREE.Color('#888880'),
-      roughness: material.roughness ?? 0.9,
-      metalness: material.metalness ?? 0.1,
-      map: material.map ?? undefined,
-      normalMap: material.normalMap ?? undefined,
-      roughnessMap: material.roughnessMap ?? undefined,
-      aoMap: material.aoMap ?? undefined,
-      displacementMap: material.displacementMap ?? undefined,
-      vertexColors: material.vertexColors ?? false,
-      side: material.side,
-    },
-    options
-  );
 }
 
 /**
- * Update river material uniform nodes (call in useFrame).
+ * Fallback property-based material extension
+ */
+function fallbackExtend(material) {
+    try {
+        if (material.color) {
+            material.color.multiplyScalar(WETNESS_DARKEN_FACTOR);
+        }
+        if (material.roughness !== undefined) {
+            material.roughness = Math.max(0.25, material.roughness - WETNESS_ROUGHNESS_REDUCTION);
+        }
+        material.needsUpdate = true;
+    } catch (e) {
+        // Silently ignore
+    }
+}
+
+/**
+ * Update shader uniforms (call in useFrame)
+ * @param {THREE.Material} material - The material to update
+ * @param {number} time - Current elapsed time
+ * @param {Object|number} options - Options object or legacy waterLevel number
  */
 export function updateRiverMaterial(material, time, options = {}) {
-  if (!material) return;
-  updateRiverNodeMaterial(material, time, options);
+    if (!material || !material.userData.shader) return;
+
+    const shader = material.userData.shader;
+    if (shader.uniforms) {
+        shader.uniforms.uTime.value = time;
+        if (typeof options === 'number') {
+            // backward compatibility: third arg used to be waterLevel
+            if (shader.uniforms.uWaterLevel) {
+                shader.uniforms.uWaterLevel.value = options;
+            }
+        } else if (options && typeof options === 'object') {
+            if (options.waterLevel !== undefined && shader.uniforms.uWaterLevel) {
+                shader.uniforms.uWaterLevel.value = options.waterLevel;
+            }
+            if (options.weatherWetness !== undefined && shader.uniforms.uWeatherWetness) {
+                shader.uniforms.uWeatherWetness.value = options.weatherWetness;
+            }
+        }
+    }
 }
 
 /**
- * Create a river-aware material with all effects pre-configured.
+ * Create a river-aware material with all effects pre-configured
+ * @param {Object} parameters - Base material parameters
+ * @returns {THREE.MeshStandardMaterial}
  */
-export function createRiverMaterial(parameters = {}, options = {}) {
-  return createRiverNodeMaterial(
-    {
-      roughness: 0.9,
-      metalness: 0.1,
-      ...parameters,
-    },
-    options
-  );
+export function createRiverMaterial(parameters = {}) {
+    const material = new THREE.MeshStandardMaterial({
+        roughness: 0.9,
+        metalness: 0.1,
+        ...parameters
+    });
+
+    extendRiverMaterial(material);
+    return material;
 }

--- a/src/utils/RiverShader.test.ts
+++ b/src/utils/RiverShader.test.ts
@@ -1,7 +1,4 @@
 import * as THREE from 'three';
-
-jest.mock('../materials/RiverNodeMaterial');
-
 import {
   MOSS_HEIGHT_FADE,
   MOSS_NORMAL_MASK,
@@ -42,15 +39,13 @@ describe('riverConstants', () => {
 });
 
 describe('extendRiverMaterial', () => {
-  test('returns a NodeMaterial without onBeforeCompile', () => {
+  test('installs onBeforeCompile on MeshStandardMaterial', () => {
     const base = new THREE.MeshStandardMaterial({ color: '#808080', roughness: 0.9 });
     const material = extendRiverMaterial(base, { enableMoss: true });
 
-    expect(material).toBeDefined();
-    expect(material.isNodeMaterial).toBe(true);
-    expect(material.onBeforeCompile).toBeUndefined();
-    expect(material.userData.riverUniforms).toBeDefined();
-    expect(base).not.toBe(material);
+    expect(material).toBe(base);
+    expect(typeof material.onBeforeCompile).toBe('function');
+    expect(material.userData.riverShader).toBeDefined();
   });
 
   test('preserves moss mask thresholds via shared constants', () => {
@@ -58,16 +53,26 @@ describe('extendRiverMaterial', () => {
     expect(MOSS_NORMAL_MASK.high).toBe(0.82);
   });
 
-  test('updateRiverMaterial writes uniform node values', () => {
+  test('updateRiverMaterial writes shader uniform values after compile', () => {
     const material = extendRiverMaterial(new THREE.MeshStandardMaterial(), {
       waterLevel: 13,
       wetnessRange: 4,
     });
 
+    const shader = {
+      uniforms: {
+        uTime: { value: 0 },
+        uWaterLevel: { value: 13 },
+        uWeatherWetness: { value: 0 },
+      },
+    };
+    material.onBeforeCompile(shader);
+    material.userData.shader = shader;
+
     updateRiverMaterial(material, 1.5, { waterLevel: 12, weatherWetness: 0.4 });
 
-    expect(material.userData.riverUniforms.uTime.value).toBe(1.5);
-    expect(material.userData.riverUniforms.uWaterLevel.value).toBe(12);
-    expect(material.userData.riverUniforms.uWeatherWetness.value).toBe(0.4);
+    expect(shader.uniforms.uTime.value).toBe(1.5);
+    expect(shader.uniforms.uWaterLevel.value).toBe(12);
+    expect(shader.uniforms.uWeatherWetness.value).toBe(0.4);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The game crashed on load in production with:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'replace')
```

This came from Three.js shader compilation when `MeshStandardNodeMaterial` / `MeshBasicNodeMaterial` (from `three/webgpu`) were used with the production `WebGLRenderer`. NodeMaterials require the WebGPU/Node pipeline and do not compile under the classic WebGL renderer.

Related console noise:
- `WARNING: Multiple instances of Three.js being imported` (from `three/webgpu` being bundled separately)
- `/watershed_native.js` 404 when deployed under a subpath (`base: './'`)

## Fix

- **Restore GLSL `RiverShader.js`** — uses `onBeforeCompile` shader injection, compatible with `WebGLRenderer`
- **Restore GLSL `CanyonMaterial.js`** — uses `ShaderMaterial` for slot-canyon wall rendering
- **Update `TrackSegmentMeshes`** — reads `ShaderMaterial.uniforms` instead of `userData.canyonUniforms`
- **Fix WASM path** — `WatershedWasm.ts` now resolves `watershed_native.js` via `import.meta.env.BASE_URL` so it works when deployed at `./` (e.g. `/watershed/`)

`RiverNodeMaterial.ts` / `CanyonNodeMaterial.ts` are left in place for a future WebGPU migration but are no longer on the hot path.

## Verification

- `pnpm build` succeeds
- Playwright headless load of production preview (`?renderer=webgl`, 10s) — **0 shader crashes**, no `replace` errors, no duplicate Three.js warning
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c13fc426-02fd-42d7-8595-43356de8bc66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c13fc426-02fd-42d7-8595-43356de8bc66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer canyon and river rendering with more detailed lighting, layering, weathering, moss, and water effects.
  * Improved support for loading map and terrain assets from different deployment base paths.

* **Bug Fixes**
  * Fixed canyon material updates so animated surface effects refresh more reliably.
  * Improved river material updates to keep water, wetness, and related visual settings in sync during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->