### PR TITLE
feat(settings): persistent player Settings panel (audio, controls, graphics)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,9 @@ import { Loader } from './components/Loader';
 import { StartMenu } from './components/StartMenu';
 import { PauseMenu } from './components/PauseMenu';
 import DebugPanel from './components/DebugPanel';
+import { SettingsPanel } from './ui/SettingsPanel';
+import { SettingsSync } from './ui/SettingsSync';
+import { rehydrateSettings } from './systems/useSettingsStore';
 import { useDebugStages } from './debug/debugStages';
 import { isCleanTestMode, setCleanTestMode } from './utils/cleanTestMode';
 import ErrorBoundary from './components/ErrorBoundary';
@@ -64,6 +67,7 @@ const isTypingTarget = (target: EventTarget | null) => {
 
 function App() {
   const [phase, setPhase] = useState<GamePhase>('menu');
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [skipLoader, setSkipLoader] = useState(false);
   const debug = useDebugStages();
   const [selectedMapId, setSelectedMapId] = useState<MapRegistryId>(() => getActiveMapId());
@@ -99,6 +103,12 @@ function App() {
   useEffect(() => {
     initPersistence(getActiveRunKey(selectedMapId));
     syncMapUrl(selectedMapId);
+  }, []);
+
+  // Client-only rehydration of persisted settings (skipHydration in the store).
+  // Flips `_hasHydrated`, which gates the panel + all setting application.
+  useEffect(() => {
+    rehydrateSettings();
   }, []);
 
   const handleSelectMap = useCallback((mapId: MapRegistryId) => {
@@ -287,6 +297,7 @@ function App() {
         )
       ) : (
         <>
+          <SettingsSync />
           <Canvas
             key={`renderer-${rendererPreference}`}
             gl={async (props) =>
@@ -328,20 +339,31 @@ function App() {
           {debug.isStageEnabled('uiOverlay') && !skipLoader && <Loader />}
 
           {/* Goal 4: Start Menu — shown before first run */}
-          {debug.isStageEnabled('uiOverlay') && phase === 'menu' && (
+          {debug.isStageEnabled('uiOverlay') && phase === 'menu' && !settingsOpen && (
             <StartMenu
               onStart={handleStart}
               selectedMapId={selectedMapId}
               onSelectMap={handleSelectMap}
+              onOpenOptions={() => setSettingsOpen(true)}
             />
           )}
           {/* Goal 4: Pause Menu — shown when pointer lock is lost during play */}
-          {debug.isStageEnabled('uiOverlay') && phase === 'paused' && (
+          {debug.isStageEnabled('uiOverlay') && phase === 'paused' && !settingsOpen && (
             <PauseMenu
               onResume={handleResume}
               onRestart={handleRestart}
               onQuit={handleQuit}
+              onOpenOptions={() => setSettingsOpen(true)}
             />
+          )}
+          {/* Options — reachable from StartMenu and PauseMenu. Rendered in the
+              unlocked (menu/paused) state so key/mouse capture never fights
+              pointer lock. Closing returns to the parent menu; from the pause
+              menu that lands on RESUME, which re-locks on the user's click. */}
+          {debug.isStageEnabled('uiOverlay') && settingsOpen && (phase === 'menu' || phase === 'paused') && (
+            <div className="settings-panel-overlay">
+              <SettingsPanel onClose={() => setSettingsOpen(false)} />
+            </div>
           )}
           {debug.debugEnabled && !cleanTest && (
             <DebugPanel

--- a/src/Experience.tsx
+++ b/src/Experience.tsx
@@ -8,6 +8,8 @@ import RendererDiagnosticsMonitor from './rendering/RendererDiagnosticsMonitor';
 import InnerExperience from './experience/InnerExperience';
 import { NOOP_DEBUG } from './experience/constants';
 import { initShelfLaunchScoringListener } from './systems/LaunchScoringSession';
+import { useSettingsStore } from './systems/useSettingsStore';
+import { bindingsToDreiMap } from './systems/settingsDerive';
 import type { RendererPreference } from './rendering/types';
 import type { ExperienceProps, InnerExperienceProps, VehicleType } from './experience/types';
 
@@ -30,6 +32,12 @@ export default function Experience({
 }: ExperienceProps) {
   const isDebug = typeof window !== 'undefined' && window.location.search.includes('debug=true');
 
+  // Rebindable controls: derive drei's KeyboardControls map from the settings
+  // store. Changing the reference rebuilds drei's listeners (a brief reset of
+  // pressed keys is expected and fine — rebinding happens paused/unlocked).
+  const bindings = useSettingsStore((s) => s.bindings);
+  const keyboardMap = bindingsToDreiMap(bindings);
+
   useEffect(() => {
     initShelfLaunchScoringListener();
   }, []);
@@ -37,18 +45,7 @@ export default function Experience({
   return (
     <>
       {isDebug && <Stats />}
-      <KeyboardControls
-        map={[
-          { name: 'forward', keys: ['ArrowUp', 'KeyW'] },
-          { name: 'backward', keys: ['ArrowDown', 'KeyS'] },
-          { name: 'leftward', keys: ['ArrowLeft', 'KeyA'] },
-          { name: 'rightward', keys: ['ArrowRight', 'KeyD'] },
-          { name: 'jump', keys: ['Space'] },
-          { name: 'sprint', keys: ['ShiftLeft', 'ShiftRight'] },
-          { name: 'brake', keys: ['ControlLeft', 'ControlRight'] },
-          { name: 'dodge', keys: ['AltLeft', 'AltRight'] },
-        ]}
-      >
+      <KeyboardControls map={keyboardMap}>
         <LODProvider initialQuality="high" enableAdaptive targetFPS={60}>
           <BiomeProvider initialBiome="canyonSummer" enableTimeOfDay={false}>
             <SunPositionProvider>

--- a/src/components/PauseMenu.tsx
+++ b/src/components/PauseMenu.tsx
@@ -2,20 +2,15 @@
 // Pause overlay with resume, restart, quit, and settings
 
 import React, { useState, useEffect, useRef } from 'react';
-import { useGameStore, type QualityPreset } from '../systems/GameState';
+import { useGameStore } from '../systems/GameState';
 
 interface PauseMenuProps {
   onResume: () => void;
   onRestart: () => void;
   onQuit: () => void;
+  /** Open the full Options panel (audio, controls/rebinding, graphics). */
+  onOpenOptions: () => void;
 }
-
-const QUALITY_LABELS: Record<QualityPreset, string> = {
-  low: 'Low',
-  medium: 'Medium',
-  high: 'High',
-  ultra: 'Ultra',
-};
 
 /**
  * PauseMenu — In-game pause overlay.
@@ -27,33 +22,23 @@ const QUALITY_LABELS: Record<QualityPreset, string> = {
  * - Settings panel: graphics quality, sound volume
  * - Keyboard shortcuts: R for restart, Esc to close settings
  */
-export const PauseMenu: React.FC<PauseMenuProps> = ({ onResume, onRestart, onQuit }) => {
-  const [showSettings, setShowSettings] = useState(false);
+export const PauseMenu: React.FC<PauseMenuProps> = ({ onResume, onRestart, onQuit, onOpenOptions }) => {
   const [confirmRestart, setConfirmRestart] = useState(false);
   const resumeRef = useRef<HTMLButtonElement>(null);
 
-  const settings = useGameStore((s) => s.settings);
   const ghostEnabled = useGameStore((s) => s.ghostEnabled);
-  const setSettings = useGameStore((s) => s.setSettings);
   const setGhostEnabled = useGameStore((s) => s.setGhostEnabled);
 
   // Focus resume button when pause opens
   useEffect(() => {
-    if (!showSettings && !confirmRestart) {
+    if (!confirmRestart) {
       resumeRef.current?.focus();
     }
-  }, [showSettings, confirmRestart]);
+  }, [confirmRestart]);
 
   // Keyboard shortcuts
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (showSettings) {
-        if (e.key === 'Escape') {
-          e.preventDefault();
-          setShowSettings(false);
-        }
-        return;
-      }
       if (confirmRestart) {
         if (e.key === 'Escape') {
           e.preventDefault();
@@ -68,18 +53,14 @@ export const PauseMenu: React.FC<PauseMenuProps> = ({ onResume, onRestart, onQui
 
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [showSettings, confirmRestart]);
-
-  const handleQualityChange = (quality: QualityPreset) => {
-    setSettings({ quality });
-  };
+  }, [confirmRestart]);
 
   return (
     <div className="pause-menu-overlay">
       <div className="pause-menu-card">
         <h1 className="pause-menu-title">PAUSED</h1>
 
-        {!showSettings && !confirmRestart && (
+        {!confirmRestart && (
           <div className="pause-menu-buttons">
             <button
               ref={resumeRef}
@@ -102,10 +83,10 @@ export const PauseMenu: React.FC<PauseMenuProps> = ({ onResume, onRestart, onQui
 
             <button
               className="pause-menu-settings-btn"
-              onClick={() => setShowSettings(true)}
-              aria-label="Open Settings"
+              onClick={onOpenOptions}
+              aria-label="Open Options"
             >
-              SETTINGS
+              OPTIONS
             </button>
 
             <button
@@ -154,54 +135,6 @@ export const PauseMenu: React.FC<PauseMenuProps> = ({ onResume, onRestart, onQui
           </div>
         )}
 
-        {showSettings && (
-          <div className="pause-menu-settings" role="dialog" aria-label="Settings">
-            <h2 className="pause-menu-settings-title">Settings</h2>
-
-            <div className="pause-menu-setting-row">
-              <label className="pause-menu-setting-label">Graphics Quality</label>
-              <div className="pause-menu-quality-buttons">
-                {(Object.keys(QUALITY_LABELS) as QualityPreset[]).map((q) => (
-                  <button
-                    key={q}
-                    className={`pause-menu-quality-btn ${settings.quality === q ? 'active' : ''}`}
-                    onClick={() => handleQualityChange(q)}
-                    aria-pressed={settings.quality === q}
-                  >
-                    {QUALITY_LABELS[q]}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div className="pause-menu-setting-row">
-              <label className="pause-menu-setting-label" htmlFor="pause-volume">
-                Sound Volume
-              </label>
-              <input
-                id="pause-volume"
-                type="range"
-                min={0}
-                max={1}
-                step={0.05}
-                value={settings.soundVolume}
-                onChange={(e) => setSettings({ soundVolume: parseFloat(e.target.value) })}
-                className="pause-menu-slider"
-              />
-              <span className="pause-menu-volume-value">
-                {Math.round(settings.soundVolume * 100)}%
-              </span>
-            </div>
-
-            <button
-              className="pause-menu-back-btn"
-              onClick={() => setShowSettings(false)}
-              aria-label="Back to pause menu"
-            >
-              BACK
-            </button>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/src/components/ReactiveAudio.test.tsx
+++ b/src/components/ReactiveAudio.test.tsx
@@ -56,23 +56,25 @@ describe('ReactiveAudio', () => {
       'utf-8'
     );
     
-    // Check for guards before each setVolume() call
-    expect(sourceFile).toContain('const lowVol = v.low * AUDIO_CONFIG.ambient.lowVolume * master');
+    // Check for guards before each setVolume() call. Ambient stems scale by the
+    // `music` channel multiplier, SFX layers by the `sfx` channel multiplier
+    // (both layered on top of the biome/speed ducking).
+    expect(sourceFile).toContain('const lowVol = v.low * AUDIO_CONFIG.ambient.lowVolume * music');
     expect(sourceFile).toContain('if (isFinite(lowVol))');
     expect(sourceFile).toContain('ambientLowRef.current.setVolume(lowVol)');
-    
-    expect(sourceFile).toContain('const midVol = v.mid * AUDIO_CONFIG.ambient.midVolume * master');
+
+    expect(sourceFile).toContain('const midVol = v.mid * AUDIO_CONFIG.ambient.midVolume * music');
     expect(sourceFile).toContain('if (isFinite(midVol))');
     expect(sourceFile).toContain('ambientMidRef.current.setVolume(midVol)');
-    
-    expect(sourceFile).toContain('const highVol = v.high * AUDIO_CONFIG.ambient.highVolume * master');
+
+    expect(sourceFile).toContain('const highVol = v.high * AUDIO_CONFIG.ambient.highVolume * music');
     expect(sourceFile).toContain('if (isFinite(highVol))');
     expect(sourceFile).toContain('ambientHighRef.current.setVolume(highVol)');
-    
+
     expect(sourceFile).toContain('if (isFinite(rapidsVol))');
-    expect(sourceFile).toContain('sfxRapidsRef.current.setVolume(rapidsVol * master)');
-    
-    expect(sourceFile).toContain('const transitionVol = v.transition * master');
+    expect(sourceFile).toContain('sfxRapidsRef.current.setVolume(rapidsVol * sfx)');
+
+    expect(sourceFile).toContain('const transitionVol = v.transition * sfx');
     expect(sourceFile).toContain('if (isFinite(transitionVol))');
     expect(sourceFile).toContain('posTransitionRef.current.setVolume(transitionVol)');
   });

--- a/src/components/ReactiveAudio.tsx
+++ b/src/components/ReactiveAudio.tsx
@@ -366,23 +366,29 @@ export default function ReactiveAudio({
     if (!isFinite(v.coldWind)) v.coldWind = 0;
     if (!isFinite(v.iceCrack)) v.iceCrack = 0;
 
-    const master = AUDIO_CONFIG.masterVolume;
+    // Channel multipliers from the settings panel, layered on TOP of the ducking
+    // above (never an override). `AUDIO_CONFIG.masterVolume` remains the baseline
+    // mix constant; the store channels scale it. Read transiently from the
+    // AudioManager singleton so slider drags don't re-render this subtree.
+    const amMix = getAudioManager();
+    const music = AUDIO_CONFIG.masterVolume * (amMix?.getMusicVolume() ?? 1);
+    const sfx = AUDIO_CONFIG.masterVolume * (amMix?.getSfxVolume() ?? 1);
 
     // Set ambient layer volumes with guards
     if (ambientLowRef.current) {
-      const lowVol = v.low * AUDIO_CONFIG.ambient.lowVolume * master;
+      const lowVol = v.low * AUDIO_CONFIG.ambient.lowVolume * music;
       if (isFinite(lowVol)) {
         ambientLowRef.current.setVolume(lowVol);
       }
     }
     if (ambientMidRef.current) {
-      const midVol = v.mid * AUDIO_CONFIG.ambient.midVolume * master;
+      const midVol = v.mid * AUDIO_CONFIG.ambient.midVolume * music;
       if (isFinite(midVol)) {
         ambientMidRef.current.setVolume(midVol);
       }
     }
     if (ambientHighRef.current) {
-      const highVol = v.high * AUDIO_CONFIG.ambient.highVolume * master;
+      const highVol = v.high * AUDIO_CONFIG.ambient.highVolume * music;
       if (isFinite(highVol)) {
         ambientHighRef.current.setVolume(highVol);
       }
@@ -392,23 +398,23 @@ export default function ReactiveAudio({
         v.rapids *
         THREE.MathUtils.lerp(AUDIO_CONFIG.sfx.rapidsBaseVolume, AUDIO_CONFIG.sfx.rapidsMaxVolume, intensity);
       if (isFinite(rapidsVol)) {
-        sfxRapidsRef.current.setVolume(rapidsVol * master);
+        sfxRapidsRef.current.setVolume(rapidsVol * sfx);
       }
     }
     if (sfxWhooshRef.current) {
-      const whooshVol = v.whoosh * AUDIO_CONFIG.sfx.whooshMaxVolume * master;
+      const whooshVol = v.whoosh * AUDIO_CONFIG.sfx.whooshMaxVolume * sfx;
       if (isFinite(whooshVol)) {
         sfxWhooshRef.current.setVolume(whooshVol);
       }
     }
     if (sfxColdWindRef.current) {
-      const windVol = v.coldWind * master;
+      const windVol = v.coldWind * sfx;
       if (isFinite(windVol)) {
         sfxColdWindRef.current.setVolume(windVol);
       }
     }
     if (sfxIceCrackRef.current) {
-      const crackVol = v.iceCrack * master;
+      const crackVol = v.iceCrack * sfx;
       if (isFinite(crackVol)) {
         sfxIceCrackRef.current.setVolume(crackVol);
       }
@@ -434,7 +440,7 @@ export default function ReactiveAudio({
       // Harden: reset any NaN values back to 0
       if (!isFinite(v.transition)) v.transition = 0;
       
-      const transitionVol = v.transition * master;
+      const transitionVol = v.transition * sfx;
       if (isFinite(transitionVol)) {
         posTransitionRef.current.setVolume(transitionVol);
       }

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -1,8 +1,7 @@
 // src/components/StartMenu.tsx
 // Pre-game title screen with map select, start, and settings
 
-import React, { useMemo, useState } from 'react';
-import { useGameStore, type QualityPreset } from '../systems/GameState';
+import React, { useMemo } from 'react';
 import {
   formatDuration,
   isMapUnlocked,
@@ -20,14 +19,9 @@ interface StartMenuProps {
   onStart: (mapId: MapRegistryId) => void;
   selectedMapId: MapRegistryId;
   onSelectMap: (mapId: MapRegistryId) => void;
+  /** Open the full Options panel (audio, controls/rebinding, graphics). */
+  onOpenOptions: () => void;
 }
-
-const QUALITY_LABELS: Record<QualityPreset, string> = {
-  low: 'Low',
-  medium: 'Medium',
-  high: 'High',
-  ultra: 'Ultra',
-};
 
 const DIFFICULTY_LABELS: Record<MapMenuEntry['difficulty'], string> = {
   beginner: 'Beginner',
@@ -50,18 +44,11 @@ export const StartMenu: React.FC<StartMenuProps> = ({
   onStart,
   selectedMapId,
   onSelectMap,
+  onOpenOptions,
 }) => {
-  const [showSettings, setShowSettings] = useState(false);
-  const settings = useGameStore((s) => s.settings);
-  const setSettings = useGameStore((s) => s.setSettings);
-
   const completedMaps = useMemo(() => getCompletedMaps(), []);
   const lastMapId = useMemo(() => getLastMapId(), []);
   const maps = useMemo(() => listMapsForMenu(), []);
-
-  const handleQualityChange = (quality: QualityPreset) => {
-    setSettings({ quality });
-  };
 
   return (
     <div className="start-menu-overlay">
@@ -73,7 +60,7 @@ export const StartMenu: React.FC<StartMenuProps> = ({
           </p>
         </div>
 
-        {!showSettings ? (
+        {(
           <div className="start-menu-buttons">
             <div className="start-menu-map-select" role="listbox" aria-label="Select map">
               <div className="start-menu-map-select-label">Choose Map</div>
@@ -129,58 +116,10 @@ export const StartMenu: React.FC<StartMenuProps> = ({
 
             <button
               className="start-menu-settings-btn"
-              onClick={() => setShowSettings(true)}
-              aria-label="Open Settings"
+              onClick={onOpenOptions}
+              aria-label="Open Options"
             >
-              SETTINGS
-            </button>
-          </div>
-        ) : (
-          <div className="start-menu-settings" role="dialog" aria-label="Settings">
-            <h2 className="start-menu-settings-title">Settings</h2>
-
-            <div className="start-menu-setting-row">
-              <label className="start-menu-setting-label">Graphics Quality</label>
-              <div className="start-menu-quality-buttons">
-                {(Object.keys(QUALITY_LABELS) as QualityPreset[]).map((q) => (
-                  <button
-                    key={q}
-                    className={`start-menu-quality-btn ${settings.quality === q ? 'active' : ''}`}
-                    onClick={() => handleQualityChange(q)}
-                    aria-pressed={settings.quality === q}
-                  >
-                    {QUALITY_LABELS[q]}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div className="start-menu-setting-row">
-              <label className="start-menu-setting-label" htmlFor="volume-slider">
-                Sound Volume
-              </label>
-              <input
-                id="volume-slider"
-                type="range"
-                min={0}
-                max={1}
-                step={0.05}
-                value={settings.soundVolume}
-                onChange={(e) => setSettings({ soundVolume: parseFloat(e.target.value) })}
-                className="start-menu-slider"
-                aria-label="Sound volume"
-              />
-              <span className="start-menu-volume-value">
-                {Math.round(settings.soundVolume * 100)}%
-              </span>
-            </div>
-
-            <button
-              className="start-menu-back-btn"
-              onClick={() => setShowSettings(false)}
-              aria-label="Back to main menu"
-            >
-              BACK
+              OPTIONS
             </button>
           </div>
         )}

--- a/src/experience/InnerExperience.tsx
+++ b/src/experience/InnerExperience.tsx
@@ -17,6 +17,7 @@ import PillarDustVFX from '../components/Obstacles/PillarDustVFX';
 import PillarFragmentPool from '../components/Obstacles/PillarFragmentPool';
 import GhostReplayer from '../components/GhostReplayer';
 import { WaterReflectionLayer, WaterPhysicsEffects } from './WaterStack';
+import SettingsLookSync from '../ui/SettingsLookSync';
 import { useInnerExperience } from './hooks/useInnerExperience';
 import type { InnerExperienceProps } from './types';
 
@@ -66,7 +67,10 @@ export default function InnerExperience({
       {debug.isStageEnabled('physics') && (
         <Physics debug={state.isDebug || state.physicsDebugEnabled} gravity={[0, PHYSICS.GRAVITY, 0]}>
           {!state.noPointerLock && (
-            <PointerLockControls makeDefault onLock={() => {}} {...({ lockOnClick: true } as object)} />
+            <>
+              <PointerLockControls makeDefault onLock={() => {}} {...({ lockOnClick: true } as object)} />
+              <SettingsLookSync />
+            </>
           )}
 
           <VehicleMount

--- a/src/hooks/usePlayerControls.ts
+++ b/src/hooks/usePlayerControls.ts
@@ -19,6 +19,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useKeyboardControls } from '@react-three/drei';
 import * as THREE from 'three';
+import { useSettingsStore } from '../systems/useSettingsStore';
+import { bindingsToMouseMap, type SettingsAction } from '../systems/settingsDerive';
 
 export interface PlayerControls {
   /** Forward input (W / ArrowUp) */
@@ -66,6 +68,9 @@ export function usePlayerControls(camera?: THREE.Camera): PlayerControlVectors &
 
   // Refs for high-frequency keys — always fresh inside useFrame
   const extraKeysRef = useRef({ q: false, e: false, shift: false, alt: false });
+  // Pressed mouse buttons ('Mouse0'|'Mouse1'|'Mouse2') for mouse-bound actions
+  // (e.g. right-click-forward). Read transiently in getControls.
+  const mouseButtonsRef = useRef<Set<string>>(new Set());
   const [isPointerLocked, setIsPointerLocked] = useState(false);
 
   // Track pointer lock state (low frequency, OK to use state)
@@ -104,19 +109,65 @@ export function usePlayerControls(camera?: THREE.Camera): PlayerControlVectors &
     };
   }, []);
 
+  // Mouse-button bindings (right-click-forward etc.). Track pressed buttons and
+  // suppress the context menu while any mouse button is a binding so a bound
+  // right-click drives movement instead of popping the browser menu.
+  useEffect(() => {
+    const onMouseDown = (e: MouseEvent) => {
+      mouseButtonsRef.current.add(`Mouse${e.button}`);
+    };
+    const onMouseUp = (e: MouseEvent) => {
+      mouseButtonsRef.current.delete(`Mouse${e.button}`);
+    };
+    const clear = () => mouseButtonsRef.current.clear();
+    const onContextMenu = (e: MouseEvent) => {
+      const mouseMap = bindingsToMouseMap(useSettingsStore.getState().bindings);
+      if (Object.values(mouseMap).includes('Mouse2')) e.preventDefault();
+    };
+
+    window.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('blur', clear);
+    window.addEventListener('contextmenu', onContextMenu);
+    return () => {
+      window.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('blur', clear);
+      window.removeEventListener('contextmenu', onContextMenu);
+    };
+  }, []);
+
   // Imperative accessor — safe to call inside useFrame every tick
   const getControls = useCallback((): PlayerControls => {
     const keys = getKeys();
     const extra = extraKeysRef.current;
-    return {
+
+    // Base state from the drei KeyboardControls map (rebindable keys).
+    const state: Record<SettingsAction, boolean> = {
       forward: keys.forward ?? false,
       backward: keys.backward ?? false,
       leftward: keys.leftward ?? false,
       rightward: keys.rightward ?? false,
       jump: keys.jump ?? false,
-      sprint: extra.shift,
-      brake: false, // Reserved for future mapping
-      dodge: (keys as any).dodge || extra.alt,
+      // Sprint/dodge now flow through the rebindable map; keep the legacy raw
+      // Shift/Alt refs as a fallback so held modifiers still register.
+      sprint: (keys as Record<string, boolean>).sprint || extra.shift,
+      brake: (keys as Record<string, boolean>).brake ?? false,
+      dodge: (keys as Record<string, boolean>).dodge || extra.alt,
+    };
+
+    // Merge mouse-bound actions (e.g. right-click-forward).
+    const pressed = mouseButtonsRef.current;
+    if (pressed.size > 0) {
+      const mouseMap = bindingsToMouseMap(useSettingsStore.getState().bindings);
+      for (const action of Object.keys(mouseMap) as SettingsAction[]) {
+        const code = mouseMap[action];
+        if (code && pressed.has(code)) state[action] = true;
+      }
+    }
+
+    return {
+      ...state,
       paddleLeft: extra.q,
       paddleRight: extra.e,
       isPointerLocked,

--- a/src/style.css
+++ b/src/style.css
@@ -1215,3 +1215,236 @@ canvas {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* ==========================================================================
+   Settings / Options Panel (src/ui/SettingsPanel.tsx)
+   ========================================================================== */
+.settings-panel-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(0,10,25,0.92) 0%, rgba(0,5,15,0.96) 100%);
+  z-index: 200;
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.settings-panel {
+  background: rgba(0,0,0,0.6);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 20px;
+  padding: 28px 28px 20px;
+  max-width: 560px;
+  width: 100%;
+  max-height: 88vh;
+  overflow-y: auto;
+  color: #e5e7eb;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.5);
+}
+
+.settings-panel-loading {
+  text-align: center;
+  color: #9ca3af;
+  padding: 24px;
+}
+
+.settings-panel-title {
+  font-size: clamp(22px, 3.5vw, 30px);
+  font-weight: 800;
+  margin: 0 0 18px 0;
+  background: linear-gradient(135deg, #4fd1c7, #3b82f6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.settings-panel-section {
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+
+.settings-panel-section-title {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #7ec8ff;
+  margin: 0 0 12px 0;
+}
+
+.settings-panel-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.settings-panel-label {
+  flex: 0 0 150px;
+  font-size: 14px;
+  color: #cbd5e1;
+}
+
+.settings-panel-slider {
+  flex: 1;
+  min-width: 80px;
+  accent-color: #4fd1c7;
+}
+
+.settings-panel-value {
+  flex: 0 0 52px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  color: #9ca3af;
+}
+
+.settings-panel-toggle {
+  padding: 6px 16px;
+  border-radius: 8px;
+  border: 2px solid rgba(255,255,255,0.14);
+  background: transparent;
+  color: #9ca3af;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.settings-panel-toggle.on {
+  color: #7ec8ff;
+  border-color: rgba(126,200,255,0.45);
+  background: rgba(126,200,255,0.08);
+}
+
+.settings-panel-quality-buttons {
+  display: flex;
+  gap: 8px;
+  flex: 1;
+}
+.settings-panel-quality-btn {
+  flex: 1;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 2px solid rgba(255,255,255,0.12);
+  background: transparent;
+  color: #9ca3af;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.settings-panel-quality-btn.active {
+  color: #fff;
+  border-color: rgba(79,209,199,0.6);
+  background: rgba(79,209,199,0.12);
+}
+
+.settings-panel-note {
+  font-size: 12px;
+  color: #6b7280;
+  margin: 6px 0 0;
+}
+
+.settings-panel-bindings {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-panel-binding-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.settings-panel-binding-label {
+  flex: 0 0 150px;
+  font-size: 14px;
+  color: #cbd5e1;
+}
+.settings-panel-binding-controls {
+  display: flex;
+  gap: 6px;
+  flex: 1;
+}
+.settings-panel-binding-btn {
+  flex: 1;
+  min-width: 120px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 2px solid rgba(255,255,255,0.12);
+  background: rgba(255,255,255,0.03);
+  color: #e5e7eb;
+  font-family: ui-monospace, monospace;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.settings-panel-binding-btn:hover {
+  border-color: rgba(255,255,255,0.28);
+}
+.settings-panel-binding-btn.capturing {
+  border-color: #f59e0b;
+  color: #fbbf24;
+  background: rgba(245,158,11,0.1);
+}
+.settings-panel-unbind-btn {
+  flex: 0 0 auto;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 2px solid rgba(255,255,255,0.12);
+  background: transparent;
+  color: #9ca3af;
+  cursor: pointer;
+}
+.settings-panel-unbind-btn:hover {
+  border-color: rgba(255,255,255,0.28);
+  color: #fff;
+}
+.settings-panel-binding-error {
+  flex: 1 0 100%;
+  font-size: 12px;
+  color: #f87171;
+}
+
+.settings-panel-footer {
+  display: flex;
+  gap: 10px;
+  margin-top: 8px;
+}
+.settings-panel-reset-btn,
+.settings-panel-close-btn {
+  flex: 1;
+  padding: 12px 20px;
+  border-radius: 10px;
+  font-weight: 700;
+  cursor: pointer;
+  border: 2px solid rgba(255,255,255,0.12);
+  transition: all 0.15s ease;
+}
+.settings-panel-reset-btn {
+  background: transparent;
+  color: #9ca3af;
+}
+.settings-panel-reset-btn:hover {
+  border-color: rgba(248,113,113,0.5);
+  color: #fca5a5;
+}
+.settings-panel-close-btn {
+  background: linear-gradient(135deg, #4fd1c7, #3b82f6);
+  color: #fff;
+  border: none;
+}
+.settings-panel-close-btn:hover {
+  transform: translateY(-1px);
+}
+
+@media (max-width: 520px) {
+  .settings-panel-label,
+  .settings-panel-binding-label { flex-basis: 100%; }
+  .settings-panel-row { flex-wrap: wrap; }
+}

--- a/src/systems/AudioSystem.ts
+++ b/src/systems/AudioSystem.ts
@@ -112,7 +112,12 @@ export class AudioManager {
   private ambientTrack: THREE.Audio<AudioNode> | THREE.PositionalAudio | null = null;
   private isMuted: boolean = false;
   private masterVolume: number = 1.0;
-  
+  // Per-channel multipliers driven by the settings panel. Applied on TOP of the
+  // biome/speed ducking (never an override): master is the global listener gain,
+  // music scales ambient stems, sfx scales one-shots + reactive sfx layers.
+  private musicVolume: number = 1.0;
+  private sfxVolume: number = 1.0;
+
   // Category limits tracking
   private categoryCounts: Map<SoundCategory, number> = new Map();
   
@@ -268,8 +273,10 @@ export class AudioManager {
     // Set buffer
     source.setBuffer(buffer);
     
-    // Apply parametric controls
-    const finalVolume = Math.max(0, Math.min(1, volume * def.baseVolume * this.masterVolume));
+    // Apply parametric controls. Master is handled by the listener's global gain
+    // (setMasterVolume), so one-shots only scale by the SFX channel here to avoid
+    // squaring the master multiplier.
+    const finalVolume = Math.max(0, Math.min(1, volume * def.baseVolume * this.sfxVolume));
     const finalPitch = Math.max(0.5, Math.min(2.0, pitch * def.basePitch));
     const finalPlaybackRate = Math.max(0.5, Math.min(2.0, pitch)); // For pitch shifting
     
@@ -406,7 +413,7 @@ export class AudioManager {
       track.setVolume(0);
       
       const def = SOUND_LIBRARY[trackName];
-      const targetVol = (def?.baseVolume || 0.3) * this.masterVolume;
+      const targetVol = (def?.baseVolume || 0.3) * this.musicVolume;
       const fadeStart = Date.now();
       
       const fadeIn = () => {
@@ -429,9 +436,29 @@ export class AudioManager {
    */
   setMasterVolume(volume: number): void {
     this.masterVolume = Math.max(0, Math.min(1, volume));
-    this.listener.setMasterVolume(this.masterVolume);
+    if (!this.isMuted) {
+      this.listener.setMasterVolume(this.masterVolume);
+    }
   }
-  
+
+  /** Music-channel multiplier (ambient stems). Read transiently by ReactiveAudio. */
+  setMusicVolume(volume: number): void {
+    this.musicVolume = Math.max(0, Math.min(1, volume));
+  }
+
+  getMusicVolume(): number {
+    return this.musicVolume;
+  }
+
+  /** SFX-channel multiplier (one-shots + reactive sfx). Read transiently by ReactiveAudio. */
+  setSfxVolume(volume: number): void {
+    this.sfxVolume = Math.max(0, Math.min(1, volume));
+  }
+
+  getSfxVolume(): number {
+    return this.sfxVolume;
+  }
+
   /**
    * Mute/unmute all audio
    */

--- a/src/systems/settingsDerive.test.ts
+++ b/src/systems/settingsDerive.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_BINDINGS,
+  bindingsToDreiMap,
+  bindingsToMouseMap,
+  findConflict,
+  isReservedKeyCapture,
+  qualityToEffects,
+  settingsQualityToLOD,
+  SETTINGS_ACTIONS,
+  type Bindings,
+} from './settingsDerive';
+
+describe('bindingsToDreiMap', () => {
+  it('derives one drei entry per key-bound action, using event.code', () => {
+    const map = bindingsToDreiMap(DEFAULT_BINDINGS);
+    expect(map).toContainEqual({ name: 'forward', keys: ['KeyW'] });
+    expect(map).toContainEqual({ name: 'jump', keys: ['Space'] });
+    expect(map).toHaveLength(SETTINGS_ACTIONS.length);
+  });
+
+  it('excludes mouse-bound actions from the drei map', () => {
+    const bindings: Bindings = {
+      ...DEFAULT_BINDINGS,
+      forward: { kind: 'mouse', code: 'Mouse2' },
+    };
+    const map = bindingsToDreiMap(bindings);
+    expect(map.find((e) => e.name === 'forward')).toBeUndefined();
+    expect(map).toHaveLength(SETTINGS_ACTIONS.length - 1);
+  });
+
+  it('reflects a rebound key', () => {
+    const bindings: Bindings = {
+      ...DEFAULT_BINDINGS,
+      jump: { kind: 'key', code: 'KeyJ' },
+    };
+    expect(bindingsToDreiMap(bindings)).toContainEqual({ name: 'jump', keys: ['KeyJ'] });
+  });
+});
+
+describe('bindingsToMouseMap', () => {
+  it('captures right-click-forward as a mouse binding', () => {
+    const bindings: Bindings = {
+      ...DEFAULT_BINDINGS,
+      forward: { kind: 'mouse', code: 'Mouse2' },
+    };
+    expect(bindingsToMouseMap(bindings)).toEqual({ forward: 'Mouse2' });
+  });
+
+  it('is empty when there are no mouse bindings', () => {
+    expect(bindingsToMouseMap(DEFAULT_BINDINGS)).toEqual({});
+  });
+});
+
+describe('findConflict', () => {
+  it('detects a double-bound physical input', () => {
+    expect(findConflict(DEFAULT_BINDINGS, { kind: 'key', code: 'KeyS' })).toBe('backward');
+  });
+
+  it('ignores the excluded action', () => {
+    expect(
+      findConflict(DEFAULT_BINDINGS, { kind: 'key', code: 'KeyW' }, 'forward')
+    ).toBeNull();
+  });
+
+  it('returns null when free', () => {
+    expect(findConflict(DEFAULT_BINDINGS, { kind: 'key', code: 'KeyZ' })).toBeNull();
+  });
+});
+
+describe('isReservedKeyCapture', () => {
+  it('rejects Escape and function keys', () => {
+    expect(isReservedKeyCapture({ code: 'Escape' })).toBe(true);
+    expect(isReservedKeyCapture({ code: 'F5' })).toBe(true);
+  });
+
+  it('rejects Ctrl/Cmd combos', () => {
+    expect(isReservedKeyCapture({ code: 'KeyW', ctrlKey: true })).toBe(true);
+    expect(isReservedKeyCapture({ code: 'KeyT', metaKey: true })).toBe(true);
+  });
+
+  it('allows a bare modifier key as a binding', () => {
+    expect(isReservedKeyCapture({ code: 'ShiftLeft' })).toBe(false);
+    expect(isReservedKeyCapture({ code: 'ControlLeft', ctrlKey: true })).toBe(false);
+  });
+
+  it('allows normal keys', () => {
+    expect(isReservedKeyCapture({ code: 'KeyW' })).toBe(false);
+  });
+});
+
+describe('qualityToEffects', () => {
+  it('low strips the expensive effects', () => {
+    expect(qualityToEffects('low')).toMatchObject({
+      chromaticAberration: false,
+      godRays: false,
+      ssao: false,
+      bloom: true,
+      vignette: true,
+    });
+  });
+
+  it('med enables chromatic + god rays but not ssao', () => {
+    expect(qualityToEffects('med')).toMatchObject({ chromaticAberration: true, godRays: true, ssao: false });
+  });
+
+  it('high enables everything', () => {
+    expect(qualityToEffects('high')).toMatchObject({ godRays: true, ssao: true });
+  });
+});
+
+describe('settingsQualityToLOD', () => {
+  it('maps med → medium and passes low/high through', () => {
+    expect(settingsQualityToLOD('low')).toBe('low');
+    expect(settingsQualityToLOD('med')).toBe('medium');
+    expect(settingsQualityToLOD('high')).toBe('high');
+  });
+});

--- a/src/systems/settingsDerive.ts
+++ b/src/systems/settingsDerive.ts
@@ -1,0 +1,257 @@
+/**
+ * settingsDerive.ts — Pure helpers for the settings system.
+ *
+ * These functions are deliberately free of React, Zustand, and DOM state so
+ * they can be unit-tested without a GL context (see settingsDerive.test.ts).
+ *
+ * Responsibilities:
+ * - Canonical action list + default bindings.
+ * - `bindingsToDreiMap` — derive the <KeyboardControls map> array from bindings.
+ * - `qualityToEffects` — map a quality preset to which post effects are present.
+ * - Conflict detection + reserved-input rules for rebinding.
+ */
+
+import type { QualityPreset } from './GameState';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type VolumeChannel = 'master' | 'music' | 'sfx';
+
+/** Quality preset owned by the settings panel. Kept separate from the renderer's
+ *  QualityLevel ('low'|'medium'|'high'|'ultra') and mapped via settingsQualityToLOD. */
+export type SettingsQuality = 'low' | 'med' | 'high';
+
+/**
+ * A binding is NOT "a key" — right-click-forward is a mouse button. Always use
+ * the physical `event.code` for keys (never `event.key`, which scrambles under
+ * AZERTY/Dvorak), and a synthetic Mouse<button> code for mouse buttons.
+ */
+export type BindingKind = 'key' | 'mouse';
+export interface Binding {
+  kind: BindingKind;
+  /** `event.code` for keys (e.g. 'KeyW'); 'Mouse0'|'Mouse1'|'Mouse2' for buttons. */
+  code: string;
+}
+
+/** Rebindable actions — a subset that mirrors the drei KeyboardControls map. */
+export type SettingsAction =
+  | 'forward'
+  | 'backward'
+  | 'leftward'
+  | 'rightward'
+  | 'jump'
+  | 'sprint'
+  | 'brake'
+  | 'dodge';
+
+export const SETTINGS_ACTIONS: SettingsAction[] = [
+  'forward',
+  'backward',
+  'leftward',
+  'rightward',
+  'jump',
+  'sprint',
+  'brake',
+  'dodge',
+];
+
+export const ACTION_LABELS: Record<SettingsAction, string> = {
+  forward: 'Forward',
+  backward: 'Backward',
+  leftward: 'Strafe Left',
+  rightward: 'Strafe Right',
+  jump: 'Jump',
+  sprint: 'Sprint',
+  brake: 'Brake / Slide',
+  dodge: 'Dodge',
+};
+
+export type Bindings = Record<SettingsAction, Binding>;
+
+// ---------------------------------------------------------------------------
+// Defaults — mirror the historical hardcoded map in Experience.tsx.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_BINDINGS: Bindings = {
+  forward: { kind: 'key', code: 'KeyW' },
+  backward: { kind: 'key', code: 'KeyS' },
+  leftward: { kind: 'key', code: 'KeyA' },
+  rightward: { kind: 'key', code: 'KeyD' },
+  jump: { kind: 'key', code: 'Space' },
+  sprint: { kind: 'key', code: 'ShiftLeft' },
+  brake: { kind: 'key', code: 'ControlLeft' },
+  dodge: { kind: 'key', code: 'AltLeft' },
+};
+
+// ---------------------------------------------------------------------------
+// Reserved inputs — can never be captured.
+// ---------------------------------------------------------------------------
+
+/**
+ * Physical codes the browser owns or that the menu system needs. Capturing
+ * these would either be swallowed by the browser or break menu/pointer-lock
+ * handling.
+ */
+export const RESERVED_CODES: ReadonlySet<string> = new Set([
+  'Escape',
+  'Tab',
+  'F5',
+  'F11',
+  'F12',
+  'ContextMenu',
+  'MetaLeft',
+  'MetaRight',
+]);
+
+/**
+ * True when a keyboard capture event must be rejected: a reserved code, or a
+ * browser-owned modifier combo (Ctrl+W, Cmd+…) that we can't reliably intercept.
+ */
+export function isReservedKeyCapture(e: {
+  code: string;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+}): boolean {
+  if (RESERVED_CODES.has(e.code)) return true;
+  // Modifier keys pressed alone are fine as bindings (Shift/Ctrl/Alt sprint etc.),
+  // but Ctrl/Cmd + another key is a browser-owned combo.
+  const isModifierItself =
+    e.code.startsWith('Control') ||
+    e.code.startsWith('Shift') ||
+    e.code.startsWith('Alt') ||
+    e.code.startsWith('Meta');
+  if ((e.ctrlKey || e.metaKey) && !isModifierItself) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Conflict detection
+// ---------------------------------------------------------------------------
+
+export function bindingsEqual(a: Binding, b: Binding): boolean {
+  return a.kind === b.kind && a.code === b.code;
+}
+
+/**
+ * Returns the action already bound to `binding` (other than `exclude`), or null.
+ * Used by bindAction to reject/swap a double-bound physical input.
+ */
+export function findConflict(
+  bindings: Bindings,
+  binding: Binding,
+  exclude?: SettingsAction
+): SettingsAction | null {
+  for (const action of SETTINGS_ACTIONS) {
+    if (action === exclude) continue;
+    if (bindingsEqual(bindings[action], binding)) return action;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// drei <KeyboardControls> map derivation
+// ---------------------------------------------------------------------------
+
+export interface DreiKeyMapEntry {
+  name: string;
+  keys: string[];
+}
+
+/**
+ * Derive the drei KeyboardControls `map` from bindings. Only key-kind bindings
+ * are included — mouse bindings are handled separately by usePlayerControls,
+ * since drei's KeyboardControls only listens to the keyboard.
+ *
+ * Pure: changing the returned reference rebuilds drei's listeners with no custom
+ * event system.
+ */
+export function bindingsToDreiMap(bindings: Bindings): DreiKeyMapEntry[] {
+  const map: DreiKeyMapEntry[] = [];
+  for (const action of SETTINGS_ACTIONS) {
+    const b = bindings[action];
+    if (b.kind === 'key') {
+      map.push({ name: action, keys: [b.code] });
+    }
+  }
+  return map;
+}
+
+/** Mouse-bound actions, as `{ action: 'Mouse2' }`. Consumed by usePlayerControls. */
+export function bindingsToMouseMap(
+  bindings: Bindings
+): Partial<Record<SettingsAction, string>> {
+  const out: Partial<Record<SettingsAction, string>> = {};
+  for (const action of SETTINGS_ACTIONS) {
+    const b = bindings[action];
+    if (b.kind === 'mouse') out[action] = b.code;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Quality → post-effect presence (pure, tested)
+// ---------------------------------------------------------------------------
+
+export interface EffectPresence {
+  bloom: boolean;
+  vignette: boolean;
+  chromaticAberration: boolean;
+  godRays: boolean;
+  ssao: boolean;
+}
+
+/**
+ * Which post-processing effects are present for a quality preset. Effect
+ * *toggles* apply live; resolution/multisampling changes are deferred to reload.
+ */
+export function qualityToEffects(quality: SettingsQuality): EffectPresence {
+  switch (quality) {
+    case 'low':
+      return {
+        bloom: true,
+        vignette: true,
+        chromaticAberration: false,
+        godRays: false,
+        ssao: false,
+      };
+    case 'med':
+      return {
+        bloom: true,
+        vignette: true,
+        chromaticAberration: true,
+        godRays: true,
+        ssao: false,
+      };
+    case 'high':
+    default:
+      return {
+        bloom: true,
+        vignette: true,
+        chromaticAberration: true,
+        godRays: true,
+        ssao: true,
+      };
+  }
+}
+
+/** Map the settings-panel quality onto the renderer's LOD QualityPreset. */
+export function settingsQualityToLOD(quality: SettingsQuality): QualityPreset {
+  switch (quality) {
+    case 'low':
+      return 'low';
+    case 'med':
+      return 'medium';
+    case 'high':
+    default:
+      return 'high';
+  }
+}
+
+/** Human labels for the quality buttons. */
+export const QUALITY_LABELS: Record<SettingsQuality, string> = {
+  low: 'Low',
+  med: 'Medium',
+  high: 'High',
+};

--- a/src/systems/useSettingsStore.test.ts
+++ b/src/systems/useSettingsStore.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  useSettingsStore,
+  DEFAULT_SETTINGS,
+  migrateSettings,
+  createSafeStorage,
+} from './useSettingsStore';
+import { DEFAULT_BINDINGS } from './settingsDerive';
+
+const reset = () =>
+  useSettingsStore.setState({
+    masterVolume: DEFAULT_SETTINGS.masterVolume,
+    musicVolume: DEFAULT_SETTINGS.musicVolume,
+    sfxVolume: DEFAULT_SETTINGS.sfxVolume,
+    mouseSensitivity: DEFAULT_SETTINGS.mouseSensitivity,
+    invertY: DEFAULT_SETTINGS.invertY,
+    quality: DEFAULT_SETTINGS.quality,
+    bindings: { ...DEFAULT_BINDINGS },
+    _hasHydrated: false,
+  });
+
+beforeEach(reset);
+
+describe('defaults', () => {
+  it('start at documented values', () => {
+    const s = useSettingsStore.getState();
+    expect(s.masterVolume).toBe(1.0);
+    expect(s.musicVolume).toBe(0.8);
+    expect(s.sfxVolume).toBe(0.9);
+    expect(s.mouseSensitivity).toBe(1.0);
+    expect(s.invertY).toBe(false);
+    expect(s.quality).toBe('high');
+    expect(s.bindings.forward).toEqual({ kind: 'key', code: 'KeyW' });
+  });
+});
+
+describe('setters', () => {
+  it('setVolume clamps per channel', () => {
+    useSettingsStore.getState().setVolume('music', 0.3);
+    expect(useSettingsStore.getState().musicVolume).toBe(0.3);
+    useSettingsStore.getState().setVolume('master', 5);
+    expect(useSettingsStore.getState().masterVolume).toBe(1);
+    useSettingsStore.getState().setVolume('sfx', -1);
+    expect(useSettingsStore.getState().sfxVolume).toBe(0);
+  });
+
+  it('setSensitivity clamps to [0.1, 2.0]', () => {
+    useSettingsStore.getState().setSensitivity(10);
+    expect(useSettingsStore.getState().mouseSensitivity).toBe(2.0);
+    useSettingsStore.getState().setSensitivity(0);
+    expect(useSettingsStore.getState().mouseSensitivity).toBe(0.1);
+  });
+
+  it('setInvertY and setQuality mutate', () => {
+    useSettingsStore.getState().setInvertY(true);
+    expect(useSettingsStore.getState().invertY).toBe(true);
+    useSettingsStore.getState().setQuality('low');
+    expect(useSettingsStore.getState().quality).toBe('low');
+  });
+});
+
+describe('bindAction conflict handling', () => {
+  it('rebinds a free input', () => {
+    useSettingsStore.getState().bindAction('jump', { kind: 'key', code: 'KeyJ' });
+    expect(useSettingsStore.getState().bindings.jump).toEqual({ kind: 'key', code: 'KeyJ' });
+  });
+
+  it('swaps rather than double-binds a conflicting input', () => {
+    // Bind forward to backward's key (KeyS) → they swap.
+    useSettingsStore.getState().bindAction('forward', { kind: 'key', code: 'KeyS' });
+    const b = useSettingsStore.getState().bindings;
+    expect(b.forward).toEqual({ kind: 'key', code: 'KeyS' });
+    expect(b.backward).toEqual({ kind: 'key', code: 'KeyW' }); // got forward's old key
+  });
+
+  it('accepts a mouse binding for forward', () => {
+    useSettingsStore.getState().bindAction('forward', { kind: 'mouse', code: 'Mouse2' });
+    expect(useSettingsStore.getState().bindings.forward).toEqual({ kind: 'mouse', code: 'Mouse2' });
+  });
+
+  it('unbindAction restores the default', () => {
+    useSettingsStore.getState().bindAction('jump', { kind: 'key', code: 'KeyJ' });
+    useSettingsStore.getState().unbindAction('jump');
+    expect(useSettingsStore.getState().bindings.jump).toEqual(DEFAULT_BINDINGS.jump);
+  });
+});
+
+describe('resetToDefaults', () => {
+  it('restores every setting', () => {
+    const s = useSettingsStore.getState();
+    s.setVolume('master', 0.2);
+    s.setSensitivity(1.7);
+    s.setInvertY(true);
+    s.setQuality('low');
+    s.bindAction('jump', { kind: 'key', code: 'KeyJ' });
+    useSettingsStore.getState().resetToDefaults();
+    const after = useSettingsStore.getState();
+    expect(after.masterVolume).toBe(1.0);
+    expect(after.mouseSensitivity).toBe(1.0);
+    expect(after.invertY).toBe(false);
+    expect(after.quality).toBe('high');
+    expect(after.bindings.jump).toEqual(DEFAULT_BINDINGS.jump);
+  });
+});
+
+describe('migrateSettings — merge over defaults', () => {
+  it('backfills a missing action from defaults', () => {
+    const partial = {
+      masterVolume: 0.5,
+      bindings: { forward: { kind: 'key', code: 'KeyI' } }, // only one action present
+    };
+    const migrated = migrateSettings(partial, 0);
+    expect(migrated.masterVolume).toBe(0.5);
+    expect(migrated.bindings.forward).toEqual({ kind: 'key', code: 'KeyI' });
+    // Missing actions backfilled:
+    expect(migrated.bindings.jump).toEqual(DEFAULT_BINDINGS.jump);
+    expect(migrated.bindings.backward).toEqual(DEFAULT_BINDINGS.backward);
+  });
+
+  it('falls back entirely for corrupt/absent data', () => {
+    expect(migrateSettings(null, 0).quality).toBe('high');
+    expect(migrateSettings('garbage', 0).bindings.forward).toEqual(DEFAULT_BINDINGS.forward);
+  });
+
+  it('clamps out-of-range persisted numbers', () => {
+    const migrated = migrateSettings({ masterVolume: 9, mouseSensitivity: 99 }, 0);
+    expect(migrated.masterVolume).toBe(1);
+    expect(migrated.mouseSensitivity).toBe(2.0);
+  });
+});
+
+describe('rehydration merge — backfills missing actions on same-version data', () => {
+  it('a persisted v1 blob missing an action is backfilled after rehydrate', async () => {
+    const { rehydrateSettings } = await import('./useSettingsStore');
+    // Simulate a same-version (1) persisted blob that predates the `dodge` action.
+    const blob = {
+      state: {
+        masterVolume: 0.4,
+        bindings: {
+          forward: { kind: 'key', code: 'KeyI' },
+          // no `dodge` — must be backfilled from defaults, not left undefined
+        },
+      },
+      version: 1,
+    };
+    window.localStorage.setItem('watershed-settings', JSON.stringify(blob));
+    rehydrateSettings();
+    await Promise.resolve();
+    const s = useSettingsStore.getState();
+    expect(s.masterVolume).toBe(0.4);
+    expect(s.bindings.forward).toEqual({ kind: 'key', code: 'KeyI' });
+    expect(s.bindings.dodge).toEqual(DEFAULT_BINDINGS.dodge);
+    expect(s._hasHydrated).toBe(true);
+    window.localStorage.removeItem('watershed-settings');
+  });
+});
+
+describe('createSafeStorage — degrades to memory on throwing setItem', () => {
+  it('does not throw when the backend rejects setItem, and reads back from memory', () => {
+    const throwingSetItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+    const storage = createSafeStorage();
+    expect(() => storage.setItem('k', 'v')).not.toThrow();
+    // Value is retrievable from the in-memory fallback even though the backend failed.
+    expect(storage.getItem('k')).toBe('v');
+    throwingSetItem.mockRestore();
+  });
+});

--- a/src/systems/useSettingsStore.ts
+++ b/src/systems/useSettingsStore.ts
@@ -1,0 +1,306 @@
+/**
+ * useSettingsStore.ts — Dedicated, persisted player-settings store.
+ *
+ * WHY A SEPARATE STORE (settled decision, see the issue):
+ * - Isolates settings churn from GameState (which holds per-frame data like
+ *   speed/score) so a volume-slider drag can't re-render gameplay subscribers.
+ * - Matches the Zustand store pattern the codebase already runs.
+ * - All genuine complexity (conflict detection, migration, transient reads)
+ *   lives in the store *actions*, not in structure.
+ *
+ * PERSISTENCE:
+ * - Persisted to localStorage under 'watershed-settings' (version 1).
+ * - migrate() MERGES persisted state OVER DEFAULT_SETTINGS so a newly-added
+ *   action/setting is backfilled instead of dropped.
+ * - skipHydration + an explicit rehydrate() at app root, with a `_hasHydrated`
+ *   flag, kills the flash-of-defaults / SSR-style hydration mismatch.
+ * - The storage is wrapped so a throwing setItem (private mode / quota) degrades
+ *   to in-memory instead of crashing boot.
+ */
+
+import { create } from 'zustand';
+import { persist, createJSONStorage, type StateStorage } from 'zustand/middleware';
+import {
+  DEFAULT_BINDINGS,
+  findConflict,
+  type Binding,
+  type Bindings,
+  type SettingsAction,
+  type SettingsQuality,
+  type VolumeChannel,
+} from './settingsDerive';
+
+// ---------------------------------------------------------------------------
+// State + actions
+// ---------------------------------------------------------------------------
+
+export interface SettingsState {
+  masterVolume: number;
+  musicVolume: number;
+  sfxVolume: number;
+  /** Mouse-look multiplier, 0.1–2.0. */
+  mouseSensitivity: number;
+  invertY: boolean;
+  quality: SettingsQuality;
+  bindings: Bindings;
+  /** Flipped true once persisted state has rehydrated (or confirmed absent). */
+  _hasHydrated: boolean;
+}
+
+export interface SettingsActions {
+  setVolume: (channel: VolumeChannel, value: number) => void;
+  setSensitivity: (value: number) => void;
+  setInvertY: (value: boolean) => void;
+  setQuality: (quality: SettingsQuality) => void;
+  /**
+   * Bind a physical input to an action. Performs conflict detection: if the
+   * input is already bound to another action, the two are SWAPPED rather than
+   * allowing a double-bound physical input. No-ops on an unchanged binding.
+   */
+  bindAction: (action: SettingsAction, binding: Binding) => void;
+  unbindAction: (action: SettingsAction) => void;
+  resetToDefaults: () => void;
+  setHasHydrated: (value: boolean) => void;
+}
+
+export type SettingsStore = SettingsState & SettingsActions;
+
+const clamp = (v: number, lo: number, hi: number) =>
+  Math.max(lo, Math.min(hi, Number.isFinite(v) ? v : lo));
+
+export const DEFAULT_SETTINGS: SettingsState = {
+  masterVolume: 1.0,
+  musicVolume: 0.8,
+  sfxVolume: 0.9,
+  mouseSensitivity: 1.0,
+  invertY: false,
+  quality: 'high',
+  bindings: { ...DEFAULT_BINDINGS },
+  _hasHydrated: false,
+};
+
+// ---------------------------------------------------------------------------
+// Storage wrapper — degrade to in-memory on a throwing setItem.
+// ---------------------------------------------------------------------------
+
+export function createSafeStorage(): StateStorage {
+  const memory = new Map<string, string>();
+  let backendUsable = true;
+
+  const backend = (): Storage | null => {
+    if (typeof window === 'undefined') return null;
+    try {
+      return window.localStorage;
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    getItem: (name) => {
+      if (backendUsable) {
+        try {
+          const ls = backend();
+          if (ls) {
+            const v = ls.getItem(name);
+            if (v !== null) return v;
+          }
+        } catch {
+          backendUsable = false;
+        }
+      }
+      return memory.has(name) ? memory.get(name)! : null;
+    },
+    setItem: (name, value) => {
+      // Always keep an in-memory copy so reads work even if the backend fails.
+      memory.set(name, value);
+      if (!backendUsable) return;
+      try {
+        const ls = backend();
+        ls?.setItem(name, value);
+      } catch {
+        // Private mode / quota exceeded — stop touching the backend, keep memory.
+        backendUsable = false;
+      }
+    },
+    removeItem: (name) => {
+      memory.delete(name);
+      if (!backendUsable) return;
+      try {
+        backend()?.removeItem(name);
+      } catch {
+        backendUsable = false;
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Migration — merge persisted OVER defaults so missing keys are backfilled.
+// ---------------------------------------------------------------------------
+
+export function migrateSettings(
+  persisted: unknown,
+  _version: number
+): SettingsState {
+  const base: SettingsState = {
+    ...DEFAULT_SETTINGS,
+    bindings: { ...DEFAULT_BINDINGS },
+  };
+  if (!persisted || typeof persisted !== 'object') return base;
+
+  const p = persisted as Partial<SettingsState>;
+
+  // Merge bindings action-by-action so a newly-added action falls back to its
+  // default instead of being undefined.
+  const mergedBindings: Bindings = { ...DEFAULT_BINDINGS };
+  if (p.bindings && typeof p.bindings === 'object') {
+    for (const action of Object.keys(DEFAULT_BINDINGS) as SettingsAction[]) {
+      const candidate = (p.bindings as Partial<Bindings>)[action];
+      if (
+        candidate &&
+        (candidate.kind === 'key' || candidate.kind === 'mouse') &&
+        typeof candidate.code === 'string'
+      ) {
+        mergedBindings[action] = { kind: candidate.kind, code: candidate.code };
+      }
+    }
+  }
+
+  return {
+    masterVolume:
+      typeof p.masterVolume === 'number' ? clamp(p.masterVolume, 0, 1) : base.masterVolume,
+    musicVolume:
+      typeof p.musicVolume === 'number' ? clamp(p.musicVolume, 0, 1) : base.musicVolume,
+    sfxVolume:
+      typeof p.sfxVolume === 'number' ? clamp(p.sfxVolume, 0, 1) : base.sfxVolume,
+    mouseSensitivity:
+      typeof p.mouseSensitivity === 'number'
+        ? clamp(p.mouseSensitivity, 0.1, 2.0)
+        : base.mouseSensitivity,
+    invertY: typeof p.invertY === 'boolean' ? p.invertY : base.invertY,
+    quality:
+      p.quality === 'low' || p.quality === 'med' || p.quality === 'high'
+        ? p.quality
+        : base.quality,
+    bindings: mergedBindings,
+    // Never trust a persisted hydration flag.
+    _hasHydrated: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const VOLUME_KEY: Record<VolumeChannel, keyof SettingsState> = {
+  master: 'masterVolume',
+  music: 'musicVolume',
+  sfx: 'sfxVolume',
+};
+
+export const useSettingsStore = create<SettingsStore>()(
+  persist(
+    (set, get) => ({
+      ...DEFAULT_SETTINGS,
+      bindings: { ...DEFAULT_BINDINGS },
+
+      setVolume: (channel, value) =>
+        set({ [VOLUME_KEY[channel]]: clamp(value, 0, 1) } as Partial<SettingsState>),
+
+      setSensitivity: (value) => set({ mouseSensitivity: clamp(value, 0.1, 2.0) }),
+
+      setInvertY: (value) => set({ invertY: value }),
+
+      setQuality: (quality) => set({ quality }),
+
+      bindAction: (action, binding) =>
+        set((state) => {
+          const current = state.bindings[action];
+          if (
+            current &&
+            current.kind === binding.kind &&
+            current.code === binding.code
+          ) {
+            return {}; // no-op — already bound here
+          }
+          const conflict = findConflict(state.bindings, binding, action);
+          const next: Bindings = { ...state.bindings, [action]: { ...binding } };
+          if (conflict) {
+            // Swap: give the conflicting action this action's previous binding
+            // so no physical input is ever double-bound.
+            next[conflict] = { ...current };
+          }
+          return { bindings: next };
+        }),
+
+      unbindAction: (action) =>
+        set((state) => ({
+          bindings: { ...state.bindings, [action]: { ...DEFAULT_BINDINGS[action] } },
+        })),
+
+      resetToDefaults: () =>
+        set({
+          masterVolume: DEFAULT_SETTINGS.masterVolume,
+          musicVolume: DEFAULT_SETTINGS.musicVolume,
+          sfxVolume: DEFAULT_SETTINGS.sfxVolume,
+          mouseSensitivity: DEFAULT_SETTINGS.mouseSensitivity,
+          invertY: DEFAULT_SETTINGS.invertY,
+          quality: DEFAULT_SETTINGS.quality,
+          bindings: { ...DEFAULT_BINDINGS },
+        }),
+
+      setHasHydrated: (value) => set({ _hasHydrated: value }),
+    }),
+    {
+      name: 'watershed-settings',
+      version: 1,
+      storage: createJSONStorage(() => createSafeStorage()),
+      skipHydration: true,
+      migrate: (persisted, version) => migrateSettings(persisted, version),
+      // Custom merge so backfill-over-defaults runs on EVERY load, not only on a
+      // version bump: the default shallow merge would let a same-version persisted
+      // `bindings` object that predates a newly-added action leave that action
+      // undefined. migrateSettings normalizes + backfills against DEFAULT_SETTINGS.
+      merge: (persisted, current) => ({
+        ...current,
+        ...migrateSettings(persisted, 1),
+      }),
+      // Only persist the settings themselves, never the transient hydration flag.
+      partialize: (state) => ({
+        masterVolume: state.masterVolume,
+        musicVolume: state.musicVolume,
+        sfxVolume: state.sfxVolume,
+        mouseSensitivity: state.mouseSensitivity,
+        invertY: state.invertY,
+        quality: state.quality,
+        bindings: state.bindings,
+      }),
+      onRehydrateStorage: () => (state) => {
+        // Runs after rehydrate() resolves (success or failure).
+        state?.setHasHydrated(true);
+        useSettingsStore.setState({ _hasHydrated: true });
+      },
+    }
+  )
+);
+
+/**
+ * Rehydrate persisted settings. Call once in a client-only effect at app root.
+ * Safe to call more than once. Flips `_hasHydrated` via onRehydrateStorage.
+ */
+export function rehydrateSettings(): void {
+  const result = useSettingsStore.persist?.rehydrate?.();
+  // If rehydrate returned a promise, mark hydrated on settle as a belt-and-braces
+  // guard (older zustand may skip onRehydrateStorage when there is nothing stored).
+  if (result && typeof (result as Promise<unknown>).then === 'function') {
+    (result as Promise<unknown>).then(
+      () => useSettingsStore.getState().setHasHydrated(true),
+      () => useSettingsStore.getState().setHasHydrated(true)
+    );
+  } else {
+    useSettingsStore.getState().setHasHydrated(true);
+  }
+}
+
+export default useSettingsStore;

--- a/src/ui/SettingsLookSync.tsx
+++ b/src/ui/SettingsLookSync.tsx
@@ -1,0 +1,57 @@
+/**
+ * SettingsLookSync.tsx — Applies mouse-look settings to the active
+ * PointerLockControls. Mounted inside the R3F tree next to <PointerLockControls>.
+ *
+ * - Sensitivity → `controls.pointerSpeed` (native, live).
+ * - Invert-Y → a capture-phase mousemove that pre-rotates the camera pitch by
+ *   +2·Δy before PointerLockControls subtracts Δy, netting an inverted vertical.
+ *   PointerLockControls recomputes its euler from the (now pre-rotated) camera
+ *   quaternion each move, so the two compose cleanly with no custom controller.
+ *
+ * Settings are read transiently (getState) so slider drags never re-render the
+ * scene subtree.
+ */
+
+import { useEffect } from 'react';
+import { useThree, useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { useSettingsStore } from '../systems/useSettingsStore';
+
+const HALF_PI = Math.PI / 2;
+
+/* eslint-disable react-hooks/exhaustive-deps */
+
+export default function SettingsLookSync() {
+  const camera = useThree((s) => s.camera);
+  const controls = useThree((s) => s.controls) as
+    | (THREE.Object3D & { pointerSpeed?: number })
+    | null;
+
+  // Live sensitivity → pointerSpeed.
+  useFrame(() => {
+    if (controls && 'pointerSpeed' in controls) {
+      controls.pointerSpeed = useSettingsStore.getState().mouseSensitivity;
+    }
+  });
+
+  // Invert-Y counter-rotation.
+  useEffect(() => {
+    const euler = new THREE.Euler(0, 0, 0, 'YXZ');
+    const onMove = (e: MouseEvent) => {
+      if (!document.pointerLockElement) return;
+      const s = useSettingsStore.getState();
+      if (!s.invertY) return;
+      const movementY = e.movementY || 0;
+      if (movementY === 0) return;
+      euler.setFromQuaternion(camera.quaternion);
+      euler.x += 2 * movementY * 0.002 * s.mouseSensitivity;
+      euler.x = Math.max(-HALF_PI, Math.min(HALF_PI, euler.x));
+      camera.quaternion.setFromEuler(euler);
+    };
+    // Capture phase so we run before PointerLockControls' document handler.
+    window.addEventListener('mousemove', onMove, true);
+    return () => window.removeEventListener('mousemove', onMove, true);
+  }, [camera]);
+
+  return null;
+}

--- a/src/ui/SettingsPanel.test.tsx
+++ b/src/ui/SettingsPanel.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SettingsPanel } from './SettingsPanel';
+import { useSettingsStore, DEFAULT_SETTINGS } from '../systems/useSettingsStore';
+import { DEFAULT_BINDINGS } from '../systems/settingsDerive';
+
+beforeEach(() => {
+  useSettingsStore.setState({
+    masterVolume: DEFAULT_SETTINGS.masterVolume,
+    musicVolume: DEFAULT_SETTINGS.musicVolume,
+    sfxVolume: DEFAULT_SETTINGS.sfxVolume,
+    mouseSensitivity: DEFAULT_SETTINGS.mouseSensitivity,
+    invertY: DEFAULT_SETTINGS.invertY,
+    quality: DEFAULT_SETTINGS.quality,
+    bindings: { ...DEFAULT_BINDINGS },
+    _hasHydrated: true, // simulate post-hydration
+  });
+});
+
+describe('SettingsPanel', () => {
+  it('shows a loading state before hydration', () => {
+    useSettingsStore.setState({ _hasHydrated: false });
+    render(<SettingsPanel onClose={() => {}} />);
+    expect(screen.getByText(/loading settings/i)).toBeInTheDocument();
+  });
+
+  it('renders audio, controls, and graphics sections when hydrated', () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    expect(screen.getByLabelText('Master Volume')).toBeInTheDocument();
+    expect(screen.getByLabelText('Mouse Sensitivity')).toBeInTheDocument();
+    expect(screen.getByText('Quality')).toBeInTheDocument();
+  });
+
+  it('updates the store live when a slider changes', () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    const music = screen.getByLabelText('Music Volume') as HTMLInputElement;
+    fireEvent.change(music, { target: { value: '0.3' } });
+    expect(useSettingsStore.getState().musicVolume).toBeCloseTo(0.3);
+  });
+
+  it('toggles invert-Y', () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    const toggle = screen.getByRole('switch', { name: /invert y-axis/i });
+    fireEvent.click(toggle);
+    expect(useSettingsStore.getState().invertY).toBe(true);
+  });
+
+  it('changes quality live', () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Low' }));
+    expect(useSettingsStore.getState().quality).toBe('low');
+  });
+
+  it('captures a KEY binding via the capture widget', () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    fireEvent.click(screen.getByLabelText(/Rebind Jump/i));
+    // Next keydown becomes the binding.
+    fireEvent.keyDown(window, { code: 'KeyJ' });
+    expect(useSettingsStore.getState().bindings.jump).toEqual({ kind: 'key', code: 'KeyJ' });
+  });
+
+  it('captures a MOUSE binding via the capture widget', () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    fireEvent.click(screen.getByLabelText(/Rebind Forward/i));
+    fireEvent.mouseDown(window, { button: 2 });
+    expect(useSettingsStore.getState().bindings.forward).toEqual({ kind: 'mouse', code: 'Mouse2' });
+  });
+
+  it('refuses a reserved key and shows an error', () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    fireEvent.click(screen.getByLabelText(/Rebind Jump/i));
+    fireEvent.keyDown(window, { code: 'F5' });
+    expect(useSettingsStore.getState().bindings.jump).toEqual(DEFAULT_BINDINGS.jump);
+    expect(screen.getByRole('alert')).toHaveTextContent(/reserved/i);
+  });
+
+  it('dismisses back to the parent via onClose', () => {
+    const onClose = vi.fn();
+    render(<SettingsPanel onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ui/SettingsPanel.tsx
+++ b/src/ui/SettingsPanel.tsx
@@ -1,0 +1,295 @@
+/**
+ * SettingsPanel.tsx — Player-facing settings overlay.
+ *
+ * Reachable from StartMenu ("Options") and PauseMenu. Reads and writes the
+ * dedicated `useSettingsStore`. Panel and all setting application are gated on
+ * `_hasHydrated` to avoid a flash-of-defaults.
+ *
+ * CAPTURE WIDGET: drei has no "listen for next input" helper, so we build one.
+ * Capture runs in the UNLOCKED (normal DOM) state — the panel only mounts inside
+ * the menu/pause overlays, where the pointer is never locked — so a rebind never
+ * fights pointer-lock. A focused "Rebind" button records the next keydown OR
+ * mousedown as a Binding; reserved inputs are refused; Escape cancels capture.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  useSettingsStore,
+} from '../systems/useSettingsStore';
+import {
+  ACTION_LABELS,
+  QUALITY_LABELS,
+  SETTINGS_ACTIONS,
+  isReservedKeyCapture,
+  type Binding,
+  type SettingsAction,
+  type SettingsQuality,
+  type VolumeChannel,
+} from '../systems/settingsDerive';
+
+interface SettingsPanelProps {
+  /** Called when the player dismisses the panel (returns to the parent menu). */
+  onClose: () => void;
+}
+
+const MOUSE_LABELS: Record<string, string> = {
+  Mouse0: 'Left Click',
+  Mouse1: 'Middle Click',
+  Mouse2: 'Right Click',
+};
+
+function bindingLabel(binding: Binding): string {
+  if (binding.kind === 'mouse') return MOUSE_LABELS[binding.code] ?? binding.code;
+  // Friendly-ish label from event.code: 'KeyW' → 'W', 'ArrowUp' → 'Arrow Up'.
+  if (binding.code.startsWith('Key')) return binding.code.slice(3);
+  if (binding.code.startsWith('Digit')) return binding.code.slice(5);
+  if (binding.code === 'Space') return 'Space';
+  return binding.code.replace(/([a-z])([A-Z])/g, '$1 $2');
+}
+
+const VOLUME_CHANNELS: { channel: VolumeChannel; label: string }[] = [
+  { channel: 'master', label: 'Master' },
+  { channel: 'music', label: 'Music' },
+  { channel: 'sfx', label: 'SFX' },
+];
+
+/** Per-action key/mouse capture row. */
+const BindingRow: React.FC<{
+  action: SettingsAction;
+  binding: Binding;
+  capturing: boolean;
+  invalidMsg: string | null;
+  onBeginCapture: () => void;
+  onUnbind: () => void;
+}> = ({ action, binding, capturing, invalidMsg, onBeginCapture, onUnbind }) => (
+  <div className="settings-panel-binding-row">
+    <span className="settings-panel-binding-label">{ACTION_LABELS[action]}</span>
+    <div className="settings-panel-binding-controls">
+      <button
+        type="button"
+        className={`settings-panel-binding-btn ${capturing ? 'capturing' : ''}`}
+        onClick={onBeginCapture}
+        aria-label={`Rebind ${ACTION_LABELS[action]} (currently ${bindingLabel(binding)})`}
+      >
+        {capturing ? 'Press any key…' : bindingLabel(binding)}
+      </button>
+      <button
+        type="button"
+        className="settings-panel-unbind-btn"
+        onClick={onUnbind}
+        aria-label={`Reset ${ACTION_LABELS[action]} binding to default`}
+      >
+        ↺
+      </button>
+    </div>
+    {invalidMsg && (
+      <span className="settings-panel-binding-error" role="alert">
+        {invalidMsg}
+      </span>
+    )}
+  </div>
+);
+
+export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose }) => {
+  const hasHydrated = useSettingsStore((s) => s._hasHydrated);
+  const masterVolume = useSettingsStore((s) => s.masterVolume);
+  const musicVolume = useSettingsStore((s) => s.musicVolume);
+  const sfxVolume = useSettingsStore((s) => s.sfxVolume);
+  const mouseSensitivity = useSettingsStore((s) => s.mouseSensitivity);
+  const invertY = useSettingsStore((s) => s.invertY);
+  const quality = useSettingsStore((s) => s.quality);
+  const bindings = useSettingsStore((s) => s.bindings);
+
+  const setVolume = useSettingsStore((s) => s.setVolume);
+  const setSensitivity = useSettingsStore((s) => s.setSensitivity);
+  const setInvertY = useSettingsStore((s) => s.setInvertY);
+  const setQuality = useSettingsStore((s) => s.setQuality);
+  const bindAction = useSettingsStore((s) => s.bindAction);
+  const unbindAction = useSettingsStore((s) => s.unbindAction);
+  const resetToDefaults = useSettingsStore((s) => s.resetToDefaults);
+
+  const [capturing, setCapturing] = useState<SettingsAction | null>(null);
+  const [invalid, setInvalid] = useState<{ action: SettingsAction; msg: string } | null>(null);
+
+  const volumeByChannel: Record<VolumeChannel, number> = {
+    master: masterVolume,
+    music: musicVolume,
+    sfx: sfxVolume,
+  };
+
+  const beginCapture = useCallback((action: SettingsAction) => {
+    setInvalid(null);
+    setCapturing(action);
+  }, []);
+
+  // Listen for the next physical input while capturing.
+  useEffect(() => {
+    if (!capturing) return;
+    const action = capturing;
+
+    const finish = (binding: Binding) => {
+      bindAction(action, binding);
+      setCapturing(null);
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.code === 'Escape') {
+        setCapturing(null); // cancel
+        return;
+      }
+      if (isReservedKeyCapture(e)) {
+        setInvalid({ action, msg: 'That key is reserved.' });
+        setCapturing(null);
+        return;
+      }
+      finish({ kind: 'key', code: e.code });
+    };
+
+    const onMouseDown = (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      finish({ kind: 'mouse', code: `Mouse${e.button}` });
+    };
+
+    const onContextMenu = (e: MouseEvent) => e.preventDefault();
+
+    // Capture phase so we intercept before other handlers.
+    window.addEventListener('keydown', onKeyDown, true);
+    window.addEventListener('mousedown', onMouseDown, true);
+    window.addEventListener('contextmenu', onContextMenu, true);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown, true);
+      window.removeEventListener('mousedown', onMouseDown, true);
+      window.removeEventListener('contextmenu', onContextMenu, true);
+    };
+  }, [capturing, bindAction]);
+
+  if (!hasHydrated) {
+    return (
+      <div className="settings-panel" role="dialog" aria-label="Settings" aria-busy="true">
+        <p className="settings-panel-loading">Loading settings…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-panel" role="dialog" aria-label="Settings">
+      <h2 className="settings-panel-title">Options</h2>
+
+      <section className="settings-panel-section" aria-label="Audio">
+        <h3 className="settings-panel-section-title">Audio</h3>
+        {VOLUME_CHANNELS.map(({ channel, label }) => (
+          <div className="settings-panel-row" key={channel}>
+            <label className="settings-panel-label" htmlFor={`vol-${channel}`}>
+              {label} Volume
+            </label>
+            <input
+              id={`vol-${channel}`}
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={volumeByChannel[channel]}
+              onChange={(e) => setVolume(channel, parseFloat(e.target.value))}
+              className="settings-panel-slider"
+            />
+            <span className="settings-panel-value">
+              {Math.round(volumeByChannel[channel] * 100)}%
+            </span>
+          </div>
+        ))}
+      </section>
+
+      <section className="settings-panel-section" aria-label="Controls">
+        <h3 className="settings-panel-section-title">Controls</h3>
+
+        <div className="settings-panel-row">
+          <label className="settings-panel-label" htmlFor="sensitivity">
+            Mouse Sensitivity
+          </label>
+          <input
+            id="sensitivity"
+            type="range"
+            min={0.1}
+            max={2.0}
+            step={0.05}
+            value={mouseSensitivity}
+            onChange={(e) => setSensitivity(parseFloat(e.target.value))}
+            className="settings-panel-slider"
+          />
+          <span className="settings-panel-value">{mouseSensitivity.toFixed(2)}×</span>
+        </div>
+
+        <div className="settings-panel-row">
+          <label className="settings-panel-label" htmlFor="invert-y">
+            Invert Y-Axis
+          </label>
+          <button
+            id="invert-y"
+            type="button"
+            className={`settings-panel-toggle ${invertY ? 'on' : ''}`}
+            onClick={() => setInvertY(!invertY)}
+            role="switch"
+            aria-checked={invertY}
+          >
+            {invertY ? 'On' : 'Off'}
+          </button>
+        </div>
+
+        <div className="settings-panel-bindings">
+          {SETTINGS_ACTIONS.map((action) => (
+            <BindingRow
+              key={action}
+              action={action}
+              binding={bindings[action]}
+              capturing={capturing === action}
+              invalidMsg={invalid?.action === action ? invalid.msg : null}
+              onBeginCapture={() => beginCapture(action)}
+              onUnbind={() => unbindAction(action)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="settings-panel-section" aria-label="Graphics">
+        <h3 className="settings-panel-section-title">Graphics</h3>
+        <div className="settings-panel-row">
+          <label className="settings-panel-label">Quality</label>
+          <div className="settings-panel-quality-buttons">
+            {(Object.keys(QUALITY_LABELS) as SettingsQuality[]).map((q) => (
+              <button
+                key={q}
+                type="button"
+                className={`settings-panel-quality-btn ${quality === q ? 'active' : ''}`}
+                onClick={() => setQuality(q)}
+                aria-pressed={quality === q}
+              >
+                {QUALITY_LABELS[q]}
+              </button>
+            ))}
+          </div>
+        </div>
+        <p className="settings-panel-note">
+          Effect toggles apply immediately. Resolution changes apply on next map load.
+        </p>
+      </section>
+
+      <div className="settings-panel-footer">
+        <button
+          type="button"
+          className="settings-panel-reset-btn"
+          onClick={resetToDefaults}
+        >
+          Reset to Defaults
+        </button>
+        <button type="button" className="settings-panel-close-btn" onClick={onClose}>
+          Back
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsPanel;

--- a/src/ui/SettingsSync.tsx
+++ b/src/ui/SettingsSync.tsx
@@ -1,0 +1,62 @@
+/**
+ * SettingsSync.tsx — Headless bridge that applies persisted settings to the
+ * blind consumers (audio + graphics quality). DOM-level, no R3F required.
+ *
+ * - Audio: pushes master/music/SFX channel volumes into the AudioManager. Master
+ *   is the global listener gain; music/SFX are multipliers ReactiveAudio reads
+ *   transiently each frame, coexisting with the biome/speed ducking.
+ * - Graphics: maps the settings-panel quality preset onto the existing
+ *   GameState.settings.quality, which already drives LOD + post-processing LIVE
+ *   (LODManager syncs from it) — so effect toggles apply with no renderer churn.
+ *
+ * All application is gated on `_hasHydrated` to avoid a flash-of-defaults.
+ */
+
+import { useEffect } from 'react';
+import { useSettingsStore } from '../systems/useSettingsStore';
+import { settingsQualityToLOD } from '../systems/settingsDerive';
+import { getAudioManager } from '../systems/AudioSystem';
+import { useGameStore } from '../systems/GameState';
+
+export const SettingsSync: React.FC = () => {
+  const hasHydrated = useSettingsStore((s) => s._hasHydrated);
+  const masterVolume = useSettingsStore((s) => s.masterVolume);
+  const musicVolume = useSettingsStore((s) => s.musicVolume);
+  const sfxVolume = useSettingsStore((s) => s.sfxVolume);
+  const quality = useSettingsStore((s) => s.quality);
+
+  // Apply audio channels. The AudioManager is a singleton created when the
+  // experience mounts; if it isn't ready yet, retry on rAF until it is, then
+  // stop. Subsequent value changes re-run this effect and re-apply immediately.
+  useEffect(() => {
+    if (!hasHydrated) return;
+    let raf = 0;
+    let tries = 0;
+    const apply = () => {
+      const am = getAudioManager();
+      if (am) {
+        am.setMasterVolume(masterVolume);
+        am.setMusicVolume(musicVolume);
+        am.setSfxVolume(sfxVolume);
+        return;
+      }
+      if (tries++ < 600) raf = requestAnimationFrame(apply);
+    };
+    apply();
+    return () => cancelAnimationFrame(raf);
+  }, [hasHydrated, masterVolume, musicVolume, sfxVolume]);
+
+  // Apply graphics quality via the existing GameState plumbing.
+  useEffect(() => {
+    if (!hasHydrated) return;
+    const lodQuality = settingsQualityToLOD(quality);
+    const gs = useGameStore.getState();
+    if (gs.settings.quality !== lodQuality) {
+      gs.setSettings({ quality: lodQuality });
+    }
+  }, [hasHydrated, quality]);
+
+  return null;
+};
+
+export default SettingsSync;


### PR DESCRIPTION
## Summary

Adds a persistent, player-facing **Settings/Options panel** as the companion to the multi-map campaign UX (#297). A dedicated, isolated Zustand store (`useSettingsStore`) with `persist` owns audio, controls, and graphics settings — fully decoupled from map/biome/renderer internals.

### Pre-work findings (open questions resolved)
- **Keybind source:** drei `<KeyboardControls>` IS mounted at root (`Experience.tsx`) — that is the single source of truth, so rebinding = feeding a derived `map`. `usePlayerControls` *also* had raw `window` keydown listeners for sprint/dodge (using `e.key`, unrebindable) — routed through the store-derived map instead.
- **Stores:** `GameState` holds hot per-frame data → built a new isolated store as directed.
- **Audio:** `AudioSystem` had a `masterVolume` + `THREE.AudioListener` but no music/SFX split → introduced channel multipliers.
- **Post pipeline:** imperative `EffectComposer`; quality already drives effects live via `GameState.settings.quality` (LODManager syncs from it) → reused that plumbing, no renderer refactor.

## Phase 1 — Store & persistence
- `useSettingsStore` (`zustand/middleware` `persist`): master/music/sfx volume, mouse sensitivity, invert-Y, quality preset, and per-action bindings.
- `Binding = { kind: 'key' | 'mouse'; code }` — always `event.code` (physical), so AZERTY/Dvorak maps stay correct; right-click-forward is a real mouse binding (`Mouse2`).
- `name: 'watershed-settings'`, `version: 1`, `skipHydration` + explicit `rehydrate()` with a `_hasHydrated` gate (kills flash-of-defaults). `migrate()` **and** a custom `merge` backfill persisted state OVER `DEFAULT_SETTINGS`, so a newly-added action is filled in, not dropped — on every load, not only on a version bump.
- Storage wrapper degrades to **in-memory** when `setItem` throws (private mode / quota) instead of crashing boot.
- `bindAction` does conflict detection and **swaps** rather than double-binding a physical input; reserved inputs (Esc, F-keys, Ctrl/Cmd combos) can't be captured; unbind + reset-to-defaults.

## Phase 2 — UI (`src/ui/SettingsPanel.tsx`)
- Volume/sensitivity sliders, invert-Y + quality toggles, and a per-action **key/mouse capture widget** (records the next keydown/mousedown, unbind, global reset). Reachable via **Options** from StartMenu and PauseMenu (the old inline quality/volume mini-panels are replaced by this richer panel).

## Phase 3 — Consumer wiring (blind reads, no physics/renderer refactors)
- **Input:** drei map derived from bindings; `usePlayerControls` reads sprint/dodge/brake from the map and merges mouse-bound actions, suppressing `contextmenu` when `Mouse2` is bound.
- **Look:** `SettingsLookSync` drives `PointerLockControls.pointerSpeed` (sensitivity) and applies invert-Y via a capture-phase counter-rotation.
- **Audio:** `AudioManager` gains music/sfx channel multipliers applied **on top of** the existing biome/speed ducking (master stays the listener gain); `SettingsSync` pushes channel volumes live.
- **Graphics:** quality preset maps onto `GameState.settings.quality`, which already drives LOD + post-processing live — effect toggles apply immediately; resolution/multisampling changes are deferred-to-reload (labeled in the panel). Default preset == current behavior.

## Menu / pointer-lock safety
Open/close stays driven by `pointerlockchange` (ESC-safe). The panel renders only in the unlocked menu/paused state, so key/mouse capture never fights pointer lock. Closing from the pause menu lands on RESUME, which re-locks on the user's click (no silent re-lock).

## Tests
- **Store:** defaults, each setter, `migrate()`/`merge` backfill (missing action filled from defaults), throwing-storage → memory, `bindAction` conflict swap, reset.
- **Pure derivations:** `bindingsToDreiMap` (keyMap → drei map) and `qualityToEffects` (quality → effect presence).
- **UI:** SettingsPanel render, live slider→store, key AND mouse capture, reserved-key refusal, dismiss.
- `npm run typecheck` and `npx vitest run` both green (395 passing); production `vite build` succeeds.

## Behavior note
Bindings are one-per-action (WASD canonical, rebindable); the old duplicate arrow-key aliases are no longer in the default map, matching the single-binding rebind model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0157MwqvLbb9c7G9KEboza3W)_