### PR TITLE
Settings panel: wire KeyboardControls map and live post-effect toggles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Canvas } from '@react-three/fiber';
 import Experience from './Experience';
 import { Loader } from './components/Loader';
@@ -71,6 +71,10 @@ function App() {
   const [worldEnabled, setWorldEnabled] = useState(false);
   const [skipLoader, setSkipLoader] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const settingsOpenRef = useRef(settingsOpen);
+  useEffect(() => {
+    settingsOpenRef.current = settingsOpen;
+  }, [settingsOpen]);
   const debug = useDebugStages();
   const [selectedMapId, setSelectedMapId] = useState<MapRegistryId>(() => getActiveMapId());
   const [cleanTest, setCleanTestActive] = useState(() => isCleanTestMode());
@@ -203,7 +207,9 @@ function App() {
         try {
           const locked = !!document.pointerLockElement;
           setPhase((prev) => {
-            if (locked && prev === 'paused') return 'playing';
+            // Don't auto-resume while the Options panel is open — the player
+            // must dismiss settings and click RESUME (user gesture) to re-lock.
+            if (locked && prev === 'paused' && !settingsOpenRef.current) return 'playing';
             if (!locked && prev === 'playing') return 'paused';
             return prev;
           });

--- a/src/Experience.tsx
+++ b/src/Experience.tsx
@@ -46,18 +46,7 @@ export default function Experience({
   return (
     <>
       {isDebug && <Stats />}
-      <KeyboardControls
-        map={[
-          { name: 'forward', keys: ['ArrowUp', 'KeyW'] },
-          { name: 'backward', keys: ['ArrowDown', 'KeyS'] },
-          { name: 'leftward', keys: ['ArrowLeft', 'KeyA'] },
-          { name: 'rightward', keys: ['ArrowRight', 'KeyD'] },
-          { name: 'jump', keys: ['Space'] },
-          { name: 'sprint', keys: ['ShiftLeft', 'ShiftRight'] },
-          { name: 'brake', keys: ['ControlLeft', 'ControlRight'] },
-          { name: 'dodge', keys: ['AltLeft', 'AltRight'] },
-        ]}
-      >
+      <KeyboardControls map={keyboardMap}>
         <LODProvider initialQuality="high" enableAdaptive targetFPS={60}>
           <BiomeProvider initialBiome="canyonSummer" enableTimeOfDay={false}>
             <SunPositionProvider>

--- a/src/components/PostProcessingPipeline.jsx
+++ b/src/components/PostProcessingPipeline.jsx
@@ -13,6 +13,8 @@ import { useBiome } from '../systems/BiomeSystem';
 import { useSunPosition } from '../systems/SunPositionSystem';
 import { GOD_RAYS_SHADER, getGodRaySunColor } from '../systems/volumetric/VolumetricGodRays';
 import { useGameStore } from '../systems/GameState';
+import { useSettingsStore } from '../systems/useSettingsStore';
+import { qualityToEffects } from '../systems/settingsDerive';
 
 const CHROMATIC_ABERRATION_SHADER = {
   name: 'ChromaticAberrationShader',
@@ -186,6 +188,8 @@ export function PostProcessingPipeline({
   const { config } = useLOD();
   const { timeOfDay, currentBiome } = useBiome();
   const { sunWorldPosition } = useSunPosition();
+  const settingsQuality = useSettingsStore((s) => (s._hasHydrated ? s.quality : 'high'));
+  const effectPresence = useMemo(() => qualityToEffects(settingsQuality), [settingsQuality]);
 
   // Refs for smooth animation values
   const smoothed = useRef({
@@ -366,9 +370,21 @@ export function PostProcessingPipeline({
     smoothed.current.saturation += (targetSaturation - smoothed.current.saturation) * t;
     smoothed.current.vignetteBoost += (targetVignetteBoost - smoothed.current.vignetteBoost) * t;
 
-    // Apply to passes
+    // Apply to passes — effect *toggles* from the settings quality preset apply
+    // live via pass.enabled; resolution/multisampling stay on the LOD path.
+    if (passes.bloomPass) {
+      passes.bloomPass.enabled = effectPresence.bloom;
+    }
+    if (passes.vignettePass) {
+      passes.vignettePass.enabled = effectPresence.vignette;
+    }
+    if (passes.chromaticPass) {
+      passes.chromaticPass.enabled = effectPresence.chromaticAberration;
+    }
+
     if (passes.godRaysPass) {
       const shouldRenderGodRays =
+        effectPresence.godRays &&
         (isTightCanyon || waterfallBoost > 0.2) &&
         (quality === 'medium' || quality === 'high' || quality === 'ultra') &&
         (config.enableGodRays || quality === 'medium');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the consumer wiring for the persistent settings system (#297). Most of the store, UI, audio sync, and look-sync were already on `main`; this PR fixes the remaining integration gaps.

## Pre-work findings

| Area | Canonical source |
|------|------------------|
| **Keybinds** | `KeyboardControls` in `Experience.tsx` — vehicles read via `useKeyboardControls` + `usePlayerControls` (mouse bindings from store). UI menus keep their own `keydown` handlers for Enter/R/Esc shortcuts only. |
| **Stores** | `useSettingsStore` (persisted, isolated) + `GameState` (hot per-frame data) |
| **Audio** | `AudioManager.setMasterVolume` / `setMusicVolume` / `setSfxVolume`; `ReactiveAudio` applies music/SFX as multipliers on top of biome/speed ducking |
| **Post FX** | Imperative `EffectComposer` in `PostProcessingPipeline.jsx`; LOD quality drives resolution/reflection budgets via `SettingsSync` → `GameState` → `LODManager` |

## Changes

- **`Experience.tsx`** — Feed `bindingsToDreiMap(bindings)` into `<KeyboardControls map={…}>` instead of the hardcoded WASD map (rebinding now takes effect live).
- **`PostProcessingPipeline.jsx`** — Read `qualityToEffects` from `useSettingsStore` and toggle bloom / vignette / chromatic aberration / god-rays passes live via `pass.enabled`.
- **`App.tsx`** — Don't auto-resume from pause while the Options panel is open; player must dismiss settings and click **RESUME** (user gesture) to re-acquire pointer lock.

## Already on main (no changes needed)

- `useSettingsStore` with persist, migrate-over-defaults, safe storage, `_hasHydrated`
- `SettingsPanel` reachable from StartMenu + PauseMenu
- `SettingsSync` (audio + LOD quality) and `SettingsLookSync` (sensitivity / invert-Y)
- Vitest coverage for store, derive helpers, and panel UI

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (430 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c91fb31e-3e0a-486f-9361-9f8f92ace39c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c91fb31e-3e0a-486f-9361-9f8f92ace39c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

