### PR TITLE
Deploy dry-run hygiene pass; forward args from build_and_patch.py to deploy.py

### DIFF
--- a/build_and_patch.py
+++ b/build_and_patch.py
@@ -1,5 +1,7 @@
 import subprocess
 import os
+import sys
+import shlex
 
 WEBGPU_TS_DIR = '.'
 DEPLOY_SCRIPT = os.path.join(WEBGPU_TS_DIR, 'deploy.py')
@@ -15,10 +17,17 @@ def run_command(command, cwd=None):
     return True
 
 def main():
+    # Forward any extra CLI args (e.g. --dry-run) straight through to deploy.py so
+    # the full build -> package path can be exercised without a real upload.
+    deploy_args = sys.argv[1:]
+    deploy_cmd = "python3 deploy.py"
+    if deploy_args:
+        deploy_cmd += " " + " ".join(shlex.quote(a) for a in deploy_args)
+
     if not run_command("pnpm run build", cwd=WEBGPU_TS_DIR):
         return
     if os.path.exists(DEPLOY_SCRIPT):
-        if not run_command("python3 deploy.py", cwd=WEBGPU_TS_DIR):
+        if not run_command(deploy_cmd, cwd=WEBGPU_TS_DIR):
             return
     else:
         print(f"❌ ERROR: {DEPLOY_SCRIPT} not found.")


### PR DESCRIPTION
## Summary

Hygiene pass exercising the full **build → package → deploy dry-run** path end-to-end. No real upload was performed. One minimal fix committed.

### Fix
`build_and_patch.py` previously always invoked `python3 deploy.py` with no arguments, so the composite wrapper could only ever trigger a **real** upload — the dry-run path was unreachable through it. It now forwards extra CLI args to `deploy.py`, so `python3 build_and_patch.py --dry-run` runs the full build + packaging without a network upload and without requiring `DEPLOY_TOKEN`, mirroring `deploy.py --dry-run`.

`deploy.py` itself needed **no changes** — PR #260's `--dry-run` hardening is correct (verified below).

## Verification

**1. Build** — `npm run build` → exit 0, `build/` produced. `build:wasm` gracefully skips when Emscripten is absent and falls back to the committed prebuilt WASM in `public/`. Only warning is the informational Vite >500 kB chunk-size notice.

**2. Dry-run** — `python3 deploy.py --dry-run` with `DEPLOY_TOKEN` **unset** → exit 0, packages the zip, makes **zero** network calls (health-check GET is guarded by `if not args.dry_run`; `deploy_bundle` returns before the token check and `requests.post`). The real path (`python3 deploy.py`, no token) correctly **fails loud** with exit 1 *before* any upload. `python3 build_and_patch.py --dry-run` now runs the whole path end-to-end → exit 0, no upload.

**3. WASM bundling** — physics WASM is present and referenced with relative paths:
- `build/rapier.wasm` (1.5 MB) and `build/watershed_native.wasm` + `.js` all emitted.
- `index.html` references assets as `./assets/…`; asset base is baked in as `./` (vite `base: './'`).
- `@dimforge/rapier3d-compat` inlines its WASM as base64 (magic `AGFzbQ` present in both `vendor-rapier` and the `rapier.worker` chunk), so physics is self-contained; the `new URL("rapier_wasm3d_bg.wasm", …)` is an unused fallback.
- `watershed_native.js` loads its `.wasm` via `locateFile` → `resolvePublicAsset`, resolved relative to `window.location.href`.

**4. No debug/dev leakage** — no `.map` files in `build/` (Vite sourcemaps off by default); no editor/stray files; only expected assets, sounds, levels, shaders, and WASM.

**5. Dependency pinning** — `pnpm-lock.yaml` is committed, so `pnpm install --frozen-lockfile` gives a reproducible install for this exact build despite caret ranges.

## Flags (observations only — out of scope, not changed)
- `@xenova/transformers: "latest"` in `package.json` is unpinned (resolves to `2.17.2` in the lockfile, so frozen installs are stable, but it drifts on any lock refresh) **and** is not imported anywhere in `src/` — dead, loosely-pinned dependency.
- `public/rapier.wasm` (1.5 MB) is copied into `build/` but appears unreferenced — the worker uses the base64-inlined compat build. Harmless bundle bloat.
- No `package-lock.json` committed, so the "npm also works" path is not reproducible without a lockfile; pnpm is the reproducible route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Z23GasBBCfkDS7XjNjgs6

---
_Generated by [Claude Code](https://claude.ai/code/session_016Z23GasBBCfkDS7XjNjgs6)_