### PR TITLE
Fix pointer lock WrongDocumentError on startup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,29 +178,34 @@ function App() {
     }
   }, [debug.isStageEnabled, debug.setStageFailure, debug.setStageLoading, debug.setStageSuccess]);
 
-  const handleStart = useCallback(() => {
-    setPhase('playing');
-    if (!window.location.search.includes('no-pointer-lock')) {
-      const canvas = document.querySelector('canvas');
-      if (canvas) {
-        canvas.requestPointerLock().catch((err) => {
-          console.warn('[App] Pointer lock failed:', err);
-        });
-      }
+  const requestPointerLockSafely = useCallback(() => {
+    if (window.location.search.includes('no-pointer-lock')) return;
+    // Canvas may already be locked (e.g. PointerLockControls' own lockOnClick
+    // handler beat us to it), or detached/swapped (renderer preference change
+    // remounts the Canvas with a new key). Guard both to avoid the
+    // WrongDocumentError/unhandled rejection that requestPointerLock throws
+    // for a stale or already-locked element.
+    if (document.pointerLockElement) return;
+    const canvas = document.querySelector('canvas');
+    if (!canvas || !canvas.isConnected) return;
+    try {
+      canvas.requestPointerLock()?.catch((err: unknown) => {
+        console.warn('[App] Pointer lock failed:', err);
+      });
+    } catch (err) {
+      console.warn('[App] Pointer lock failed:', err);
     }
   }, []);
 
+  const handleStart = useCallback(() => {
+    setPhase('playing');
+    requestPointerLockSafely();
+  }, [requestPointerLockSafely]);
+
   const handleResume = useCallback(() => {
     setPhase('playing');
-    if (!window.location.search.includes('no-pointer-lock')) {
-      const canvas = document.querySelector('canvas');
-      if (canvas) {
-        canvas.requestPointerLock().catch((err) => {
-          console.warn('[App] Pointer lock failed:', err);
-        });
-      }
-    }
-  }, []);
+    requestPointerLockSafely();
+  }, [requestPointerLockSafely]);
 
   const handleRestart = useCallback(() => {
     window.location.reload();


### PR DESCRIPTION
## Summary
- Console on startup showed a `WrongDocumentError: The root document of this element is not valid for pointer lock` and a related unhandled promise rejection.
- Root cause: `App.tsx`'s `handleStart`/`handleResume` unconditionally called `document.querySelector('canvas').requestPointerLock()`, racing with drei's `<PointerLockControls lockOnClick>` (in `Experience.jsx`) which manages its own lock-on-click behavior, and with canvas remounts triggered by renderer-preference changes (`Canvas key={renderer-...}`). This could hand `requestPointerLock()` a stale/already-locked or detached canvas element.
- Fix: extracted a `requestPointerLockSafely` helper that no-ops if pointer lock is already engaged (`document.pointerLockElement`) or the canvas is missing/detached, and wraps the call in both a synchronous `try/catch` and a `.catch` on the returned promise (covers browsers that throw synchronously vs. those that reject).

## Other startup console items observed (not addressed in this PR)
- Rapier "deprecated parameters" warning originates inside `@react-three/rapier`/`@dimforge/rapier3d-compat`'s own init code, not our `rapier.worker.ts`; only fixable by a version bump.
- `THREE.Texture: Unable to serialize Texture` warning is benign (likely devtools introspection).
- Sustained slow frames / LOD downgrade is a separate performance investigation, out of scope here.

## Test plan
- [x] `npx tsc --noEmit` shows no new errors introduced in `src/App.tsx`
- [ ] Manually verify Start/Resume no longer throws `WrongDocumentError` in console on startup
- [ ] Confirm pointer lock still engages correctly when clicking Start/Resume in a normal (non-sandboxed) browser


---
_Generated by [Claude Code](https://claude.ai/code/session_01SSABNzmaetDuafGHoSuFK4)_