### PR TITLE
feat: Lumber Flume authored map (?map=lumber)

### DIFF
--- a/src/components/TrackSegment/TrackSegmentMeshes.tsx
+++ b/src/components/TrackSegment/TrackSegmentMeshes.tsx
@@ -40,6 +40,7 @@ import Rock from '../Obstacles/Rock';
 import IceSpray from '../Environment/IceSpray';
 import Icicles from '../Environment/Icicles';
 import IceSheets from '../Environment/IceSheets';
+import LumberProps from '../LumberProps';
 
 import { useLOD } from '../../systems/LODManager';
 import { useBiome } from '../../systems/BiomeSystem';
@@ -92,6 +93,7 @@ export function TrackSegmentMeshes({
     weatherWetnessRef,
     isSlotCanyon = false,
     usePooledStaticObstacles = false,
+    config,
 }: TrackSegmentMeshesProps) {
     const { quality: lodQuality } = useLOD();
     const { timeOfDay } = useBiome();
@@ -100,12 +102,30 @@ export function TrackSegmentMeshes({
     const waterfallFanAngle = (type === 'waterfall' && (particleCount || 0) >= 500) ? 60 : 0;
     const biomeProfile = useMemo(() => getTrackBiomeProfile(biome), [biome]);
     const isGlacier = isGlacialBiome(biome, biomeProfile);
+    const isLumberFlume = biomeProfile.id === 'lumberFlume';
+    const openFloor = Boolean(config?.openFloor);
     const slushiness = isGlacier ? (biomeProfile.id === 'glacialMelt' ? 0.85 : 0.55) : 0;
     const birdType = biomeProfile.id === 'slotCanyon' ? 'hawk' : 'songbird';
     const batsActive = (biomeProfile.id === 'slotCanyon' || isAutumnLike(biome) || biome === 'canyon') && timeOfDay > 0.65;
     const showCanyonBackground = biomeProfile.id === 'slotCanyon' || biome === 'canyon';
     // Clone material for wall to apply RiverShader effects
     const wallMaterialRef = useRef<WallMaterial | null>(null);
+
+    // Static lumber debris positions (v1 — visual only, not breakable)
+    const lumberPropPositions = useMemo(() => {
+      if (!isLumberFlume) return [];
+      const fromDriftwood = (placementData.driftwood || [])
+        .slice(0, 10)
+        .map((t) => t.position.clone());
+      if (fromDriftwood.length > 0) return fromDriftwood;
+      // Fallback: a few props along the segment centerline
+      if (!segmentPath || pathLength <= 0) return [];
+      return [0.2, 0.45, 0.7].map((t) => {
+        const p = segmentPath.getPoint(t);
+        p.y = waterLevel + 0.15;
+        return p;
+      });
+    }, [isLumberFlume, placementData.driftwood, segmentPath, pathLength, waterLevel]);
 
     // Track player velocity via ref for shader-driven effects without per-frame re-rendering.
     const playerVelocityRef = useRef(0);
@@ -366,7 +386,9 @@ export function TrackSegmentMeshes({
             {/* Visual canyon — no Rapier collider (physics uses low-poly collisionGeometry). */}
             <mesh geometry={canyonGeometry} material={rockMaterial} />
 
-            {/* Collision-only U-profile (~1/4 visual density). Invisible; preserves wallFriction / flood friction. */}
+            {/* Collision-only U-profile (~1/4 visual density). Invisible; preserves wallFriction / flood friction.
+                openFloor gaps skip the trimesh so the player flies an air corridor. */}
+            {!openFloor && (
             <RigidBody
                 key={`rb-collision-${segmentId}`}
                 type="fixed"
@@ -382,6 +404,7 @@ export function TrackSegmentMeshes({
             >
                 <mesh geometry={collisionGeometry} visible={false} />
             </RigidBody>
+            )}
 
             {/* Goal 3: Splash pool invisible catch collider */}
             {(type === 'splash' || type === 'pond') && (
@@ -522,6 +545,15 @@ export function TrackSegmentMeshes({
 
             {/* Driftwood - Along river banks */}
             <Driftwood transforms={placementData.driftwood} />
+
+            {/* Lumber Flume static plank / log / barrel props (v1 visual only) */}
+            {isLumberFlume && lumberPropPositions.length > 0 && (
+                <>
+                    <LumberProps type="plank" positions={lumberPropPositions.slice(0, 4)} />
+                    <LumberProps type="log" positions={lumberPropPositions.slice(2, 6)} />
+                    <LumberProps type="barrel" positions={lumberPropPositions.slice(5, 8)} />
+                </>
+            )}
 
             {/* Pinecones - Under trees */}
             <Pinecone transforms={placementData.pinecones} />

--- a/src/components/TrackSegment/hooks/populateSidePart1.ts
+++ b/src/components/TrackSegment/hooks/populateSidePart1.ts
@@ -339,7 +339,8 @@ export function populateSidePart1(args: PopulateSideArgs): void {
 
                 // 4.6 FERNS (New: Undergrowth clusters)
                 // Ferns like the "floor" of the forest, often near trees or walls
-                const fernChance = isAutumnLike(biome) ? 0.4 : 0.3;
+                const isLumberFlume = biomeProfile?.id === 'lumberFlume' || biome === 'lumberFlume';
+                const fernChance = isLumberFlume ? 0.7 : isAutumnLike(biome) ? 0.4 : 0.3;
                 if (!isSlotCanyon && !isGlacier && seededRandom(seedState.value++) > (1.0 - fernChance)) {
                     // Spawn a cluster
                     const clusterSize = 3 + Math.floor(seededRandom(seedState.value++) * 3);

--- a/src/components/TrackSegment/hooks/populateSidePart2.ts
+++ b/src/components/TrackSegment/hooks/populateSidePart2.ts
@@ -390,7 +390,10 @@ export function populateSidePart2(args: PopulateSideArgs): void {
                         });
                     }
                 } else if (!isAutumnLike(biome) || type === 'pond') { // More common in summer or open ponds
-                    if (seededRandom(seedState.value++) > 0.92) { // Occasional
+                    const isLumberFlume = biomeProfile?.id === 'lumberFlume' || biome === 'lumberFlume';
+                    // Lumber flume: denser dappled canopy shafts
+                    const shaftThreshold = isLumberFlume ? 0.72 : 0.92;
+                    if (seededRandom(seedState.value++) > shaftThreshold) { // Occasional
                         const dist = (seededRandom(seedState.value++) - 0.5) * canyonWidth * 0.6;
                         const offset = binormal.clone().multiplyScalar(dist);
                         const position = new THREE.Vector3().copy(pathPoint).add(offset);

--- a/src/components/TrackSegment/types.ts
+++ b/src/components/TrackSegment/types.ts
@@ -160,6 +160,8 @@ export interface TrackSegmentConfig {
   launchShelf?: {
     rockRef: { localX: number; localZ: number; scale: number };
   };
+  /** Skip floor trimesh collider (air corridor / broken trestle gap). */
+  openFloor?: boolean;
   lodQuality?: 'low' | 'medium' | 'high' | 'ultra' | string;
   particleCount?: number;
   rockDensity?: 'low' | 'medium' | 'high';

--- a/src/configs/BiomePalettes.ts
+++ b/src/configs/BiomePalettes.ts
@@ -542,42 +542,54 @@ export const BiomePalettes: Record<BiomeId, BiomePalette> = {
     transitionDuration: 5,
   },
 
-  // Stubs until Lumber Flume / Hydro-Dam content lands
   lumberFlume: {
     id: 'lumberFlume',
     name: 'Lumber Flume',
-    description: 'Mossy wooden flume — stub palette pending content',
-    skyColor: '#87CEEB',
-    fogColor: '#B8D4C8',
-    fogDensity: 0.02,
-    fogNear: 40,
-    fogFar: 220,
-    waterColor: '#3A8B6A',
-    waterDeepColor: '#1a4a3a',
-    foamColor: '#E0F0E8',
-    causticsIntensity: 0.5,
-    waterOpacity: 0.85,
-    flowSpeed: 1.2,
-    lightTemp: 5500,
-    sunColor: '#FFF5E0',
-    sunIntensity: 1.1,
-    ambientIntensity: 0.35,
-    hemiSkyColor: '#87CEEB',
-    hemiGroundColor: '#3a5a3a',
-    fillColor: '#A0C080',
-    fillIntensity: 0.25,
-    rockBaseColor: '#6a5a4a',
+    description: 'Mossy wooden aqueduct through dense forest — dappled sun shafts, damp timber greens',
+
+    // Filtered canopy sky, soft green haze
+    skyColor: '#6BA88A',
+    fogColor: '#A8C8B0',
+    fogDensity: 0.024,
+    fogNear: 28,
+    fogFar: 160,
+
+    // Tea-stained flume water
+    waterColor: '#3A7A58',
+    waterDeepColor: '#1a4030',
+    foamColor: '#D8F0E0',
+    causticsIntensity: 0.45,
+    waterOpacity: 0.82,
+    flowSpeed: 1.55,
+
+    // Warm dappled noon through canopy gaps
+    lightTemp: 5200,
+    sunColor: '#FFE8C0',
+    sunIntensity: 1.05,
+    ambientIntensity: 0.38,
+    hemiSkyColor: '#90C0A0',
+    hemiGroundColor: '#2a4030',
+    fillColor: '#B0D080',
+    fillIntensity: 0.28,
+
+    // Wet bark / mossy timber canyon walls
+    rockBaseColor: '#5a4a38',
     rockMossColor: '#2a5a2a',
-    weatheringIntensity: 0.7,
-    vegetationColor: '#2d5a2d',
-    vegetationDensity: 1.1,
-    treeDensity: 1.2,
-    grassDensity: 0.9,
-    wildflowerColors: ['#f0e080', '#e08060', '#80c080'],
-    fireflyCount: 8,
-    mistDensity: 0.35,
-    sunShaftIntensity: 0.5,
+    weatheringIntensity: 0.85,
+
+    // Dense forest floor
+    vegetationColor: '#2d6a2d',
+    vegetationDensity: 1.35,
+    treeDensity: 1.45,
+    grassDensity: 1.0,
+    wildflowerColors: ['#c8e070', '#e0a060', '#70b070', '#f0d898'],
+
+    fireflyCount: 10,
+    mistDensity: 0.42,
+    sunShaftIntensity: 0.95,
     fallingLeaves: false,
+    ambientAudio: 'ambient-flume-001',
+
     transitionDuration: 4,
   },
   hydroDam: {

--- a/src/configs/TrackBiomes.ts
+++ b/src/configs/TrackBiomes.ts
@@ -167,7 +167,27 @@ export const TRACK_BIOMES: Record<BiomeId, TrackBiomeProfile> = {
   alpineSpring: { ...canyonSummerProfile, id: 'alpineSpring' },
   midnightMist: { ...canyonAutumnProfile, id: 'midnightMist' },
   cavern: { ...slotCanyonProfile, id: 'cavern' },
-  lumberFlume: { ...canyonSummerProfile, id: 'lumberFlume' },
+  lumberFlume: {
+    id: 'lumberFlume',
+    waterWidth: 8,
+    canyonWidth: 28,
+    // Lower walls than summer canyon — elevated wooden aqueduct read
+    wallHeight: 12,
+    wallTightness: 0.62,
+    wallFriction: 0.42,
+    wallShadowStrength: 0.7,
+    vegetationDensity: 1.35,
+    rockDensity: 'medium',
+    // Damp mossy timber / wet bark tones
+    rockBaseColor: '#5a4a38',
+    rockShadowColor: '#2a3a28',
+    rockRimColor: '#8a9a70',
+    decorationBias: { trees: 1.4, grasses: 0.9, reeds: 0.7, rocks: 0.6 },
+    treeSpeciesWeights: {
+      floor: { conifer: 0.55, broadleaf: 0.25, birch: 0.1, snag: 0.1 },
+      rim: { conifer: 0.65, broadleaf: 0.15, birch: 0.05, snag: 0.15 },
+    },
+  },
   hydroDam: { ...slotCanyonProfile, id: 'hydroDam' },
 };
 

--- a/src/configs/__tests__/biomeId.test.ts
+++ b/src/configs/__tests__/biomeId.test.ts
@@ -78,6 +78,13 @@ describe('track + palette lookup for canonical ids', () => {
       expect(palette.id).toBe(id);
     }
   });
+
+  it('lumberFlume profile is not a summer clone', () => {
+    const lumber = getTrackBiomeProfile('lumberFlume');
+    const summer = getTrackBiomeProfile('canyonSummer');
+    expect(lumber.wallHeight).toBeLessThan(summer.wallHeight);
+    expect(lumber.vegetationDensity).toBeGreaterThan(summer.vegetationDensity);
+  });
 });
 
 describe('legacy map-load fixture', () => {

--- a/src/experience/InnerExperience.tsx
+++ b/src/experience/InnerExperience.tsx
@@ -83,10 +83,9 @@ export default function InnerExperience({
           <FlowForecast
             temperature={8}
             snowpackIndex={0.65}
-            damReleaseSchedule={[...DAM_RELEASE_SCHEDULE]}
+            damReleaseSchedule={DAM_RELEASE_SCHEDULE as Array<{ hour: number; release: number }>}
             onForecastChange={state.setForecastSamples}
           />
-
           {debug.isStageEnabled('dataProcessing') &&
             (state.levelUrl ? (
               <LevelLoader

--- a/src/experience/constants.ts
+++ b/src/experience/constants.ts
@@ -34,6 +34,17 @@ export const BIOME_LIGHTING: Record<string, BiomeLightingConfig> = {
     fillColor: '#ffc888',
     fillIntensity: 0.18,
   },
+  lumberFlume: {
+    ambientIntensity: 0.38,
+    hemiSky: '#90c0a0',
+    hemiGround: '#2a4030',
+    hemiIntensity: 0.75,
+    dirColor: '#ffe8c0',
+    dirIntensity: 1.05,
+    dirPosition: [8, 28, 14],
+    fillColor: '#b0d080',
+    fillIntensity: 0.28,
+  },
 };
 
 export const NOOP_DEBUG: DebugStageController = {

--- a/src/experience/hooks/useExperienceWorld.ts
+++ b/src/experience/hooks/useExperienceWorld.ts
@@ -335,6 +335,10 @@ export function useExperienceWorld({
     });
   }, [debug]);
 
+  const stableSetForecastSamples = useCallback((samples: FlowForecastSample[]) => {
+    setForecastSamples(samples);
+  }, []);
+
   return {
     levelUrl,
     levelLoadError,
@@ -355,7 +359,7 @@ export function useExperienceWorld({
     handleLoopCurrentMap,
     handleContinueJourney,
     handleDefaultJourneyAction,
-    setForecastSamples,
+    setForecastSamples: stableSetForecastSamples,
     setLevelLoadError,
     setIsLoadingLevel,
     setLoadedLevelState,

--- a/src/experience/hooks/useExperienceWorld.ts
+++ b/src/experience/hooks/useExperienceWorld.ts
@@ -7,7 +7,7 @@ import { resetScoreSystemState } from '../../systems/ScoreSystem';
 import { useGameStore } from '../../systems/GameState';
 import { resetRunSession } from '../../utils/resetRunSession';
 import type { TrackManagerRef } from '../../components/TrackManager';
-import type { MapRegistryId } from '../../maps/registry';
+import { resolveMapRegistryId, type MapRegistryId } from '../../maps/registry';
 import type { DebugStageController } from '../../debug/debugStages';
 import { DEFAULT_MAPS } from '../constants';
 import type { VehicleRigidBodyRef } from '../types';
@@ -15,9 +15,7 @@ import type { VehicleRigidBodyRef } from '../types';
 function readDefaultMapIdFromUrl(): MapRegistryId {
   if (typeof window === 'undefined') return 'meander';
   const mapParam = new URLSearchParams(window.location.search).get('map');
-  if (mapParam === 'delta') return 'delta';
-  if (mapParam === 'glacial') return 'glacial';
-  return 'meander';
+  return resolveMapRegistryId(mapParam) ?? 'meander';
 }
 
 function readJourneyDefaultAction(): 'loop' | 'nextMap' {
@@ -64,7 +62,10 @@ export function useExperienceWorld({
   const [journeyDefaultAction] = useState(readJourneyDefaultAction);
 
   const activeDefaultMap = DEFAULT_MAPS[activeDefaultMapId] ?? DEFAULT_MAPS.meander;
-  const canContinueDefaultMap = activeDefaultMapId === 'meander' || activeDefaultMapId === 'glacial';
+  const canContinueDefaultMap =
+    activeDefaultMapId === 'meander' ||
+    activeDefaultMapId === 'glacial' ||
+    activeDefaultMapId === 'lumber';
 
   useEffect(() => {
     if (levelUrl || reachId) return;

--- a/src/formats/level.schema.json
+++ b/src/formats/level.schema.json
@@ -103,7 +103,7 @@
             "segmentLength": {
               "type": "number",
               "minimum": 20,
-              "maximum": 50,
+              "maximum": 150,
               "default": 30,
               "description": "Base length of each track segment"
             },
@@ -116,14 +116,14 @@
             "width": {
               "type": "number",
               "minimum": 20,
-              "maximum": 80,
+              "maximum": 120,
               "default": 35,
               "description": "Canyon width"
             },
             "wallHeight": {
               "type": "number",
               "minimum": 8,
-              "maximum": 20,
+              "maximum": 30,
               "default": 12,
               "description": "Canyon wall height"
             }
@@ -380,7 +380,7 @@
           "width": {
             "type": "number",
             "minimum": 20,
-            "maximum": 80,
+            "maximum": 120,
             "description": "Override canyon width"
           },
           "lengthMultiplier": {
@@ -410,6 +410,11 @@
             "default": 1,
             "description": "Water current strength"
           },
+          "openFloor": {
+            "type": "boolean",
+            "default": false,
+            "description": "Skip floor trimesh collider for gap / air-corridor set-pieces"
+          },
           "decorations": {
             "type": "object",
             "properties": {
@@ -424,9 +429,31 @@
                 "maximum": 100
               },
               "rocks": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 30
+                "oneOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 30
+                  },
+                  {
+                    "type": "array",
+                    "maxItems": 30,
+                    "items": {
+                      "type": "object",
+                      "required": ["localX", "localZ"],
+                      "properties": {
+                        "localX": { "type": "number" },
+                        "localZ": { "type": "number" },
+                        "scale": { "type": "number", "minimum": 0.1, "maximum": 20 },
+                        "rotation": { "type": "number" },
+                        "rockType": {
+                          "type": "string",
+                          "enum": ["boulder", "slab", "column"]
+                        }
+                      }
+                    }
+                  }
+                ]
               },
               "wildflowers": {
                 "type": "number",
@@ -582,6 +609,50 @@
                 "maximum": 10000
               }
             }
+          },
+          "waterWidth": {
+            "type": "number",
+            "minimum": 2,
+            "maximum": 80,
+            "description": "Override water surface width"
+          },
+          "slipperiness": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "treeDensity": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 50
+          },
+          "rockDensity": {
+            "type": "string",
+            "enum": ["low", "medium", "high"]
+          },
+          "journeyComplete": {
+            "type": "boolean",
+            "description": "Entering this segment triggers journey-complete"
+          },
+          "launchShelf": {
+            "type": "object",
+            "required": ["rockRef", "triggerHalfWidth", "triggerHalfLength", "triggerHeight", "triggerDownstreamOffset", "triggerYOffset"],
+            "properties": {
+              "rockRef": {
+                "type": "object",
+                "required": ["localX", "localZ", "scale"],
+                "properties": {
+                  "localX": { "type": "number" },
+                  "localZ": { "type": "number" },
+                  "scale": { "type": "number" }
+                }
+              },
+              "triggerHalfWidth": { "type": "number", "minimum": 0.5 },
+              "triggerHalfLength": { "type": "number", "minimum": 0.5 },
+              "triggerHeight": { "type": "number", "minimum": 0.5 },
+              "triggerDownstreamOffset": { "type": "number" },
+              "triggerYOffset": { "type": "number" }
+            }
           }
         }
       }
@@ -653,7 +724,7 @@
               "radius": {
                 "type": "number",
                 "minimum": 3,
-                "maximum": 20,
+                "maximum": 50,
                 "default": 5
               }
             }

--- a/src/formats/reach.schema.json
+++ b/src/formats/reach.schema.json
@@ -419,6 +419,11 @@
             "default": 1,
             "description": "Water current strength"
           },
+          "openFloor": {
+            "type": "boolean",
+            "default": false,
+            "description": "Skip floor trimesh collider for gap / air-corridor set-pieces"
+          },
           "decorations": {
             "type": "object",
             "properties": {

--- a/src/maps/lumber_flume.json
+++ b/src/maps/lumber_flume.json
@@ -1,0 +1,298 @@
+{
+  "metadata": {
+    "name": "Lumber Flume",
+    "author": "watershed",
+    "description": "Forest approach into a mossy wooden aqueduct, gap jump over a broken trestle, and splash landing back into the river.",
+    "difficulty": "intermediate",
+    "estimatedDuration": 280,
+    "version": "1.0.0",
+    "tags": ["lumber", "flume", "forest", "gap"]
+  },
+  "world": {
+    "track": {
+      "waypoints": [
+        [0, 1, 40],
+        [0, 0, 10],
+        [2, -2, -30],
+        [4, -5, -90],
+        [2, -8, -160],
+        [-1, -12, -240],
+        [1, -16, -330],
+        [0, -20, -420]
+      ],
+      "segmentLength": 95,
+      "totalSegments": 16,
+      "width": 28,
+      "wallHeight": 12
+    },
+    "biome": {
+      "baseType": "lumberFlume",
+      "sky": {
+        "color": "#6ba88a",
+        "cloudDensity": 0.45,
+        "cloudColor": "#d0e8d8"
+      },
+      "fog": {
+        "color": "#a8c8b0",
+        "near": 28,
+        "far": 160,
+        "density": 0.024
+      },
+      "lighting": {
+        "sunIntensity": 1.05,
+        "sunAngle": 42,
+        "sunColor": "#ffe8c0",
+        "ambientIntensity": 0.38,
+        "hemiSkyColor": "#90c0a0",
+        "hemiGroundColor": "#2a4030"
+      },
+      "water": {
+        "tint": "#3a7a58",
+        "flowSpeed": 1.55,
+        "opacity": 0.82,
+        "surfaceRoughness": 0.28
+      }
+    }
+  },
+  "segments": [
+    {
+      "index": 0,
+      "name": "Forest Approach",
+      "difficulty": 0.2,
+      "biomeOverride": "lumberFlume",
+      "width": 34,
+      "waterWidth": 14,
+      "meanderStrength": 0.7,
+      "verticalBias": -0.25,
+      "physics": { "waterFlowIntensity": 0.9 },
+      "effects": { "particleCount": 40 },
+      "decorations": { "trees": 18, "rocks": 2, "ferns": 12, "sunShafts": 4, "driftwood": 4 }
+    },
+    {
+      "index": 1,
+      "name": "Timber Fringe",
+      "difficulty": 0.25,
+      "biomeOverride": "lumberFlume",
+      "width": 32,
+      "waterWidth": 12,
+      "meanderStrength": 0.65,
+      "verticalBias": -0.3,
+      "physics": { "waterFlowIntensity": 1.0 },
+      "effects": { "particleCount": 45 },
+      "decorations": { "trees": 20, "rocks": 2, "ferns": 14, "sunShafts": 5, "driftwood": 5 }
+    },
+    {
+      "index": 2,
+      "name": "Moss Banks",
+      "difficulty": 0.3,
+      "biomeOverride": "lumberFlume",
+      "width": 30,
+      "waterWidth": 11,
+      "meanderStrength": 0.55,
+      "verticalBias": -0.4,
+      "physics": { "waterFlowIntensity": 1.1 },
+      "effects": { "particleCount": 50 },
+      "decorations": { "trees": 22, "rocks": 3, "ferns": 16, "sunShafts": 6, "mushrooms": 8 }
+    },
+    {
+      "index": 3,
+      "name": "Flume Intake",
+      "difficulty": 0.4,
+      "biomeOverride": "lumberFlume",
+      "width": 28,
+      "waterWidth": 9,
+      "meanderStrength": 0.35,
+      "verticalBias": -0.55,
+      "physics": { "waterFlowIntensity": 1.3 },
+      "effects": { "particleCount": 60, "cameraShake": 0.05 },
+      "decorations": { "trees": 16, "rocks": 4, "ferns": 10, "sunShafts": 5, "driftwood": 8 }
+    },
+    {
+      "index": 4,
+      "name": "Elevated Flume",
+      "difficulty": 0.5,
+      "biomeOverride": "lumberFlume",
+      "width": 26,
+      "waterWidth": 8,
+      "meanderStrength": 0.2,
+      "verticalBias": -0.7,
+      "physics": { "waterFlowIntensity": 1.5 },
+      "effects": { "particleCount": 70, "cameraShake": 0.08 },
+      "decorations": { "trees": 14, "rocks": 3, "ferns": 8, "sunShafts": 7, "driftwood": 10 }
+    },
+    {
+      "index": 5,
+      "name": "Flume Straight",
+      "difficulty": 0.55,
+      "biomeOverride": "lumberFlume",
+      "width": 24,
+      "waterWidth": 7,
+      "meanderStrength": 0.12,
+      "verticalBias": -0.85,
+      "physics": { "waterFlowIntensity": 1.65 },
+      "effects": { "particleCount": 80, "cameraShake": 0.1 },
+      "decorations": { "trees": 12, "rocks": 2, "ferns": 6, "sunShafts": 6, "driftwood": 12 }
+    },
+    {
+      "index": 6,
+      "name": "Timber Chute",
+      "difficulty": 0.6,
+      "biomeOverride": "lumberFlume",
+      "width": 24,
+      "waterWidth": 7,
+      "meanderStrength": 0.08,
+      "verticalBias": -1.0,
+      "physics": { "waterFlowIntensity": 1.75 },
+      "effects": { "particleCount": 90, "cameraShake": 0.12 },
+      "decorations": { "trees": 10, "rocks": 2, "ferns": 5, "sunShafts": 5, "driftwood": 14 }
+    },
+    {
+      "index": 7,
+      "name": "Flume Bend",
+      "difficulty": 0.62,
+      "biomeOverride": "lumberFlume",
+      "width": 25,
+      "waterWidth": 7,
+      "meanderStrength": 0.45,
+      "verticalBias": -1.1,
+      "physics": { "waterFlowIntensity": 1.8 },
+      "effects": { "particleCount": 95, "cameraShake": 0.14 },
+      "decorations": { "trees": 11, "rocks": 3, "ferns": 6, "sunShafts": 4, "driftwood": 12 }
+    },
+    {
+      "index": 8,
+      "name": "High Flume",
+      "difficulty": 0.65,
+      "biomeOverride": "lumberFlume",
+      "width": 24,
+      "waterWidth": 6,
+      "meanderStrength": 0.1,
+      "verticalBias": -1.25,
+      "physics": { "waterFlowIntensity": 1.9 },
+      "effects": { "particleCount": 100, "cameraShake": 0.15 },
+      "decorations": { "trees": 9, "rocks": 2, "ferns": 4, "sunShafts": 5, "driftwood": 15 }
+    },
+    {
+      "index": 9,
+      "name": "Trestle Approach",
+      "difficulty": 0.7,
+      "biomeOverride": "lumberFlume",
+      "width": 26,
+      "waterWidth": 7,
+      "meanderStrength": 0.15,
+      "verticalBias": -1.4,
+      "physics": { "waterFlowIntensity": 2.0 },
+      "effects": { "particleCount": 110, "cameraShake": 0.18 },
+      "decorations": { "trees": 8, "rocks": 4, "ferns": 3, "sunShafts": 3, "driftwood": 16 }
+    },
+    {
+      "index": 10,
+      "name": "Gap Launch",
+      "difficulty": 0.8,
+      "type": "waterfall",
+      "biomeOverride": "lumberFlume",
+      "width": 28,
+      "waterWidth": 8,
+      "meanderStrength": 0.0,
+      "verticalBias": -2.7,
+      "forwardMomentum": 0.14,
+      "openFloor": true,
+      "physics": { "waterFlowIntensity": 2.1, "gravityMultiplier": 1.3 },
+      "effects": { "particleCount": 220, "cameraShake": 0.38 },
+      "decorations": {
+        "trees": 2,
+        "rocks": [
+          { "localX": -10, "localZ": -28, "scale": 3.2, "rotation": 0.1, "rockType": "slab" }
+        ],
+        "driftwood": 8
+      },
+      "launchShelf": {
+        "rockRef": { "localX": -10, "localZ": -28, "scale": 3.2 },
+        "triggerHalfWidth": 8.0,
+        "triggerHalfLength": 6.5,
+        "triggerHeight": 5.5,
+        "triggerDownstreamOffset": 5.0,
+        "triggerYOffset": 0.8
+      }
+    },
+    {
+      "index": 11,
+      "name": "Landing Pool",
+      "difficulty": 0.45,
+      "type": "splash",
+      "biomeOverride": "lumberFlume",
+      "width": 40,
+      "waterWidth": 16,
+      "meanderStrength": 0.25,
+      "verticalBias": -0.5,
+      "physics": { "waterFlowIntensity": 1.2, "gravityMultiplier": 1.0 },
+      "effects": { "particleCount": 160, "cameraShake": 0.2 },
+      "decorations": { "trees": 10, "rocks": 3, "ferns": 8, "mist": 6, "driftwood": 10 }
+    },
+    {
+      "index": 12,
+      "name": "Broken Trestle",
+      "difficulty": 0.55,
+      "biomeOverride": "lumberFlume",
+      "width": 30,
+      "waterWidth": 10,
+      "meanderStrength": 0.5,
+      "verticalBias": -0.6,
+      "physics": { "waterFlowIntensity": 1.35 },
+      "effects": { "particleCount": 90, "cameraShake": 0.1 },
+      "decorations": { "trees": 12, "rocks": 8, "ferns": 6, "driftwood": 18, "sunShafts": 4 }
+    },
+    {
+      "index": 13,
+      "name": "Trestle Wreckage",
+      "difficulty": 0.5,
+      "type": "rapids",
+      "biomeOverride": "lumberFlume",
+      "width": 32,
+      "waterWidth": 11,
+      "meanderStrength": 0.6,
+      "verticalBias": -0.45,
+      "physics": { "waterFlowIntensity": 1.25 },
+      "effects": { "particleCount": 120 },
+      "decorations": { "trees": 14, "rocks": 10, "ferns": 8, "driftwood": 20, "rapids": 8 }
+    },
+    {
+      "index": 14,
+      "name": "River Rejoin",
+      "difficulty": 0.3,
+      "biomeOverride": "lumberFlume",
+      "width": 34,
+      "waterWidth": 14,
+      "meanderStrength": 0.7,
+      "verticalBias": -0.25,
+      "physics": { "waterFlowIntensity": 1.0 },
+      "effects": { "particleCount": 60 },
+      "decorations": { "trees": 16, "rocks": 3, "ferns": 10, "sunShafts": 5, "driftwood": 8 }
+    },
+    {
+      "index": 15,
+      "name": "Meander Handoff",
+      "difficulty": 0.2,
+      "biomeOverride": "canyonSummer",
+      "width": 35,
+      "waterWidth": 18,
+      "meanderStrength": 0.75,
+      "verticalBias": -0.15,
+      "physics": { "waterFlowIntensity": 0.85 },
+      "effects": { "transitionDuration": 2000, "particleCount": 100 },
+      "decorations": { "trees": 14, "rocks": 2, "ferns": 6 }
+    }
+  ],
+  "spawns": {
+    "start": {
+      "position": [0, 3, -8],
+      "rotation": [0, 0, 0],
+      "velocity": [0, 0, 0]
+    },
+    "checkpoints": [
+      { "segment": 5, "position": [0, -8, -180], "radius": 25 },
+      { "segment": 10, "position": [0, -14, -320], "radius": 30 },
+      { "segment": 11, "position": [0, -18, -360], "radius": 35 }
+    ]
+  }
+}

--- a/src/maps/lumber_flume.ts
+++ b/src/maps/lumber_flume.ts
@@ -1,0 +1,30 @@
+/**
+ * lumber_flume.ts
+ *
+ * Authored forest → elevated flume → gap jump map.
+ * Segments 0–15 are in `lumber_flume.json`; continuation into
+ * `meander_to_waterfall.json` is handled by MapRegistry continuation wiring.
+ */
+
+import type { SegmentRange } from '../systems/MapSystem';
+
+/** First segment index of the lumber flume map. */
+export const LUMBER_FLUME_START_INDEX = 0;
+
+/** Segment count of the authored lumber flume sequence before meander handoff. */
+export const LUMBER_FLUME_SEGMENT_COUNT = 16;
+
+/** Gap / launch set-piece segment index (open-floor waterfall + launch shelf). */
+export const LUMBER_FLUME_GAP_SEGMENT_INDEX = 10;
+
+/** Splash landing pool immediately after the gap. */
+export const LUMBER_FLUME_LANDING_SEGMENT_INDEX = 11;
+
+/**
+ * Procedural fallback once lumber flume + meander authored segments are exhausted.
+ * Reuses the meander post-reach table.
+ */
+export { MEANDER_FALLBACK_PROGRESSION as LUMBER_FLUME_FALLBACK_PROGRESSION } from './meander_to_waterfall';
+
+/** Empty typed alias kept for tests that assert a fallback array exists. */
+export const LUMBER_FLUME_STANDALONE_FALLBACK: SegmentRange[] = [];

--- a/src/maps/registry.ts
+++ b/src/maps/registry.ts
@@ -10,6 +10,7 @@ import type { BiomeId } from '../configs/biomes';
 import glacialLevel from './glacial_source.json';
 import meanderLevel from './meander_to_waterfall.json';
 import deltaLevel from './delta_rapids.json';
+import lumberLevel from './lumber_flume.json';
 import {
   DELTA_RAPIDS_CONTINUED_START_INDEX,
   GLACIER_START_INDEX,
@@ -20,6 +21,10 @@ import {
   GLACIAL_SOURCE_START_INDEX,
   GLACIAL_SOURCE_FALLBACK_PROGRESSION,
 } from './glacial_source';
+import {
+  LUMBER_FLUME_START_INDEX,
+  LUMBER_FLUME_FALLBACK_PROGRESSION,
+} from './lumber_flume';
 
 export interface MapContinuation {
   levelData: LevelData;
@@ -46,6 +51,18 @@ export const MAP_REGISTRY = {
     fallbackProgression: GLACIAL_SOURCE_FALLBACK_PROGRESSION,
     startIndex: GLACIAL_SOURCE_START_INDEX,
     initialBiome: 'glacialMelt',
+    continuation: {
+      levelData: meanderLevel as unknown as LevelData,
+      startIndex: 0,
+    },
+  },
+  lumber: {
+    id: 'lumber',
+    label: 'Map 0.5: Lumber Flume',
+    levelData: lumberLevel as unknown as LevelData,
+    fallbackProgression: LUMBER_FLUME_FALLBACK_PROGRESSION,
+    startIndex: LUMBER_FLUME_START_INDEX,
+    initialBiome: 'lumberFlume',
     continuation: {
       levelData: meanderLevel as unknown as LevelData,
       startIndex: 0,
@@ -80,4 +97,16 @@ export function getMapDefinition(mapId: MapRegistryId = ACTIVE_MAP_ID): MapDefin
 
 export function getActiveMap(): MapDefinition {
   return getMapDefinition(ACTIVE_MAP_ID);
+}
+
+/** Resolve `?map=` URL tokens (and registry ids) to a MapRegistryId. */
+export function resolveMapRegistryId(raw: string | null | undefined): MapRegistryId | null {
+  if (!raw) return null;
+  const key = raw.trim().toLowerCase();
+  if (key === 'lumber' || key === 'lumberflume' || key === 'flume') return 'lumber';
+  if (key === 'glacial' || key === 'glacier') return 'glacial';
+  if (key === 'delta') return 'delta';
+  if (key === 'meander') return 'meander';
+  if (key in MAP_REGISTRY) return key as MapRegistryId;
+  return null;
 }

--- a/src/systems/ChunkManager.ts
+++ b/src/systems/ChunkManager.ts
@@ -57,10 +57,11 @@ export interface SegmentData {
   gravityMultiplier?: number;
   /** Pre-calculated spawn data for objects. */
   spawns?: SpawnData[];
-  /** Authored decoration / launch-shelf overrides passed through to TrackSegment. */
+  /** Authored decoration / launch-shelf / gap overrides passed through to TrackSegment. */
   config?: {
     decorations?: Record<string, number | DecorationPlacement[]>;
     launchShelf?: { rockRef: { localX: number; localZ: number; scale: number } };
+    openFloor?: boolean;
   };
   /** Backing MapSystem chunk for pool recycling. */
   _baseChunk?: BaseMapChunk;

--- a/src/systems/MapSystem.ts
+++ b/src/systems/MapSystem.ts
@@ -95,6 +95,11 @@ export interface LevelSegment {
   slipperiness?: number;
   treeDensity?: number;
   rockDensity?: 'low' | 'medium' | 'high';
+  /**
+   * When true, TrackSegment skips the floor trimesh collider so the player
+   * flies an air corridor (gap / broken trestle set-pieces).
+   */
+  openFloor?: boolean;
 }
 
 export interface LevelSpawns {
@@ -147,10 +152,11 @@ export interface BaseMapChunk {
   canyonWidth: number;
   /** Pre-calculated spawn data for objects */
   spawns: SpawnData[];
-  /** Authored decoration / launch-shelf config passed through to TrackSegment */
+  /** Authored decoration / launch-shelf / gap config passed through to TrackSegment */
   config?: {
     decorations?: Record<string, number | DecorationPlacement[]>;
     launchShelf?: LaunchShelfConfig;
+    openFloor?: boolean;
   };
   /** Reference to physics collider */
   collider?: RapierRigidBody;
@@ -264,6 +270,11 @@ export interface SegmentProgressionConfig {
   decorations?: Record<string, number | DecorationPlacement[]>;
   /** Optional launch-shelf gameplay trigger for waterfall set-pieces. */
   launchShelf?: LaunchShelfConfig;
+  /**
+   * When true, the segment is an air corridor — no floor trimesh collider.
+   * Pair with a splash/pond landing segment for a playable gap jump.
+   */
+  openFloor?: boolean;
   /**
    * Surface slipperiness 0–1. 0 = normal grip, 1 = frictionless ice.
    * Consumed by WaterFlowForces / RaftVehicle to reduce lateral drag and
@@ -699,8 +710,12 @@ export function buildProceduralSegment(
     canyonWidth: progression.width,
     spawns,
     config:
-      progression.decorations || progression.launchShelf
-        ? { decorations: progression.decorations, launchShelf: progression.launchShelf }
+      progression.decorations || progression.launchShelf || progression.openFloor
+        ? {
+            decorations: progression.decorations,
+            launchShelf: progression.launchShelf,
+            openFloor: progression.openFloor,
+          }
         : undefined,
     active: true,
   };
@@ -1013,8 +1028,12 @@ export class JSONMapManager implements MapManager {
       waterWidth: config.waterWidth ?? this.levelData.world.track.width ?? DEFAULT_MAP_CONFIG.waterWidth,
       canyonWidth: config.width || this.levelData.world.track.width || DEFAULT_MAP_CONFIG.canyonWidth,
       spawns,
-      config: progression.decorations || progression.launchShelf
-        ? { decorations: progression.decorations, launchShelf: progression.launchShelf }
+      config: progression.decorations || progression.launchShelf || progression.openFloor
+        ? {
+            decorations: progression.decorations,
+            launchShelf: progression.launchShelf,
+            openFloor: progression.openFloor,
+          }
         : undefined,
       active: true,
     };
@@ -1105,6 +1124,7 @@ export class JSONMapManager implements MapManager {
       launchShelf: seg.launchShelf,
       journeyComplete: seg.journeyComplete,
       slipperiness: seg.slipperiness,
+      openFloor: seg.openFloor,
     };
   }
 }

--- a/src/systems/VehicleSystem.ts
+++ b/src/systems/VehicleSystem.ts
@@ -44,7 +44,7 @@ export const MATERIAL_FROM_BIOME: Record<string, SurfaceMaterial> = {
   delta: SurfaceMaterial.MOSS,
   cavern: SurfaceMaterial.CONCRETE,
   midnightMist: SurfaceMaterial.MOSS,
-  lumberFlume: SurfaceMaterial.ROCK,
+  lumberFlume: SurfaceMaterial.WOOD,
   hydroDam: SurfaceMaterial.CONCRETE,
   // Legacy aliases (map-load / events may still emit briefly)
   summer: SurfaceMaterial.ROCK,

--- a/src/systems/__tests__/MapSystem.lumber.test.ts
+++ b/src/systems/__tests__/MapSystem.lumber.test.ts
@@ -1,0 +1,128 @@
+/**
+ * MapSystem — lumber_flume.json validation + registry wiring
+ */
+
+import { JSONMapManager, ProceduralMapManager, type LevelData } from '../MapSystem';
+import lumberData from '../../maps/lumber_flume.json';
+import meanderData from '../../maps/meander_to_waterfall.json';
+import {
+  LUMBER_FLUME_GAP_SEGMENT_INDEX,
+  LUMBER_FLUME_LANDING_SEGMENT_INDEX,
+  LUMBER_FLUME_SEGMENT_COUNT,
+} from '../../maps/lumber_flume';
+import {
+  MAP_REGISTRY,
+  getMapDefinition,
+  resolveMapRegistryId,
+} from '../../maps/registry';
+import { getTrackBiomeProfile } from '../../configs/TrackBiomes';
+import { getBiomePalette } from '../../configs/BiomePalettes';
+import { validateLevel } from '../../utils/levelValidator';
+import { SurfaceMaterial, MATERIAL_FROM_BIOME } from '../VehicleSystem';
+
+const lumberLevel = lumberData as unknown as LevelData;
+const meanderLevel = meanderData as unknown as LevelData;
+
+describe('JSONMapManager — lumber_flume', () => {
+  let manager: JSONMapManager;
+
+  beforeAll(() => {
+    manager = new JSONMapManager(lumberLevel);
+  });
+
+  it('instantiates with 16 authored segments', () => {
+    expect(manager.levelData?.world.track.totalSegments).toBe(LUMBER_FLUME_SEGMENT_COUNT);
+    expect(manager.levelData?.segments.length).toBe(LUMBER_FLUME_SEGMENT_COUNT);
+  });
+
+  it('segment 0 uses lumberFlume biome with forest approach density', () => {
+    const cfg = manager.getChunkConfig(0);
+    expect(cfg.biome).toBe('lumberFlume');
+    expect(cfg.treeDensity).toBeGreaterThanOrEqual(14);
+    expect(cfg.flowSpeed).toBeGreaterThan(0.8);
+  });
+
+  it('gap segment is an open-floor waterfall with launch shelf', () => {
+    const cfg = manager.getChunkConfig(LUMBER_FLUME_GAP_SEGMENT_INDEX);
+    expect(cfg.type).toBe('waterfall');
+    expect(cfg.openFloor).toBe(true);
+    expect(cfg.launchShelf).toBeDefined();
+    expect(cfg.verticalBias).toBeLessThanOrEqual(-2.5);
+  });
+
+  it('landing segment is a splash pool after the gap', () => {
+    const cfg = manager.getChunkConfig(LUMBER_FLUME_LANDING_SEGMENT_INDEX);
+    expect(cfg.type).toBe('splash');
+    expect(cfg.width).toBeGreaterThanOrEqual(35);
+  });
+
+  it('final segment handoffs toward summer meander', () => {
+    const cfg = manager.getChunkConfig(15);
+    expect(cfg.biome).toBe('canyonSummer');
+  });
+});
+
+describe('ProceduralMapManager — lumber → meander chaining', () => {
+  const manager = new ProceduralMapManager(
+    lumberLevel,
+    [],
+    {},
+    { levelData: meanderLevel, startIndex: 0 },
+  );
+
+  it('segment 16 resolves to meander segment 0 (summer meander)', () => {
+    const cfg = manager.getChunkConfig(16);
+    expect(cfg.biome).toBe('canyonSummer');
+    expect(cfg.treeDensity).toBeGreaterThanOrEqual(10);
+  });
+});
+
+describe('MAP_REGISTRY — lumber entry', () => {
+  it('registers lumber with lumberFlume initial biome and meander continuation', () => {
+    const def = getMapDefinition('lumber');
+    expect(def.id).toBe('lumber');
+    expect(def.initialBiome).toBe('lumberFlume');
+    expect(def.levelData.world.track.totalSegments).toBe(16);
+    expect(def.continuation?.levelData).toBeDefined();
+    expect(MAP_REGISTRY.lumber).toBe(def);
+  });
+
+  it('resolveMapRegistryId accepts lumber / flume aliases', () => {
+    expect(resolveMapRegistryId('lumber')).toBe('lumber');
+    expect(resolveMapRegistryId('lumberFlume')).toBe('lumber');
+    expect(resolveMapRegistryId('flume')).toBe('lumber');
+    expect(resolveMapRegistryId('LUMBER')).toBe('lumber');
+    expect(resolveMapRegistryId('unknown-map')).toBeNull();
+  });
+});
+
+describe('lumberFlume biome profile + palette', () => {
+  it('has a distinct track profile vs summer canyon', () => {
+    const lumber = getTrackBiomeProfile('lumberFlume');
+    const summer = getTrackBiomeProfile('canyonSummer');
+    expect(lumber.id).toBe('lumberFlume');
+    expect(lumber.wallHeight).toBeLessThan(summer.wallHeight);
+    expect(lumber.vegetationDensity).toBeGreaterThan(summer.vegetationDensity);
+    expect(lumber.rockBaseColor).not.toBe(summer.rockBaseColor);
+  });
+
+  it('palette reads as damp wood greens with strong sun shafts', () => {
+    const palette = getBiomePalette('lumberFlume');
+    expect(palette.id).toBe('lumberFlume');
+    expect(palette.sunShaftIntensity).toBeGreaterThanOrEqual(0.9);
+    expect(palette.treeDensity).toBeGreaterThan(1.2);
+    expect(palette.name).toMatch(/lumber/i);
+  });
+
+  it('maps surface friction to wood', () => {
+    expect(MATERIAL_FROM_BIOME.lumberFlume).toBe(SurfaceMaterial.WOOD);
+  });
+});
+
+describe('lumber_flume.json schema validation', () => {
+  it('validates against the level schema', () => {
+    const result = validateLevel(lumberData);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/src/utils/levelValidator.ts
+++ b/src/utils/levelValidator.ts
@@ -50,10 +50,10 @@ const DIFFICULTY_TYPES = ['beginner', 'intermediate', 'expert', 'custom'];
 // Numeric ranges for validation
 const RANGES = {
   difficulty: { min: 0, max: 1 },
-  segmentLength: { min: 20, max: 50 },
+  segmentLength: { min: 20, max: 150 },
   totalSegments: { min: 1, max: 50 },
-  width: { min: 20, max: 80 },
-  wallHeight: { min: 8, max: 20 },
+  width: { min: 20, max: 120 },
+  wallHeight: { min: 8, max: 30 },
   meanderStrength: { min: 0, max: 3 },
   verticalBias: { min: -3, max: 0 },
   forwardMomentum: { min: 0.1, max: 2 },

--- a/verification/lumber_flume_smoke.mjs
+++ b/verification/lumber_flume_smoke.mjs
@@ -1,0 +1,152 @@
+/**
+ * lumber_flume_smoke.mjs — Smoke screenshots for Lumber Flume set-pieces.
+ * Launches a fresh Chrome per boot attempt (SwiftShader often kills the browser).
+ */
+import puppeteer from 'puppeteer';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT = path.join(__dirname, 'output');
+const BASE = process.env.WATERSHED_URL ?? 'http://localhost:3000';
+const TARGET = `${BASE}?map=lumber&renderer=webgl&screenshot=1&no-pointer-lock=1`;
+const ARGS = [
+  '--no-sandbox',
+  '--headless=new',
+  '--enable-unsafe-swiftshader',
+  '--ignore-gpu-blocklist',
+  '--disable-dev-shm-usage',
+  '--window-size=1280,720',
+  '--hide-scrollbars',
+];
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const SHOTS = [
+  { seg: 5, file: 'lumber_flume.png' },
+  { seg: 10, file: 'lumber_gap.png' },
+  { seg: 11, file: 'lumber_landing.png' },
+];
+
+async function launch() {
+  return puppeteer.launch({
+    headless: 'new',
+    ignoreDefaultArgs: true,
+    executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || '/usr/bin/google-chrome',
+    args: ARGS,
+  });
+}
+
+async function bootOnce() {
+  const browser = await launch();
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 720 });
+  const errors = [];
+  page.on('pageerror', (e) => errors.push(String(e.message || e)));
+
+  try {
+    await page.goto(TARGET, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForSelector('canvas', { timeout: 30000 });
+    await sleep(2500);
+
+    const crashed = await page.evaluate(
+      () => /Maximum update depth|Application Error/i.test(document.body.innerText || ''),
+    );
+    if (crashed) {
+      await browser.close();
+      return { ok: false, reason: 'update-depth', errors };
+    }
+
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button,[role=button]')).find((el) =>
+        /start|play|begin/i.test(el.innerText || ''),
+      );
+      btn?.click();
+    });
+    await sleep(1500);
+
+    await page.evaluate(() => {
+      const c = document.querySelector('canvas');
+      if (!c) return;
+      c.requestPointerLock = () => Promise.resolve();
+      try {
+        Object.defineProperty(document, 'pointerLockElement', {
+          configurable: true,
+          get: () => c,
+        });
+        document.dispatchEvent(new Event('pointerlockchange'));
+      } catch (_) {}
+    });
+
+    await page.waitForFunction(() => !!window.__watershedScreenshot, { timeout: 20000 });
+    await sleep(3000);
+
+    const status = await page.evaluate(() => ({
+      hasApi: !!window.__watershedScreenshot,
+      crashed: /Maximum update depth|Application Error/i.test(document.body.innerText || ''),
+    }));
+
+    if (status.crashed || !status.hasApi) {
+      await browser.close();
+      return { ok: false, reason: status.crashed ? 'post-start-crash' : 'no-api', errors };
+    }
+
+    return { ok: true, browser, page, errors };
+  } catch (err) {
+    await browser.close().catch(() => {});
+    return { ok: false, reason: String(err.message || err), errors };
+  }
+}
+
+fs.mkdirSync(OUT, { recursive: true });
+
+let session = null;
+for (let i = 0; i < 6; i += 1) {
+  console.log(`boot attempt ${i + 1}`);
+  session = await bootOnce();
+  if (session.ok) {
+    console.log('boot ok');
+    break;
+  }
+  console.log('boot failed:', session.reason, session.errors?.slice(0, 3));
+  await sleep(800);
+}
+
+if (!session?.ok) {
+  console.error('Could not boot');
+  process.exit(1);
+}
+
+const { browser, page } = session;
+
+await page.evaluate(() => {
+  document
+    .querySelectorAll('.ui-overlay,.game-hud,.pause-menu,.start-menu,.debug-panel')
+    .forEach((el) => {
+      el.style.opacity = '0';
+    });
+});
+
+const report = { url: TARGET, shots: [] };
+for (const shot of SHOTS) {
+  console.log(`capture seg ${shot.seg} → ${shot.file}`);
+  await page.evaluate((seg) => window.__watershedScreenshot.teleportToSegment(seg), shot.seg);
+  await sleep(4000);
+  const outPath = path.join(OUT, shot.file);
+  await page.screenshot({ path: outPath, type: 'png' });
+  const meta = await page.evaluate(() => {
+    const d = window.__watershedPhysicsDebug || {};
+    return {
+      seg: d.currentSegmentIndex ?? null,
+      y: d.position?.y ?? null,
+      textHit: (document.body.innerText || '').match(/LUMBER|FLUME|CANYON|SUMMER/i)?.[0] ?? null,
+    };
+  });
+  const size = fs.statSync(outPath).size;
+  console.log(`  size=${size} meta=${JSON.stringify(meta)}`);
+  report.shots.push({ ...shot, outPath, size, meta });
+}
+
+fs.writeFileSync(path.join(OUT, 'lumber_smoke_report.json'), JSON.stringify(report, null, 2));
+await browser.close();
+console.log('done');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds the missing **Lumber Flume** forest map so the alpine → delta journey has a playable wood/moss aqueduct chapter.

### Content
- `src/maps/lumber_flume.json` — 16 segments: forest approach → elevated flume → **open-floor gap jump** (seg 10 + launch shelf) → splash landing → broken trestle → river rejoin / summer handoff
- Registry id **`lumber`** with continuation into meander (`?map=lumber`, also `flume` / `lumberFlume`)
- Distinct `lumberFlume` track profile + palette (lower walls, denser trees, damp timber greens, strong sun shafts)
- Static plank/log/barrel props via existing `LumberProps` (v1 visual)

### Engine plumbing
- `openFloor` segment flag skips floor trimesh collider for air-corridor gaps
- Level/reach schema updates for authored rock placements, launch shelves, and realistic length/width ranges
- Surface friction maps to `WOOD`

### Stability (found during smoke)
- Fixed FlowForecast infinite re-render: `InnerExperience` was spreading `DAM_RELEASE_SCHEDULE` every render, invalidating the forecast memo and looping `setState`

### Tests
- `MapSystem.lumber.test.ts` — map load, gap/landing, meander chaining, registry aliases, **schema validation**
- BiomeId parity: lumberFlume is not a summer clone
- `CI=true pnpm test` — 331 passed

### Smoke screenshots
Headless SwiftShader cannot reliably capture 3D frames in this environment (TESTING.md F-8). Added `verification/lumber_flume_smoke.mjs` for local/GPU runs:
```bash
pnpm dev
node verification/lumber_flume_smoke.mjs
```

## Test plan
- [x] `CI=true pnpm test`
- [x] `?map=lumber` resolves via registry; start menu boots without Application Error after FlowForecast fix
- [ ] Local GPU: smoke script captures flume / gap / landing under `verification/output/`
- [ ] Runner + raft clear seg 10 gap into seg 11 landing pool
- [ ] Journey continues into meander without soft-lock

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb061408-acac-49d8-b347-04a487545163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb061408-acac-49d8-b347-04a487545163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the new Lumber Flume map with 16 authored segments, themed scenery, checkpoints, rapids, gaps, and landing areas.
  * Added Lumber Flume biome visuals, lighting, audio, vegetation, wood surfaces, and atmospheric effects.
  * Added support for selectable maps through URL parameters and map aliases.
  * Added open-floor segments for air corridors and broken-trestle-style set pieces.
  * Expanded level authoring options for decorations, water, terrain, checkpoints, and launch shelves.

* **Bug Fixes**
  * Improved map continuation and default map selection behavior.
  * Adjusted Lumber Flume vegetation and sun-shaft frequency for its environment.

* **Tests**
  * Added coverage for Lumber Flume loading, validation, registry aliases, biome properties, and progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->