### PR TITLE
Separate TrackSegment visual canyon from Rapier collision mesh

### DIFF
--- a/docs/reference/plan.md
+++ b/docs/reference/plan.md
@@ -16,10 +16,15 @@ The project has established a spline-based track system. The immediate focus is 
 - [ ] Implement object pooling for performance
 
 ### Priority B: Physics Optimization
-- [ ] Create simplified collision geometry (low-poly walls)
-- [ ] Separate visual mesh from physics mesh
+- [x] Create simplified collision geometry (low-poly walls)
+- [x] Separate visual mesh from physics mesh
 - [ ] Profile and optimize Rapier physics performance
 - [ ] Consider convex decomposition vs trimesh
+
+Collision mesh notes (`TrackSegment`):
+- Visual canyon (`buildCanyonGeometry`) is collider-free; Rapier uses invisible `buildCollisionGeometry` (~1/4 XZ density, shared U-profile, no rock noise / vertex colors).
+- Expected triangle reduction per segment ≈ 1/16 of the prior visual trimesh (e.g. ~48 m path: visual ~41×49 verts → collision ~11×13 verts).
+- Friction still comes from `biomeProfile.wallFriction` with Flooded/HighFlow overrides; restitution unchanged for slot canyon.
 
 ### Priority C: Water Flow (Deferred / WebGPU)
 - [ ] Design water flow compute shader (experimental; live renderer remains WebGL2)

--- a/src/components/PLAN.md
+++ b/src/components/PLAN.md
@@ -35,7 +35,7 @@
 - [ ] Add more variation to canyon shape (width, depth changes)
 - [ ] Implement proper water physics interaction
 - [ ] Add edge details (rocks, debris on banks)
-- [ ] Optimize collision mesh (use simplified collider)
+- [ ] Optimize collision mesh (use simplified collider) — TrackSegment now mounts low-poly `collisionGeometry` under Rapier; visual canyon is collider-free. Further convex/heightfield work still open.
 
 ---
 

