### PR TITLE
fix load lockup: spawn/init storm + deferred world boot

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,8 @@ const isTypingTarget = (target: EventTarget | null) => {
 
 function App() {
   const [phase, setPhase] = useState<GamePhase>('menu');
+  /** Heavy Physics/track mount — deferred after Start so the menu can unmount first. */
+  const [worldEnabled, setWorldEnabled] = useState(false);
   const [skipLoader, setSkipLoader] = useState(false);
   const debug = useDebugStages();
   const [selectedMapId, setSelectedMapId] = useState<MapRegistryId>(() => getActiveMapId());
@@ -231,6 +233,13 @@ function App() {
     (mapId: MapRegistryId = selectedMapId) => {
       handleSelectMap(mapId);
       setPhase('playing');
+      // Defer world mount by two frames so StartMenu can unmount and paint
+      // before Rapier + 7 track segments block the main thread.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          setWorldEnabled(true);
+        });
+      });
       requestPointerLockSafely();
     },
     [handleSelectMap, requestPointerLockSafely, selectedMapId],
@@ -246,6 +255,7 @@ function App() {
   }, []);
 
   const handleQuit = useCallback(() => {
+    setWorldEnabled(false);
     setPhase('menu');
   }, []);
 
@@ -253,6 +263,7 @@ function App() {
     if (document.pointerLockElement) {
       document.exitPointerLock();
     }
+    setWorldEnabled(false);
     setPhase('menu');
   }, []);
 
@@ -310,13 +321,21 @@ function App() {
               debug.runStage('visualization', () => undefined);
             }}
           >
-            <React.Suspense fallback={null}>
+            <React.Suspense
+              fallback={
+                <mesh>
+                  <boxGeometry args={[0.5, 0.5, 0.5]} />
+                  <meshBasicMaterial color="#1a2a3a" />
+                </mesh>
+              }
+            >
               <Experience
                 debug={debug}
                 physicsDebug={physicsDebug}
                 rendererPreference={rendererPreference}
                 wireframeDebug={wireframeDebug}
                 cleanTest={cleanTest}
+                worldEnabled={worldEnabled}
                 mapId={selectedMapId}
                 onMapChange={handleMapChange}
                 onReturnToMenu={handleReturnToMenu}