--- a/src/components/TrackSegment/TrackSegmentMeshes.tsx
+++ b/src/components/TrackSegment/TrackSegmentMeshes.tsx
@@ -68,6 +68,7 @@ export function TrackSegmentMeshes({
     segmentId,
     active,
     canyonGeometry,
+    collisionGeometry,
     wallShellGeometry,
     waterGeometry,
     rockMaterial,
@@ -362,8 +363,24 @@ export function TrackSegmentMeshes({
                     intensity={0.55}
                 />
             )}
-            <RigidBody key={`rb-${segmentId}`} type="fixed" colliders="trimesh" friction={segmentState === 'Flooded' ? 0.55 : segmentState === 'HighFlow' ? 0.8 : biomeProfile.wallFriction} restitution={biomeProfile.id === 'slotCanyon' ? 0.02 : 0.1}>
-                <mesh geometry={canyonGeometry} material={rockMaterial} />
+            {/* Visual canyon — no Rapier collider (physics uses low-poly collisionGeometry). */}
+            <mesh geometry={canyonGeometry} material={rockMaterial} />
+
+            {/* Collision-only U-profile (~1/4 visual density). Invisible; preserves wallFriction / flood friction. */}
+            <RigidBody
+                key={`rb-collision-${segmentId}`}
+                type="fixed"
+                colliders="trimesh"
+                friction={
+                    segmentState === 'Flooded'
+                        ? 0.55
+                        : segmentState === 'HighFlow'
+                          ? 0.8
+                          : biomeProfile.wallFriction
+                }
+                restitution={biomeProfile.id === 'slotCanyon' ? 0.02 : 0.1}
+            >
+                <mesh geometry={collisionGeometry} visible={false} />
             </RigidBody>
 
             {/* Goal 3: Splash pool invisible catch collider */}

--- a/src/components/TrackSegment/hooks/geometryBuilders.test.ts
+++ b/src/components/TrackSegment/hooks/geometryBuilders.test.ts
@@ -4,8 +4,11 @@ import { getTrackBiomeProfile } from '../../../configs/TrackBiomes';
 import type { ChannelProfileSample } from '../types';
 import {
   buildCanyonGeometry,
+  buildCollisionGeometry,
   buildWallShellGeometry,
   buildWaterGeometry,
+  canyonSubdivisionCounts,
+  CANYON_COLLISION_SUBDIVISION_DIVISOR,
   geometryHasFinitePositions,
   type GeometryBuildContext,
 } from './geometryBuilders';
@@ -95,7 +98,72 @@ describe('TrackSegment geometryBuilders', () => {
     const ctx = makeContext({ segmentPath: degenerate });
 
     expect(buildCanyonGeometry(ctx)).toBeNull();
+    expect(buildCollisionGeometry(ctx)).toBeNull();
     expect(buildWallShellGeometry(ctx)).toBeNull();
     expect(buildWaterGeometry(ctx)).toBeNull();
+  });
+
+  it('builds a collision mesh with far fewer vertices than the visual canyon mesh', () => {
+    const ctx = makeContext();
+    const pathLen = ctx.segmentPath.getLength();
+    const visualCounts = canyonSubdivisionCounts(pathLen, 'visual');
+    const collisionCounts = canyonSubdivisionCounts(pathLen, 'collision');
+
+    expect(collisionCounts.segmentsX).toBeLessThan(visualCounts.segmentsX);
+    expect(collisionCounts.segmentsZ).toBeLessThan(visualCounts.segmentsZ);
+    expect(collisionCounts.segmentsX * CANYON_COLLISION_SUBDIVISION_DIVISOR).toBeLessThanOrEqual(
+      visualCounts.segmentsX
+    );
+
+    const visual = buildCanyonGeometry(ctx);
+    const collision = buildCollisionGeometry(ctx);
+    expect(visual).not.toBeNull();
+    expect(collision).not.toBeNull();
+    expect(geometryHasFinitePositions(collision!)).toBe(true);
+
+    const visualVerts = visual!.attributes.position.count;
+    const collisionVerts = collision!.attributes.position.count;
+    // ~1/4 XZ density ⇒ roughly ≤ 1/16 vertices; assert a generous ≪ bound.
+    expect(collisionVerts).toBeLessThan(visualVerts / 4);
+    expect(collisionVerts).toBeLessThan(visualVerts);
+    // Collision mesh skips vertex colors (visual-only attribute).
+    expect(collision!.attributes.color).toBeUndefined();
+  });
+
+  it('keeps collision ≪ visual vertex counts on slot-canyon and waterfall-length paths', () => {
+    const cases: Array<{ label: string; overrides: Partial<GeometryBuildContext>; length: number }> = [
+      {
+        label: 'slot canyon',
+        length: 60,
+        overrides: {
+          biome: 'slotCanyon',
+          isSlotCanyon: true,
+          canyonWidth: getTrackBiomeProfile('slotCanyon').canyonWidth,
+          biomeProfile: getTrackBiomeProfile('slotCanyon'),
+        },
+      },
+      {
+        label: 'waterfall approach',
+        length: 90,
+        overrides: {
+          biome: 'canyonSummer',
+          isSlotCanyon: false,
+        },
+      },
+    ];
+
+    for (const { label, length, overrides } of cases) {
+      const ctx = makeContext({
+        segmentPath: makeStraightPath(length),
+        ...overrides,
+      });
+      const visual = buildCanyonGeometry(ctx);
+      const collision = buildCollisionGeometry(ctx);
+      expect(visual, label).not.toBeNull();
+      expect(collision, label).not.toBeNull();
+      const visualVerts = visual!.attributes.position.count;
+      const collisionVerts = collision!.attributes.position.count;
+      expect(collisionVerts, label).toBeLessThan(visualVerts / 4);
+    }
   });
 });

--- a/src/components/TrackSegment/hooks/geometryBuilders.ts
+++ b/src/components/TrackSegment/hooks/geometryBuilders.ts
@@ -99,6 +99,92 @@ function safePathPoint(segmentPath: THREE.CatmullRomCurve3, t: number, segmentId
   }
 }
 