--- a/src/Experience.tsx
+++ b/src/Experience.tsx
@@ -24,6 +24,7 @@ export default function Experience({
   rendererPreference = 'webgl',
   wireframeDebug = false,
   cleanTest = false,
+  worldEnabled = true,
   mapId,
   onMapChange,
   onReturnToMenu,
@@ -49,7 +50,7 @@ export default function Experience({
           { name: 'dodge', keys: ['AltLeft', 'AltRight'] },
         ]}
       >
-        <LODProvider initialQuality="high" enableAdaptive targetFPS={60}>
+        <LODProvider initialQuality="medium" enableAdaptive targetFPS={60}>
           <BiomeProvider initialBiome="canyonSummer" enableTimeOfDay={false}>
             <SunPositionProvider>
               <BiomeTransition />
@@ -58,6 +59,7 @@ export default function Experience({
                 physicsDebug={physicsDebug}
                 wireframeDebug={wireframeDebug}
                 cleanTest={cleanTest}
+                worldEnabled={worldEnabled}
                 mapId={mapId}
                 onMapChange={onMapChange}
                 onReturnToMenu={onReturnToMenu}

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -20,9 +20,8 @@ export const Loader = () => {
   // Match the logic above: if !active, start fading
   const isFading = !active;
 
-  // Show 100% if total is 0 to avoid "0%" confusion
-  // Updated to avoid 0%
-  const displayProgress = Math.max(1, Math.round(progress));
+  // Show 0% until progress reports; avoid a stuck "1%" idle flash
+  const displayProgress = Math.round(progress);
 
   return (
     <div className={`loader-overlay ${isFading ? 'fade-out' : ''}`}>

--- a/src/components/TrackManager.tsx
+++ b/src/components/TrackManager.tsx
@@ -116,6 +116,11 @@ const TrackManager = forwardRef<TrackManagerRef, TrackManagerProps>(function Tra
   }));
 
   const forecastByIndexRef = useRef<Map<number, string>>(new Map());
+  // Keep callbacks in refs so ChunkManager init does not tear down / rebuild the
+  // pool when parent re-renders (e.g. Zustand setSpawnPoint during initializePool).
+  // That remount loop caused "Maximum update depth exceeded" and a hard load freeze.
+  const onBiomeChangeRef = useRef(onBiomeChange);
+  onBiomeChangeRef.current = onBiomeChange;
   const weatherWetnessRef = useRef(0);
   const mapManagerRef = useRef<MapManager>(
     new ProceduralMapManager(
@@ -251,14 +256,14 @@ const TrackManager = forwardRef<TrackManagerRef, TrackManagerProps>(function Tra
     }
   }, [aoMap, colorMap, displacementMap, fallbackTextures, normalMap, reachId, roughnessMap]);
 
-  // Forecast updates
+  // Forecast updates — ChunkManager.applyLiveForecast remounts only when segment
+  // states actually change (via onPoolChange). Do not force a full pool remount here.
   useEffect(() => {
     const nextForecastMap = samplesToForecastByIndex(forecastSamples);
     forecastByIndexRef.current = nextForecastMap;
 
     if (chunkManagerRef.current && chunkManagerRef.current.isInitialized()) {
       chunkManagerRef.current.setForecastByIndex(nextForecastMap);
-      setPoolVersion((v) => v + 1);
     }
   }, [forecastSamples]);
 
@@ -283,7 +288,7 @@ const TrackManager = forwardRef<TrackManagerRef, TrackManagerProps>(function Tra
     const callbacks = {
       onPoolChange: () => setPoolVersion((v) => v + 1),
       onBiomeChange: (biome: BiomeId, segmentIndex: number) => {
-        onBiomeChange?.(biome, segmentIndex);
+        onBiomeChangeRef.current?.(biome, segmentIndex);
       },
       onSegmentEnter: (index: number) => {
         const activeSegments = chunkManagerRef.current?.getActiveSegments?.() ?? [];
@@ -345,7 +350,7 @@ const TrackManager = forwardRef<TrackManagerRef, TrackManagerProps>(function Tra
       chunkManagerRef.current = null;
       pendingSynthesizesRef.current = [];
     };
-  }, [rockMaterial, onBiomeChange, reachSegments, effectiveStartIndex]);
+  }, [rockMaterial, reachSegments, effectiveStartIndex]);
 
   // Night mode: update scene fog and background
   useEffect(() => {

--- a/src/experience/InnerExperience.tsx
+++ b/src/experience/InnerExperience.tsx
@@ -28,6 +28,7 @@ export default function InnerExperience({
   physicsDebug = false,
   wireframeDebug = false,
   cleanTest = false,
+  worldEnabled = true,
   mapId,
   onMapChange,
   onReturnToMenu,
@@ -58,12 +59,14 @@ export default function InnerExperience({
         enabled={debug.isStageEnabled('visualization')}
       />
 
-      <WaterReflectionLayer
-        enabled={debug.isStageEnabled('worldSystems')}
-        enableReflections={lodConfig.enableReflections}
-      />
+      {worldEnabled && (
+        <WaterReflectionLayer
+          enabled={debug.isStageEnabled('worldSystems')}
+          enableReflections={lodConfig.enableReflections}
+        />
+      )}
 
-      {debug.isStageEnabled('physics') && (
+      {worldEnabled && debug.isStageEnabled('physics') && (
         <Physics debug={state.isDebug || state.physicsDebugEnabled} gravity={[0, PHYSICS.GRAVITY, 0]}>
           {!state.noPointerLock && (
             <PointerLockControls
@@ -110,12 +113,12 @@ export default function InnerExperience({
                 showLoader={false}
                 showError={false}
                 raftRef={state.vehicleRef}
-                onBiomeChange={(biome) => state.handleBiomeChange(biome, state.currentSegmentIndex)}
+                onBiomeChange={state.handleBiomeChange}
               />
             ) : state.reachId ? (
               <ReachManager
                 playerRef={state.vehicleRef}
-                onBiomeChange={(biome) => state.handleBiomeChange(biome, state.currentSegmentIndex)}
+                onBiomeChange={state.handleBiomeChange}
                 forecastSamples={state.forecastSamples}
                 reachId={state.reachId}
                 onLoadingChange={state.setReachLoading}
@@ -126,7 +129,7 @@ export default function InnerExperience({
               <TrackManager
                 ref={state.trackManagerRef}
                 key={state.defaultMapRunKey}
-                onBiomeChange={(biome) => state.handleBiomeChange(biome, state.currentSegmentIndex)}
+                onBiomeChange={state.handleBiomeChange}
                 raftRef={state.vehicleRef}
                 forecastSamples={state.forecastSamples}
                 startIndex={state.activeDefaultMap.startIndex}
@@ -136,7 +139,7 @@ export default function InnerExperience({
         </Physics>
       )}
 
-      {debug.isStageEnabled('postProcessing') && (
+      {worldEnabled && debug.isStageEnabled('postProcessing') && (
         <PostProcessingPipeline
           quality={state.quality}
           vehicleRef={state.vehicleRef}

--- a/src/experience/hooks/useExperienceLifecycle.ts
+++ b/src/experience/hooks/useExperienceLifecycle.ts
@@ -41,6 +41,7 @@ export function useExperienceLifecycle({
   const setWaterfallGravityMultiplier = useGameStore((s) => s.setWaterfallGravityMultiplier);
   const setDistanceTraveled = useGameStore((s) => s.setDistanceTraveled);
   const setSpawnPoint = useGameStore((s) => s.setSpawnPoint);
+  const setSpawnPoints = useGameStore((s) => s.setSpawnPoints);
 
   const slowFrameCount = useRef(0);
   const warnedSlowFrames = useRef(false);
@@ -179,12 +180,23 @@ export function useExperienceLifecycle({
         }
       };
 
+      const handleSegmentSpawns = (e: Event) => {
+        const { points } =
+          (e as CustomEvent<{ points?: Record<number, { x: number; y: number; z: number }> }>).detail ??
+          {};
+        if (points && Object.keys(points).length > 0) {
+          setSpawnPoints(points);
+        }
+      };
+
       window.addEventListener('segment-enter', handleSegmentEnter);
       window.addEventListener('segment-spawn', handleSegmentSpawn);
+      window.addEventListener('segment-spawns', handleSegmentSpawns);
       debug.setStageSuccess('stateManagement');
       return () => {
         window.removeEventListener('segment-enter', handleSegmentEnter);
         window.removeEventListener('segment-spawn', handleSegmentSpawn);
+        window.removeEventListener('segment-spawns', handleSegmentSpawns);
       };
     } catch (error) {
       debug.setStageFailure('stateManagement', error);
@@ -196,6 +208,7 @@ export function useExperienceLifecycle({
     setCurrentSegmentIndex,
     setRespawnSegmentIndex,
     setSpawnPoint,
+    setSpawnPoints,
     setWaterfallGravityMultiplier,
   ]);
 

--- a/src/experience/hooks/useExperienceWorld.ts
+++ b/src/experience/hooks/useExperienceWorld.ts
@@ -15,7 +15,7 @@ import {
   syncMapUrl,
 } from '../../maps/campaign';
 import type { DebugStageController } from '../../debug/debugStages';
-import { DEFAULT_MAPS } from '../constants';
+import { DAM_RELEASE_SCHEDULE, DEFAULT_MAPS } from '../constants';
 import type { VehicleRigidBodyRef } from '../types';
 import {
   getGhostBestScoreForMap,
@@ -26,6 +26,29 @@ import {
 import { hydrateStoreForRun } from '../../systems/persistenceBootstrap';
 import { getActiveRunKey } from '../../utils/runContext';
 import { ACTIVE_MAP_ID } from '../../maps/registry';
+import { buildForecastSamples } from '../../systems/flowForecast';
+
+const DEFAULT_FORECAST_SAMPLES: FlowForecastSample[] = buildForecastSamples({
+  temperature: 8,
+  snowpackIndex: 0.65,
+  damReleaseSchedule: DAM_RELEASE_SCHEDULE,
+  startHour: 0,
+  horizonHours: 24,
+});
+
+function forecastSamplesEqual(
+  a: ReadonlyArray<FlowForecastSample>,
+  b: ReadonlyArray<FlowForecastSample>,
+): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i].hour !== b[i].hour || a[i].flowRate !== b[i].flowRate || a[i].state !== b[i].state) {
+      return false;
+    }
+  }
+  return true;
+}
 
 interface UseExperienceWorldOptions {
   debug: DebugStageController;
@@ -71,7 +94,9 @@ export function useExperienceWorld({
   const [levelLoadError, setLevelLoadError] = useState<Error | string | null>(null);
   const [isLoadingLevel, setIsLoadingLevel] = useState(false);
   const [loadedLevelState, setLoadedLevelState] = useState<unknown>(null);
-  const [forecastSamples, setForecastSamples] = useState<FlowForecastSample[]>([]);
+  const [forecastSamples, setForecastSamples] = useState<FlowForecastSample[]>(
+    () => DEFAULT_FORECAST_SAMPLES,
+  );
   const [reachId, setReachId] = useState<string | null>(null);
   const [reachLoading, setReachLoading] = useState(false);
   const [reachError, setReachError] = useState<Error | string | null>(null);
@@ -343,7 +368,7 @@ export function useExperienceWorld({
         setWaterfallGravityMultiplier(1.0);
         snapBiomeContext(targetMap.initialBiome);
         useGameStore.setState({ currentBiome: targetMap.initialBiome, isPaused: false });
-        setForecastSamples([]);
+        setForecastSamples(DEFAULT_FORECAST_SAMPLES);
         awardedWaterfallSegmentsRef.current?.clear();
         resetScoreSystemState();
         resetRunSession({
@@ -409,6 +434,10 @@ export function useExperienceWorld({
     });
   }, [debug]);
 
+  const stableSetForecastSamples = useCallback((samples: FlowForecastSample[]) => {
+    setForecastSamples((prev) => (forecastSamplesEqual(prev, samples) ? prev : samples));
+  }, []);
+
   return {
     levelUrl,
     levelLoadError,
@@ -433,7 +462,7 @@ export function useExperienceWorld({
     handleContinueJourney,
     handleDefaultJourneyAction,
     handleReturnToMenu,
-    setForecastSamples,
+    setForecastSamples: stableSetForecastSamples,
     setLevelLoadError,
     setIsLoadingLevel,
     setLoadedLevelState,

--- a/src/experience/types.ts
+++ b/src/experience/types.ts
@@ -18,6 +18,11 @@ export interface InnerExperienceProps {
   physicsDebug?: boolean;
   wireframeDebug?: boolean;
   cleanTest?: boolean;
+  /**
+   * When false, skip Physics / track / vehicles so the Start Menu stays responsive.
+   * Cold boot previously locked the main thread building 7 trimesh segments under the menu.
+   */
+  worldEnabled?: boolean;
   /** Active campaign map — shared with StartMenu / URL resolver. */
   mapId?: import('../maps/registry').MapRegistryId;
   /** Called when continue / menu selection changes the active map. */

--- a/src/systems/ChunkManager.ts
+++ b/src/systems/ChunkManager.ts
@@ -274,6 +274,7 @@ export class ChunkManager {
     let previousSegment: SegmentData | null = null;
     const activeOrder: number[] = [];
     const segments = this.reachSegments;
+    const spawnBatch: Record<number, { x: number; y: number; z: number }> = {};
 
     for (let i = 0; i < MAX_ACTIVE_SEGMENTS; i += 1) {
       // startIndex allows the pool to begin at a negative offset (glacier prelude)
@@ -294,17 +295,23 @@ export class ChunkManager {
       if (segment) {
         const sp = segment.segmentPath.getPoint(0);
         this.spawnPoints.set(segment.id, sp);
-        window.dispatchEvent(
-          new CustomEvent('segment-spawn', {
-            detail: { segmentIndex: segment.id, spawnPoint: { x: sp.x, y: sp.y, z: sp.z } },
-          })
-        );
+        spawnBatch[segment.id] = { x: sp.x, y: sp.y, z: sp.z };
       }
     }
 
     this.pool = pool;
     this.activeOrder = activeOrder;
     this.initialized = true;
+
+    // One batched spawn update — avoids N Zustand/React flushes during cold boot.
+    if (Object.keys(spawnBatch).length > 0) {
+      window.dispatchEvent(
+        new CustomEvent('segment-spawns', {
+          detail: { points: spawnBatch },
+        })
+      );
+    }
+
     this.callbacks.onPoolChange?.();
   }
 

--- a/src/systems/GameState.ts
+++ b/src/systems/GameState.ts
@@ -95,6 +95,8 @@ export interface GameActions {
   setRespawnSegmentIndex: (index: number) => void;
   setWaterfallGravityMultiplier: (multiplier: number) => void;
   setSpawnPoint: (segmentIndex: number, point: SpawnPoint) => void;
+  /** Merge many spawn points in one store update (pool init / reset). */
+  setSpawnPoints: (points: Record<number, SpawnPoint>) => void;
   setSettings: (settings: Partial<GameSettings>) => void;
   /** Clamps value to [0, 1] before writing. Call from useFrame via getState() — never via the hook. */
   setSprintStamina: (v: number) => void;
@@ -110,7 +112,7 @@ export type GameStore = GameState & GameActions;
 // =============================================================================
 
 const DEFAULT_SETTINGS: GameSettings = {
-  quality: 'high',
+  quality: 'medium',
   soundVolume: 0.8,
 };
 
@@ -196,9 +198,41 @@ export const useGameStore = create<GameStore>((set) => ({
     set({ waterfallGravityMultiplier: multiplier }),
 
   setSpawnPoint: (segmentIndex, point) =>
-    set((state) => ({
-      spawnPoints: { ...state.spawnPoints, [segmentIndex]: point },
-    })),
+    set((state) => {
+      const prev = state.spawnPoints[segmentIndex];
+      if (
+        prev &&
+        prev.x === point.x &&
+        prev.y === point.y &&
+        prev.z === point.z
+      ) {
+        return state;
+      }
+      return {
+        spawnPoints: { ...state.spawnPoints, [segmentIndex]: point },
+      };
+    }),
+
+  setSpawnPoints: (points) =>
+    set((state) => {
+      let changed = false;
+      const next = { ...state.spawnPoints };
+      for (const key of Object.keys(points)) {
+        const segmentIndex = Number(key);
+        const point = points[segmentIndex];
+        const prev = next[segmentIndex];
+        if (
+          !prev ||
+          prev.x !== point.x ||
+          prev.y !== point.y ||
+          prev.z !== point.z
+        ) {
+          next[segmentIndex] = point;
+          changed = true;
+        }
+      }
+      return changed ? { spawnPoints: next } : state;
+    }),
 
   setSettings: (partial) =>
     set((state) => ({

--- a/src/systems/__tests__/GameState.spawnPoints.test.ts
+++ b/src/systems/__tests__/GameState.spawnPoints.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useGameStore } from '../GameState';
+
+describe('GameState spawn point updates', () => {
+  beforeEach(() => {
+    useGameStore.getState().resetGameState();
+  });
+
+  it('setSpawnPoint is a no-op when the point is unchanged', () => {
+    const store = useGameStore.getState();
+    store.setSpawnPoint(0, { x: 1, y: 2, z: 3 });
+    const first = useGameStore.getState().spawnPoints;
+
+    useGameStore.getState().setSpawnPoint(0, { x: 1, y: 2, z: 3 });
+    expect(useGameStore.getState().spawnPoints).toBe(first);
+  });
+
+  it('setSpawnPoints merges in a single update', () => {
+    useGameStore.getState().setSpawnPoints({
+      0: { x: 1, y: 2, z: 3 },
+      1: { x: 4, y: 5, z: 6 },
+    });
+    expect(useGameStore.getState().spawnPoints).toEqual({
+      0: { x: 1, y: 2, z: 3 },
+      1: { x: 4, y: 5, z: 6 },
+    });
+  });
+});

--- a/verification/boot_recover.mjs
+++ b/verification/boot_recover.mjs
@@ -1,0 +1,67 @@
+import puppeteer from 'puppeteer';
+const browser = await puppeteer.launch({
+  headless: 'new', protocolTimeout: 90000,
+  executablePath: '/usr/bin/google-chrome',
+  args: ['--no-sandbox','--enable-unsafe-swiftshader','--ignore-gpu-blocklist','--disable-dev-shm-usage','--window-size=1280,720'],
+});
+const page = await browser.newPage();
+const errs=[];
+page.on('pageerror', e => errs.push(String(e.message).slice(0,400)));
+const t0=Date.now();
+await page.goto('http://localhost:3000?renderer=webgl&screenshot=1&no-pointer-lock=1',{waitUntil:'domcontentloaded',timeout:30000});
+
+async function softEval(fn, ms=4000) {
+  const start=Date.now();
+  try {
+    const value = await Promise.race([
+      page.evaluate(fn),
+      new Promise((_,rej)=>setTimeout(()=>rej(new Error('timeout')), ms)),
+    ]);
+    return { ok:true, value, ms:Date.now()-start };
+  } catch (e) {
+    return { ok:false, err:e.message, ms:Date.now()-start };
+  }
+}
+
+const pre=[];
+for (let i=0;i<8;i++){
+  const r = await softEval(() => ({
+    menu: !!document.querySelector('.start-menu-start-btn'),
+    canvas: !!document.querySelector('canvas'),
+  }), 2000);
+  pre.push({t:Date.now()-t0, ...r});
+  if (r.ok && r.value.menu) break;
+  await new Promise(r=>setTimeout(r,200));
+}
+
+const clickStart = Date.now();
+let clickErr=null;
+try {
+  await page.click('.start-menu-start-btn', { delay: 20 });
+} catch (e) { clickErr = e.message; }
+
+// Poll for menu gone + occasional responsiveness
+const post=[];
+let menuGone=false;
+for (let i=0;i<30;i++){
+  const r = await softEval(() => ({
+    menu: !!document.querySelector('.start-menu-start-btn'),
+    canvas: !!document.querySelector('canvas'),
+  }), 5000);
+  post.push({t:Date.now()-t0, ...r});
+  if (r.ok && !r.value.menu) { menuGone=true; break; }
+  await new Promise(r=>setTimeout(r,500));
+}
+
+console.log(JSON.stringify({
+  updateDepth: errs.some(e=>/Maximum update depth/i.test(e)),
+  errs: errs.slice(0,8),
+  pre,
+  clickErr,
+  clickMs: Date.now()-clickStart,
+  menuGone,
+  post: post.slice(0,12),
+  total: Date.now()-t0,
+}, null, 2));
+await browser.close().catch(()=>{});
+process.exit(menuGone && !errs.some(e=>/Maximum update depth/i.test(e)) ? 0 : 2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cold boot was locking the main thread and throwing **Maximum update depth exceeded** under the Start Menu.

Root cause (confirmed via Puppeteer stack):

1. `ChunkManager.initializePool()` dispatched N `segment-spawn` events
2. Each `setSpawnPoint` re-rendered `InnerExperience`
3. Inline `onBiomeChange={(biome) => ...}` changed identity every render
4. `TrackManager`’s init effect depended on that callback → dispose + `initializePool` again → infinite loop

## Fixes

- **Break the remount loop:** keep `onBiomeChange` in a ref inside `TrackManager`; pass stable `handleBiomeChange` from `InnerExperience`
- **Batch spawn writes:** pool init emits one `segment-spawns` event; `setSpawnPoints` / no-op equal `setSpawnPoint`
- **Defer heavy world:** Physics / track / vehicles mount only after Start (two rAFs), so the menu stays responsive
- **Forecast hardening:** restore content-stable forecast setter; seed initial samples; don’t force pool remount on every forecast identity change
- **Lighter boot defaults:** LOD / settings quality start at `medium`
- **Loader / Suspense:** avoid stuck 1% idle flash; visible Suspense fallback

## Verification

- `verification/boot_recover.mjs`: menu responsive, Start clears menu, no update-depth errors (3/3 trials)
- `pnpm test` — 362 passed
- `pnpm typecheck` — clean

## Note

Post-Start track/trimesh build can still hitch briefly on soft GPU (SwiftShader); that is expected cost moved off the menu path, not a React deadlock.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92f4daa5-acd9-4740-9da4-e85b58667d5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92f4daa5-acd9-4740-9da4-e85b58667d5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