+/** Visual canyon floor width subdivisions (PlaneGeometry segmentsX). */
+export const CANYON_VISUAL_SEGMENTS_X = 40;
+
+/**
+ * Collision mesh uses ~1/4 the visual XZ density so Rapier solves a much
+ * smaller trimesh while preserving the same U-profile for grounding / wall-ride.
+ */
+export const CANYON_COLLISION_SUBDIVISION_DIVISOR = 4;
+
+export interface CanyonHeightSample {
+  yHeight: number;
+  /** Channel shape at this sample — used for vertex coloring on the visual mesh. */
+  channelShape: ChannelShape;
+  normalizedDist: number;
+}
+
+/**
+ * Shared U-profile height used by visual and collision canyon meshes.
+ * Collision omits high-frequency rock noise so contacts stay smooth without
+ * changing bank angles enough to break wall-ride / grounding raycasts.
+ */
+export function computeCanyonFloorHeight(
+  xLocal: number,
+  zLocal: number,
+  pathLen: number,
+  canyonWidth: number,
+  waterWidth: number,
+  channelProfile: readonly ChannelProfileSample[],
+  isSlotCanyon: boolean,
+  options: { includeRockNoise?: boolean } = {}
+): CanyonHeightSample {
+  const { includeRockNoise = true } = options;
+  const t = (zLocal + pathLen / 2) / pathLen;
+  const safeT = Math.max(0, Math.min(1, t));
+  const channelShape = sampleChannelShape(channelProfile, waterWidth, safeT);
+  const signedBankWidth = xLocal < 0 ? channelShape.leftHalfWidth : channelShape.rightHalfWidth;
+  const corridorWidth = Math.max(1.2, channelShape.corridorHalfWidth);
+  const distFromCenter = Math.abs(xLocal);
+  const normalizedDist = distFromCenter / (canyonWidth * 0.45);
+  const bankRatio = distFromCenter / Math.max(0.001, signedBankWidth);
+  const gravelBarInfluence = channelShape.gravelBarSide === Math.sign(xLocal || 1) ? 1 : 0;
+  const undercutInfluence = channelShape.undercutSide === Math.sign(xLocal || 1) ? 1 : 0;
+
+  let yHeight = isSlotCanyon
+    ? 22 + Math.pow(Math.max(0, normalizedDist), 1.8) * 18
+    : Math.pow(Math.max(0, normalizedDist), 2.5) * 12;
+
+  if (distFromCenter < signedBankWidth) {
+    const inChannel = distFromCenter / Math.max(0.001, signedBankWidth);
+    const corridorEase = THREE.MathUtils.smoothstep(inChannel, 0, 1);
+    yHeight *= isSlotCanyon ? 0.18 : 0.1;
+    yHeight -= channelShape.floorDepth * 1.4;
+    yHeight += channelShape.floorWave * (distFromCenter < corridorWidth ? 0.2 : 0.55);
+    yHeight += Math.max(0, channelShape.riffleStrength) * inChannel * 0.35;
+    yHeight += Math.max(0, 1 - corridorEase) * 0.05;
+  } else {
+    const aboveBank = Math.max(0, bankRatio - 1);
+    yHeight += aboveBank * aboveBank * 4.5 * undercutInfluence;
+    yHeight -= aboveBank * 1.25 * gravelBarInfluence;
+  }
+
+  if (includeRockNoise) {
+    const rockNoise =
+      Math.sin(zLocal * 0.8 + xLocal * 0.5) * 0.3 + Math.sin(zLocal * 2.5 + xLocal * 1.2) * 0.1;
+    yHeight += rockNoise * (0.5 + normalizedDist);
+  }
+
+  return { yHeight, channelShape, normalizedDist };
+}
+
+export function canyonSubdivisionCounts(
+  pathLen: number,
+  kind: 'visual' | 'collision'
+): { segmentsX: number; segmentsZ: number } {
+  if (kind === 'visual') {
+    return {
+      segmentsX: CANYON_VISUAL_SEGMENTS_X,
+      segmentsZ: Math.max(2, Math.floor(pathLen)),
+    };
+  }
+  return {
+    segmentsX: Math.max(4, Math.floor(CANYON_VISUAL_SEGMENTS_X / CANYON_COLLISION_SUBDIVISION_DIVISOR)),
+    segmentsZ: Math.max(2, Math.floor(pathLen / CANYON_COLLISION_SUBDIVISION_DIVISOR)),
+  };
+}
+
 /**
  * Build canyon floor BufferGeometry for a segment path.
  * Returns null when path length is invalid.
@@ -113,8 +199,7 @@ export function buildCanyonGeometry(ctx: GeometryBuildContext): THREE.BufferGeom
     return null;
   }
 
-  const segmentsX = 40;
-  const segmentsZ = Math.max(2, Math.floor(len));
+  const { segmentsX, segmentsZ } = canyonSubdivisionCounts(len, 'visual');
 
   const geo = new THREE.PlaneGeometry(canyonWidth, len, segmentsX, segmentsZ);
   geo.rotateX(-Math.PI / 2);
@@ -164,39 +249,18 @@ export function buildCanyonGeometry(ctx: GeometryBuildContext): THREE.BufferGeom
     vertex.fromBufferAttribute(positions, i);
     const xLocal = vertex.x;
     const zLocal = vertex.z;
+    const { yHeight, channelShape } = computeCanyonFloorHeight(
+      xLocal,
+      zLocal,
+      len,
+      canyonWidth,
+      waterWidth,
+      channelProfile,
+      isSlotCanyon,
+      { includeRockNoise: true }
+    );
     const t = (zLocal + len / 2) / len;
     const safeT = Math.max(0, Math.min(1, t));
-    const channelShape = sampleChannelShape(channelProfile, waterWidth, safeT);
-    const signedBankWidth = xLocal < 0 ? channelShape.leftHalfWidth : channelShape.rightHalfWidth;
-    const corridorWidth = Math.max(1.2, channelShape.corridorHalfWidth);
-    const distFromCenter = Math.abs(xLocal);
-    const normalizedDist = distFromCenter / (canyonWidth * 0.45);
-    const bankRatio = distFromCenter / Math.max(0.001, signedBankWidth);
-    const gravelBarInfluence = channelShape.gravelBarSide === Math.sign(xLocal || 1) ? 1 : 0;
-    const undercutInfluence = channelShape.undercutSide === Math.sign(xLocal || 1) ? 1 : 0;
-
-    let yHeight = isSlotCanyon
-      ? 22 + Math.pow(Math.max(0, normalizedDist), 1.8) * 18
-      : Math.pow(Math.max(0, normalizedDist), 2.5) * 12;
-
-    if (distFromCenter < signedBankWidth) {
-      const inChannel = distFromCenter / Math.max(0.001, signedBankWidth);
-      const corridorEase = THREE.MathUtils.smoothstep(inChannel, 0, 1);
-      yHeight *= isSlotCanyon ? 0.18 : 0.1;
-      yHeight -= channelShape.floorDepth * 1.4;
-      yHeight += channelShape.floorWave * (distFromCenter < corridorWidth ? 0.2 : 0.55);
-      yHeight += Math.max(0, channelShape.riffleStrength) * inChannel * 0.35;
-      yHeight += Math.max(0, 1 - corridorEase) * 0.05;
-    } else {
-      const aboveBank = Math.max(0, bankRatio - 1);
-      yHeight += aboveBank * aboveBank * 4.5 * undercutInfluence;
-      yHeight -= aboveBank * 1.25 * gravelBarInfluence;
-    }
-
-    const rockNoise =
-      Math.sin(zLocal * 0.8 + xLocal * 0.5) * 0.3 + Math.sin(zLocal * 2.5 + xLocal * 1.2) * 0.1;
-    yHeight += rockNoise * (0.5 + normalizedDist);
-
     const point = safePathPoint(segmentPath, safeT, segmentId);
 
     const depthTint = THREE.MathUtils.clamp(-channelShape.floorDepth * 0.25, 0, 0.2);
@@ -230,6 +294,66 @@ export function buildCanyonGeometry(ctx: GeometryBuildContext): THREE.BufferGeom
     }
   }
   geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+
+  if (!sanitizePositionAttribute(positions)) {
+    geo.computeVertexNormals();
+  }
+  return geo;
+}
+
+/**
+ * Build a low-poly collision-only canyon mesh (same U-profile, ~1/4 XZ density,
+ * no vertex colors / decorative rock noise). Mounted invisible under a fixed
+ * trimesh RigidBody so the visual mesh no longer owns Rapier colliders.
+ */
+export function buildCollisionGeometry(ctx: GeometryBuildContext): THREE.BufferGeometry | null {
+  const { segmentPath, segmentId, canyonWidth, waterWidth, channelProfile, isSlotCanyon } = ctx;
+
+  const len = segmentPath.getLength();
+  if (!len || len <= 0 || !Number.isFinite(len)) {
+    console.warn(`[TrackSegment ${segmentId}] Invalid pathLength for collision: ${len}`);
+    return null;
+  }
+
+  const { segmentsX, segmentsZ } = canyonSubdivisionCounts(len, 'collision');
+  const geo = new THREE.PlaneGeometry(canyonWidth, len, segmentsX, segmentsZ);
+  geo.rotateX(-Math.PI / 2);
+
+  const positions = geo.attributes.position;
+  const vertex = new THREE.Vector3();
+
+  for (let i = 0; i < positions.count; i++) {
+    vertex.fromBufferAttribute(positions, i);
+    const xLocal = vertex.x;
+    const zLocal = vertex.z;
+    const { yHeight } = computeCanyonFloorHeight(
+      xLocal,
+      zLocal,
+      len,
+      canyonWidth,
+      waterWidth,
+      channelProfile,
+      isSlotCanyon,
+      { includeRockNoise: false }
+    );
+    const t = (zLocal + len / 2) / len;
+    const safeT = Math.max(0, Math.min(1, t));
+    const point = safePathPoint(segmentPath, safeT, segmentId);
+
+    const finalX = point.x + xLocal;
+    const finalY = point.y + yHeight;
+    const finalZ = point.z;
+
+    if (Number.isFinite(finalX) && Number.isFinite(finalY) && Number.isFinite(finalZ)) {
+      positions.setXYZ(i, finalX, finalY, finalZ);
+    } else {
+      positions.setXYZ(i, 0, 0, 0);
+    }
+  }
+
+  // Drop UVs — collision mesh is invisible and Rapier only needs positions + indices.
+  geo.deleteAttribute('uv');
+  geo.deleteAttribute('normal');
 
   if (!sanitizePositionAttribute(positions)) {
     geo.computeVertexNormals();

--- a/src/components/TrackSegment/hooks/useGeometries.ts
+++ b/src/components/TrackSegment/hooks/useGeometries.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { TrackSegmentGeometries, UseGeometriesParams } from '../types';
 import {
   buildCanyonGeometry,
+  buildCollisionGeometry,
   buildWallShellGeometry,
   buildWaterGeometry,
   computePlungeImpactPlacement,
@@ -55,6 +56,11 @@ export function useGeometries({
     return buildCanyonGeometry(buildCtx);
   }, [buildCtx, pathLength]);
 
+  const collisionGeometry = useMemo(() => {
+    if (!buildCtx) return null;
+    return buildCollisionGeometry(buildCtx);
+  }, [buildCtx, pathLength]);
+
   const wallShellGeometry = useMemo(() => {
     if (!buildCtx) return null;
     return buildWallShellGeometry(buildCtx);
@@ -75,5 +81,12 @@ export function useGeometries({
     return computePlungeImpactPlacement(segmentPath, type, waterfallPos, waterWidth, segmentId);
   }, [active, segmentId, segmentPath, type, waterfallPos, waterWidth]);
 
-  return { canyonGeometry, wallShellGeometry, waterGeometry, waterfallPos, plungeImpactPlacement };
+  return {
+    canyonGeometry,
+    collisionGeometry,
+    wallShellGeometry,
+    waterGeometry,
+    waterfallPos,
+    plungeImpactPlacement,
+  };
 }

--- a/src/components/TrackSegment/index.tsx
+++ b/src/components/TrackSegment/index.tsx
@@ -106,23 +106,36 @@ export default function TrackSegment({
     biomeProfile,
   });
 
-  const { canyonGeometry, wallShellGeometry, waterGeometry, waterfallPos, plungeImpactPlacement } =
-    useGeometries({
-      active,
-      segmentPath,
-      pathLength,
-      segmentId,
-      type: segmentType,
-      channelProfile,
-      biomeProfile,
-      isSlotCanyon,
-      placementData,
-      canyonWidth,
-      waterWidth,
-      biome: biomeId,
-    });
+  const {
+    canyonGeometry,
+    collisionGeometry,
+    wallShellGeometry,
+    waterGeometry,
+    waterfallPos,
+    plungeImpactPlacement,
+  } = useGeometries({
+    active,
+    segmentPath,
+    pathLength,
+    segmentId,
+    type: segmentType,
+    channelProfile,
+    biomeProfile,
+    isSlotCanyon,
+    placementData,
+    canyonWidth,
+    waterWidth,
+    biome: biomeId,
+  });
 
-  if (!active || !rockMaterial || !canyonGeometry || !wallShellGeometry || !waterGeometry) {
+  if (
+    !active ||
+    !rockMaterial ||
+    !canyonGeometry ||
+    !collisionGeometry ||
+    !wallShellGeometry ||
+    !waterGeometry
+  ) {
     return null;
   }
 
@@ -143,6 +156,7 @@ export default function TrackSegment({
       showDebug={showDebug}
       placementData={placementData}
       canyonGeometry={canyonGeometry}
+      collisionGeometry={collisionGeometry}
       wallShellGeometry={wallShellGeometry}
       waterGeometry={waterGeometry}
       waterfallPos={waterfallPos}

--- a/src/components/TrackSegment/types.ts
+++ b/src/components/TrackSegment/types.ts
@@ -143,6 +143,8 @@ export interface PlungeImpactPlacement {
 
 export interface TrackSegmentGeometries {
   canyonGeometry: THREE.BufferGeometry | null;
+  /** Low-poly U-profile for Rapier trimesh; visual mesh stays collider-free. */
+  collisionGeometry: THREE.BufferGeometry | null;
   wallShellGeometry: THREE.BufferGeometry | null;
   waterGeometry: THREE.BufferGeometry | null;
   waterfallPos: THREE.Vector3 | null;
@@ -314,6 +316,7 @@ export interface TrackSegmentMeshesProps {
   showDebug?: boolean;
   placementData: PlacementData;
   canyonGeometry: THREE.BufferGeometry;
+  collisionGeometry: THREE.BufferGeometry;
   wallShellGeometry: THREE.BufferGeometry;
   waterGeometry: THREE.BufferGeometry;
   waterfallPos: THREE.Vector3 | null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Rapier was building trimesh colliders from the high-detail visual canyon mesh on every active `TrackSegment` (~7 segments). This PR splits visual and physics geometry:

- **`buildCollisionGeometry`** — same U-profile as the visual canyon, ~1/4 XZ subdivision, no rock noise / vertex colors
- Visual `canyonGeometry` mesh is collider-free
- Invisible low-poly mesh owns the fixed `trimesh` RigidBody
- Friction still uses `biomeProfile.wallFriction` with Flooded (`0.55`) / HighFlow (`0.8`) overrides; restitution unchanged (`0.02` slot / `0.1` otherwise)

### Measured collider size (same ~48 m path)
| Mesh | Subdiv (X×Z) | Vertices |
|------|--------------|----------|
| Visual (old collider) | 40 × 48 | 2009 |
| Collision (new) | 10 × 12 | 143 |

≈ **93% fewer vertices** per segment trimesh (~1/16 prior triangle count) — well above the ≥15% physics-cost headroom target for collider complexity. Documented in `docs/reference/plan.md`.

## Acceptance
- [x] Visual geometry no longer owns the primary Rapier collider
- [x] Wall / flood friction still applied on the physics body
- [x] Fixture test: collision vertex count ≪ visual for same path (meander + slot + long waterfall-length)
- [x] Documented measurable collider reduction (93% verts / ~16× fewer triangles)
- [ ] Manual playtest: grounding / wall-ride / raft / shelf / pillars on meander, slot, waterfall (needs in-browser pass)

## Test plan
1. `pnpm exec vitest run src/components/TrackSegment/hooks/geometryBuilders.test.ts`
2. Start game, walk meander / slot / waterfall — no fall-through
3. Wall-ride and flood friction feel unchanged
4. Optional: compare Rapier step / frame time before vs after on waterfall + slot
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f69e3d0-8143-4aaa-b993-1f9c2ecf071a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f69e3d0-8143-4aaa-b993-1f9c2ecf071a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

