### PR TITLE
Complete #313 foundation hardening — MapSystem split

### DIFF
--- a/docs/reference/TESTING.md
+++ b/docs/reference/TESTING.md
@@ -124,7 +124,7 @@ npm run typecheck
 
 **CI:** The Build workflow (`.github/workflows/build.yml`) runs a dedicated hard-fail **Typecheck** job (`pnpm typecheck`) on every `pull_request` and `push` to `main`. It is **not** `continue-on-error` and is separate from build/test so a red `tsc` shows up as its own check. Mark the GitHub check name **Typecheck** as a required status check on `main` so merges cannot skip it (repo currently has no branch protection — enable that in GitHub settings if unset).
 
-Registry/menu drift (e.g. adding a `MAP_REGISTRY` key without extending `MapRegistryId`) is also covered by `src/maps/registry.test.ts`.
+Registry/menu drift (e.g. adding a `MAP_REGISTRY` key without extending `MapRegistryId`) is covered by `src/maps/registry.contract.ts` (compile-time) and `src/maps/registry.contract.test.ts` (runtime). `src/maps/registry.test.ts` is a lighter second opinion.
 
 ### Unit Tests
 ```bash

--- a/src/systems/MapSystem.generation.ts
+++ b/src/systems/MapSystem.generation.ts
@@ -1,0 +1,467 @@
+/**
+ * MapSystem path/spawn generation — deterministic treadmill segment builders.
+ *
+ * Extracted from MapSystem.ts (issue #313). Re-exported from MapSystem.ts.
+ */
+
+import * as THREE from 'three';
+import { DEFAULT_BIOME_ID } from '../configs/biomes';
+import type {
+  BaseMapChunk,
+  MapConfig,
+  MapManager,
+  SegmentProgressionConfig,
+  SpawnData,
+} from './MapSystem.types';
+
+// =============================================================================
+// DEFAULT CONFIGURATION
+// =============================================================================
+
+export const DEFAULT_MAP_CONFIG: MapConfig = {
+  chunksAhead: 3,
+  chunksBehind: 1,
+  chunkLength: 40,
+  waterWidth: 10,
+  canyonWidth: 35,
+  baseFlowSpeed: 1.0,
+  maxSlope: 30,
+  seed: 12345,
+};
+
+/**
+ * Seed polyline used to derive segment 0's start point and tangent.
+ * The LAST point becomes segment 0's starting position (near player spawn).
+ */
+export const INITIAL_TREADMILL_POINTS = [
+  new THREE.Vector3(-4, -8, 90),
+  new THREE.Vector3(-2, -7, 60),
+  new THREE.Vector3(-1, -6.5, 30),
+  new THREE.Vector3(0, -6, 0),
+];
+
+export const DEFAULT_SEGMENT_PROGRESSION: SegmentProgressionConfig = {
+  biome: DEFAULT_BIOME_ID,
+  type: 'normal',
+  width: 35,
+  waterWidth: 10,
+  meanderStrength: 1.2,
+  verticalBias: -0.5,
+  flowSpeed: 1,
+  treeDensity: 1,
+  rockDensity: 'low',
+  slipperiness: 0,
+};
+
+// =============================================================================
+// CHUNK GENERATION UTILITIES
+// =============================================================================
+
+/**
+ * Seeded random number generator for reproducible chunks
+ */
+export class SeededRandom {
+  private seed: number;
+
+  constructor(seed: number) {
+    this.seed = seed;
+  }
+
+  next(): number {
+    this.seed = (this.seed * 9301 + 49297) % 233280;
+    return this.seed / 233280;
+  }
+
+  nextRange(min: number, max: number): number {
+    return min + this.next() * (max - min);
+  }
+
+  nextInt(min: number, max: number): number {
+    return Math.floor(this.nextRange(min, max + 1));
+  }
+}
+
+/**
+ * Generate a smooth river path with controlled meandering
+ * SWARM: Override this in biome-specific generators for different path styles
+ */
+export function generateRiverPath(
+  startPoint: THREE.Vector3,
+  startDirection: THREE.Vector3,
+  config: MapConfig,
+  seed: number,
+  meanderStrength: number = 1.0
+): THREE.Vector3[] {
+  const rng = new SeededRandom(seed);
+  const points: THREE.Vector3[] = [startPoint.clone()];
+
+  let currentPos = startPoint.clone();
+  let direction = startDirection.clone().normalize();
+
+  // Generate 4 control points for Catmull-Rom curve
+  for (let i = 0; i < 3; i++) {
+    // Meandering based on sine waves + randomness
+    const meanderPhase = seed + i * 0.5;
+    const turnFactor = Math.sin(meanderPhase) * meanderStrength * 0.3;
+
+    // Add random variation
+    direction.x += turnFactor + (rng.next() - 0.5) * 0.2;
+    direction.y += (rng.next() * 0.2 - 0.1); // Slight elevation changes
+
+    // Clamp upward slope
+    if (direction.y > -0.1) direction.y = -0.1;
+
+    // Ensure forward progress
+    if (direction.z > -0.3) direction.z = -0.3;
+
+    direction.normalize();
+
+    // Step forward
+    const stepDistance = config.chunkLength * (0.8 + rng.next() * 0.4);
+    const step = direction.clone().multiplyScalar(stepDistance);
+    currentPos.add(step);
+
+    points.push(currentPos.clone());
+  }
+
+  return points;
+}
+
+/**
+ * Generate a river path for a single treadmill segment.
+ *
+ * This is the ChunkManager-compatible variant of `generateRiverPath`:
+ * it uses the segment's authored progression (meanderStrength, verticalBias,
+ * type) and a configurable step distance to produce 4 Catmull-Rom control
+ * points that connect end-to-end with the previous segment.
+ */
+export function generateSegmentPath(
+  index: number,
+  startPoint: THREE.Vector3,
+  startDirection: THREE.Vector3,
+  progression: SegmentProgressionConfig,
+  seed: number,
+  options: {
+    stepCount?: number;
+    stepDistanceMin?: number;
+    stepDistanceMax?: number;
+  } = {}
+): THREE.Vector3[] {
+  const rng = new SeededRandom(seed);
+  const points: THREE.Vector3[] = [startPoint.clone()];
+
+  let currentPos = startPoint.clone();
+  let direction = startDirection.clone().normalize();
+
+  const meanderStrength = progression.meanderStrength ?? DEFAULT_SEGMENT_PROGRESSION.meanderStrength;
+  const verticalBias = progression.verticalBias ?? DEFAULT_SEGMENT_PROGRESSION.verticalBias;
+  const type = progression.type ?? DEFAULT_SEGMENT_PROGRESSION.type;
+
+  const stepCount = options.stepCount ?? 3;
+  const stepDistanceMin = options.stepDistanceMin ?? 30;
+  const stepDistanceMax = options.stepDistanceMax ?? 40;
+
+  for (let step = 0; step < stepCount; step += 1) {
+    const turnFactor = Math.sin(index * 0.5 + step) * meanderStrength;
+    direction.x += turnFactor * 0.3 + (rng.next() - 0.5) * 0.2;
+    direction.y += rng.next() * 0.2 + verticalBias * 0.2;
+
+    const maxUpward = type === 'pond' ? -0.01 : -0.1;
+    if (direction.y > maxUpward) direction.y = maxUpward;
+
+    direction.normalize();
+
+    if (type !== 'waterfall') {
+      if (direction.z > -0.5) direction.z = -0.5;
+    } else {
+      direction.z = -0.12;
+      direction.y = Math.min(direction.y, -0.92);
+    }
+
+    direction.normalize();
+
+    const distance = stepDistanceMin + rng.next() * (stepDistanceMax - stepDistanceMin);
+    currentPos.add(direction.clone().multiplyScalar(distance));
+    points.push(currentPos.clone());
+  }
+
+  return points;
+}
+
+/**
+ * Calculate spawn positions along a river path
+ * SWARM: Add new object types here
+ */
+export function calculateSpawns(
+  curve: THREE.CatmullRomCurve3,
+  chunkIndex: number,
+  config: MapConfig,
+  seed: number,
+  density: { trees: number; rocks: number; collectibles: number }
+): SpawnData[] {
+  const rng = new SeededRandom(seed + chunkIndex * 1000);
+  const spawns: SpawnData[] = [];
+
+  const pathLength = curve.getLength();
+  const steps = Math.floor(pathLength / 2); // Sample every 2 meters
+
+  for (let i = 0; i < steps; i++) {
+    const t = i / steps;
+    const point = curve.getPoint(t);
+    const tangent = curve.getTangent(t).normalize();
+    const up = new THREE.Vector3(0, 1, 0);
+    const binormal = new THREE.Vector3().crossVectors(tangent, up).normalize();
+
+    // Spawn on both sides
+    for (const side of [-1, 1]) {
+      const bankStart = config.waterWidth / 2;
+
+      // Trees
+      if (rng.next() < density.trees / steps) {
+        const dist = bankStart + 4 + rng.next() * 8;
+        const offset = binormal.clone().multiplyScalar(side * dist);
+        const pos = point.clone().add(offset);
+
+        // Height based on distance from center (bank slope)
+        const normalizedDist = Math.abs(side * dist) / (config.canyonWidth * 0.45);
+        const height = Math.pow(Math.max(0, normalizedDist), 2.5) * 12;
+        pos.y += height - 0.5;
+
+        spawns.push({
+          type: 'tree',
+          position: pos,
+          rotation: new THREE.Euler(0, rng.next() * Math.PI * 2, 0),
+          scale: new THREE.Vector3(1.5, 1.5, 1.5).multiplyScalar(1 + rng.next() * 0.5),
+          meta: { variant: rng.nextInt(0, 3) }
+        });
+      }
+
+      // Rocks (obstacles)
+      if (rng.next() < density.rocks / steps) {
+        const dist = bankStart + 1 + rng.next() * 4;
+        const offset = binormal.clone().multiplyScalar(side * dist);
+        const pos = point.clone().add(offset);
+
+        const normalizedDist = Math.abs(side * dist) / (config.canyonWidth * 0.45);
+        const height = Math.pow(Math.max(0, normalizedDist), 2.5) * 12;
+        pos.y += height;
+
+        spawns.push({
+          type: 'rock',
+          position: pos,
+          rotation: new THREE.Euler(
+            rng.next() * Math.PI,
+            rng.next() * Math.PI,
+            rng.next() * Math.PI
+          ),
+          scale: new THREE.Vector3(1, 1, 1).multiplyScalar(0.8 + rng.next() * 0.8),
+          meta: { collider: true }
+        });
+      }
+    }
+  }
+
+  return spawns;
+}
+
+/**
+ * Calculate spawn positions for a segment using its authored progression.
+ *
+ * Tree/rock counts are taken from `progression.decorations` when available
+ * (matching the JSON level format), otherwise derived from `treeDensity` /
+ * `rockDensity`. This is the shared helper used by both DefaultMapManager and
+ * JSONMapManager so spawn placement has a single deterministic source.
+ */
+export function calculateSegmentSpawns(
+  curve: THREE.CatmullRomCurve3,
+  progression: SegmentProgressionConfig,
+  index: number,
+  seed: number
+): SpawnData[] {
+  const rng = new SeededRandom(seed + index * 1000);
+  const spawns: SpawnData[] = [];
+
+  const pathLength = curve.getLength();
+  const steps = Math.max(1, Math.floor(pathLength / 2));
+
+  const canyonWidth = progression.width ?? DEFAULT_SEGMENT_PROGRESSION.width;
+  const waterWidth = progression.waterWidth ?? DEFAULT_SEGMENT_PROGRESSION.waterWidth;
+  const decorations = progression.decorations || {};
+
+  // Resolve counts. JSON-authored maps use integer decoration counts;
+  // procedural fallback uses treeDensity / rockDensity normalized to counts.
+  const treeCount =
+    typeof decorations.trees === 'number'
+      ? decorations.trees
+      : Math.round((progression.treeDensity ?? DEFAULT_SEGMENT_PROGRESSION.treeDensity) * 8);
+  const rockCount =
+    typeof decorations.rocks === 'number'
+      ? decorations.rocks
+      : progression.rockDensity === 'high'
+      ? 12
+      : progression.rockDensity === 'medium'
+      ? 6
+      : 2;
+
+  for (let i = 0; i < steps; i++) {
+    const t = i / steps;
+    const point = curve.getPoint(t);
+    const tangent = curve.getTangent(t).normalize();
+    const up = new THREE.Vector3(0, 1, 0);
+    const binormal = new THREE.Vector3().crossVectors(tangent, up).normalize();
+
+    for (const side of [-1, 1]) {
+      const bankStart = waterWidth / 2;
+
+      // Trees
+      const treeChance = treeCount / steps;
+      if (rng.next() < treeChance) {
+        const dist = bankStart + 4 + rng.next() * 8;
+        const offset = binormal.clone().multiplyScalar(side * dist);
+        const pos = point.clone().add(offset);
+
+        const normalizedDist = Math.abs(side * dist) / (canyonWidth * 0.45);
+        const height = Math.pow(Math.max(0, normalizedDist), 2.5) * 12;
+        pos.y += height - 0.5;
+
+        spawns.push({
+          type: 'tree',
+          position: pos,
+          rotation: new THREE.Euler(0, rng.next() * Math.PI * 2, 0),
+          scale: new THREE.Vector3(1.5, 1.5, 1.5).multiplyScalar(1 + rng.next() * 0.5),
+          meta: { variant: rng.nextInt(0, 3) }
+        });
+      }
+
+      // Rocks
+      const rockChance = rockCount / steps;
+      if (rng.next() < rockChance) {
+        const dist = bankStart + 1 + rng.next() * 4;
+        const offset = binormal.clone().multiplyScalar(side * dist);
+        const pos = point.clone().add(offset);
+
+        const normalizedDist = Math.abs(side * dist) / (canyonWidth * 0.45);
+        const height = Math.pow(Math.max(0, normalizedDist), 2.5) * 12;
+        pos.y += height;
+
+        spawns.push({
+          type: 'rock',
+          position: pos,
+          rotation: new THREE.Euler(
+            rng.next() * Math.PI,
+            rng.next() * Math.PI,
+            rng.next() * Math.PI
+          ),
+          scale: new THREE.Vector3(1, 1, 1).multiplyScalar(0.8 + rng.next() * 0.8),
+          meta: { collider: true }
+        });
+      }
+    }
+  }
+
+  return spawns;
+}
+
+// =============================================================================
+// TREADMILL SEGMENT BUILDER (shared by ChunkManager + DefaultMapManager)
+// =============================================================================
+
+function createSegmentCurve(
+  points: THREE.Vector3[],
+  type: SegmentProgressionConfig['type'],
+): THREE.CatmullRomCurve3 {
+  const tension = type === 'pond' ? 0.1 : 0.5;
+  return new THREE.CatmullRomCurve3(points, false, 'catmullrom', tension);
+}
+
+/**
+ * Forces the new segment's start tangent to match the previous segment's end
+ * tangent. Eliminates NaNs in Catmull-Rom derivative math at segment joints.
+ */
+export function ensureTangentContinuity(
+  prevPoints: THREE.Vector3[],
+  newPoints: THREE.Vector3[],
+): THREE.Vector3[] {
+  if (!prevPoints || prevPoints.length < 2 || newPoints.length < 2) {
+    return newPoints;
+  }
+
+  const lastTwo = prevPoints.slice(-2);
+  const prevTangent = new THREE.Vector3()
+    .subVectors(lastTwo[1], lastTwo[0])
+    .normalize();
+
+  if (!prevTangent.lengthSq() || !isFinite(prevTangent.x)) {
+    console.warn('[ensureTangentContinuity] Invalid previous tangent, skipping');
+    return newPoints;
+  }
+
+  const desiredStart = newPoints[0].clone().add(prevTangent.multiplyScalar(0.01));
+  newPoints[0] = desiredStart;
+  return newPoints;
+}
+
+export interface BuildProceduralSegmentOptions {
+  seed?: number;
+  baseSeed?: number;
+  ensureContinuity?: boolean;
+  initialPoints?: THREE.Vector3[];
+}
+
+/**
+ * Build a single treadmill segment using MapManager progression config and
+ * deterministic SeededRandom path/spawn placement.
+ */
+export function buildProceduralSegment(
+  index: number,
+  previousPoints: THREE.Vector3[] | null,
+  mapManager: MapManager,
+  options: BuildProceduralSegmentOptions = {},
+): { chunk: BaseMapChunk; progression: SegmentProgressionConfig } {
+  const progression = mapManager.getChunkConfig(index);
+  const baseSeed = options.baseSeed ?? DEFAULT_MAP_CONFIG.seed;
+  const seed = options.seed ?? baseSeed + index * 1000;
+  const initialPoints = options.initialPoints ?? INITIAL_TREADMILL_POINTS;
+
+  const lastPoints = previousPoints ?? initialPoints;
+  const lastPoint = lastPoints[lastPoints.length - 1].clone();
+  const prevPoint = (lastPoints[lastPoints.length - 2] ?? initialPoints[0]).clone();
+  const startDirection = new THREE.Vector3().subVectors(lastPoint, prevPoint).normalize();
+
+  let points = generateSegmentPath(index, lastPoint, startDirection, progression, seed);
+
+  if (options.ensureContinuity && previousPoints) {
+    points = ensureTangentContinuity(previousPoints, points);
+  }
+
+  const curve = createSegmentCurve(points, progression.type);
+  const pathLength = curve.getLength();
+  const centerPoint = curve.getPoint(0.5);
+  const spawns = calculateSegmentSpawns(curve, progression, index, seed);
+
+  const chunk: BaseMapChunk = {
+    id: `chunk-${index}`,
+    index,
+    position: centerPoint,
+    pathPoints: points,
+    curve,
+    length: pathLength,
+    biome: progression.biome,
+    flowSpeed: progression.flowSpeed,
+    waterLevel: 0.5,
+    waterWidth: progression.waterWidth,
+    canyonWidth: progression.width,
+    spawns,
+    config:
+      progression.decorations || progression.launchShelf || progression.openFloor
+        ? {
+            decorations: progression.decorations,
+            launchShelf: progression.launchShelf,
+            openFloor: progression.openFloor,
+          }
+        : undefined,
+    active: true,
+  };
+
+  return { chunk, progression };
+}

--- a/src/systems/MapSystem.ts
+++ b/src/systems/MapSystem.ts
@@ -1,752 +1,66 @@
 /**
  * MapSystem.ts - Core map chunk management for Watershed
- * 
+ *
  * RESPONSIBILITIES:
  * - Define base chunk interface for all biomes
  * - Handle chunk lifecycle (load/update/unload)
  * - Coordinate chunk treadmill based on player position
  * - Load and parse JSON level files
- * 
+ *
+ * Types and path/spawn generation live in sibling modules and are re-exported
+ * here so existing `from '../systems/MapSystem'` imports stay stable.
+ *
  * SWARM: Extend BaseMapChunk for new biome-specific data
  */
 
 import * as THREE from 'three';
-import type { RapierRigidBody } from '@react-three/rapier';
+import { normalizeBiomeId } from '../configs/biomes';
+import type {
+  BaseMapChunk,
+  LevelData,
+  LevelSegment,
+  MapConfig,
+  MapManager,
+  SegmentProgressionConfig,
+  SegmentRange,
+} from './MapSystem.types';
 import {
-  type BiomeId,
-  DEFAULT_BIOME_ID,
-  normalizeBiomeId,
-} from '../configs/biomes';
-
-// =============================================================================
-// JSON LEVEL FORMAT INTERFACES
-// =============================================================================
-
-export interface LevelMetadata {
-  name: string;
-  author: string;
-  description?: string;
-  difficulty: 'beginner' | 'intermediate' | 'expert' | 'custom';
-  estimatedDuration: number;
-  version: string;
-  tags?: string[];
-}
-
-export interface LevelWorld {
-  track: {
-    waypoints: number[][];
-    segmentLength: number;
-    totalSegments: number;
-    width?: number;
-    wallHeight?: number;
-  };
-  biome: {
-    baseType: string;
-    sky: { color: string; cloudDensity?: number; cloudColor?: string };
-    fog: { color: string; near: number; far: number; density?: number };
-    lighting: {
-      sunIntensity: number;
-      sunAngle: number;
-      sunColor?: string;
-      ambientIntensity?: number;
-      hemiSkyColor?: string;
-      hemiGroundColor?: string;
-    };
-    water: { tint: string; flowSpeed: number; opacity?: number; surfaceRoughness?: number };
-  };
-}
-
-export interface DecorationPlacement {
-  localX: number;
-  localZ: number;
-  scale?: number;
-  rotation?: number;
-  rockType?: 'boulder' | 'slab' | 'column';
-}
-
-export interface LevelSegment {
-  index: number;
-  name?: string;
-  type?: 'normal' | 'waterfall' | 'pond' | 'splash' | 'rapids';
-  biomeOverride?: string;
-  difficulty: number;
-  width?: number;
-  waterWidth?: number;
-  lengthMultiplier?: number;
-  meanderStrength?: number;
-  verticalBias?: number;
-  forwardMomentum?: number;
-  decorations?: Record<string, number | DecorationPlacement[]>;
-  physics?: {
-    gravityMultiplier?: number;
-    waterFlowIntensity?: number;
-    friction?: number;
-    restitution?: number;
-  };
-  safeZone?: { yMin: number; yMax: number; respawnAt?: number };
-  effects?: {
-    particleCount?: number;
-    cameraShake?: number;
-    fogDensity?: number;
-    transitionDuration?: number;
-  };
-  launchShelf?: LaunchShelfConfig;
-  journeyComplete?: boolean;
-  slipperiness?: number;
-  treeDensity?: number;
-  rockDensity?: 'low' | 'medium' | 'high';
-  /**
-   * When true, TrackSegment skips the floor trimesh collider so the player
-   * flies an air corridor (gap / broken trestle set-pieces).
-   */
-  openFloor?: boolean;
-}
-
-export interface LevelSpawns {
-  start: {
-    position: number[];
-    rotation?: number[];
-    velocity?: number[];
-  };
-  checkpoints?: Array<{
-    segment: number;
-    position: number[];
-    radius?: number;
-  }>;
-}
-
-export interface LevelData {
-  metadata: LevelMetadata;
-  world: LevelWorld;
-  segments: LevelSegment[];
-  spawns: LevelSpawns;
-  decorationPools?: Record<string, string[]>;
-}
-
-// =============================================================================
-// CORE INTERFACES
-// =============================================================================
-
-export interface BaseMapChunk {
-  /** Unique chunk identifier */
-  id: string;
-  /** Chunk sequence number (0 = start) */
-  index: number;
-  /** World-space center position */
-  position: THREE.Vector3;
-  /** Bezier/Catmull-Rom path points for river flow */
-  pathPoints: THREE.Vector3[];
-  /** Path curve (computed from pathPoints) */
-  curve?: THREE.CatmullRomCurve3;
-  /** Chunk length along Z axis */
-  length: number;
-  /** Canonical biome identifier */
-  biome: BiomeId;
-  /** Flow speed multiplier (1.0 = normal) */
-  flowSpeed: number;
-  /** Water surface Y level */
-  waterLevel: number;
-  /** River width at water surface */
-  waterWidth: number;
-  /** Total canyon width (including banks) */
-  canyonWidth: number;
-  /** Pre-calculated spawn data for objects */
-  spawns: SpawnData[];
-  /** Authored decoration / launch-shelf / gap config passed through to TrackSegment */
-  config?: {
-    decorations?: Record<string, number | DecorationPlacement[]>;
-    launchShelf?: LaunchShelfConfig;
-    openFloor?: boolean;
-  };
-  /** Reference to physics collider */
-  collider?: RapierRigidBody;
-  /** Is this chunk currently visible/active */
-  active: boolean;
-}
-
-export interface SpawnData {
-  /** Object type identifier */
-  type: string;
-  /** Spawn position */
-  position: THREE.Vector3;
-  /** Spawn rotation */
-  rotation: THREE.Euler;
-  /** Spawn scale */
-  scale: THREE.Vector3;
-  /** Additional type-specific data */
-  meta?: Record<string, any>;
-}
-
-export interface MapConfig {
-  /** Number of chunks to keep ahead of player */
-  chunksAhead: number;
-  /** Number of chunks to keep behind player */
-  chunksBehind: number;
-  /** Base chunk length in meters */
-  chunkLength: number;
-  /** River width at water level */
-  waterWidth: number;
-  /** Total canyon width */
-  canyonWidth: number;
-  /** Default flow speed */
-  baseFlowSpeed: number;
-  /** Maximum slope angle (degrees) */
-  maxSlope: number;
-  /** Seed for reproducible generation */
-  seed: number;
-}
-
-// =============================================================================
-// DEFAULT CONFIGURATION
-// =============================================================================
-
-export const DEFAULT_MAP_CONFIG: MapConfig = {
-  chunksAhead: 3,
-  chunksBehind: 1,
-  chunkLength: 40,
-  waterWidth: 10,
-  canyonWidth: 35,
-  baseFlowSpeed: 1.0,
-  maxSlope: 30,
-  seed: 12345,
-};
-
-/**
- * Seed polyline used to derive segment 0's start point and tangent.
- * The LAST point becomes segment 0's starting position (near player spawn).
- */
-export const INITIAL_TREADMILL_POINTS = [
-  new THREE.Vector3(-4, -8, 90),
-  new THREE.Vector3(-2, -7, 60),
-  new THREE.Vector3(-1, -6.5, 30),
-  new THREE.Vector3(0, -6, 0),
-];
-
-// =============================================================================
-// SEGMENT PROGRESSION CONFIG
-// =============================================================================
-
-/**
- * Per-segment configuration consumed by TrackManager to drive treadmill generation.
- * This is intentionally separate from BaseMapChunk: it is a lightweight config
- * object that describes HOW a segment should be built, not the built geometry.
- */
-export interface LaunchShelfConfig {
-  /** Reference to the authored rock that acts as the launch shelf.
-   *  The trigger zone is derived from this rock's local placement. */
-  rockRef: {
-    localX: number;
-    localZ: number;
-    scale: number;
-  };
-  /** Trigger box half-extents in meters. */
-  triggerHalfWidth: number;
-  triggerHalfLength: number;
-  triggerHeight: number;
-  /** Distance downstream from the rock center to the trigger plane. */
-  triggerDownstreamOffset: number;
-  /** Vertical offset of the trigger center above the path surface. */
-  triggerYOffset: number;
-}
-
-export interface SegmentProgressionConfig {
-  biome: BiomeId;
-  type: 'normal' | 'waterfall' | 'splash' | 'pond' | 'rapids';
-  width: number;
-  waterWidth: number;
-  meanderStrength: number;
-  verticalBias: number;
-  flowSpeed: number;
-  treeDensity: number;
-  rockDensity: 'low' | 'medium' | 'high';
-  forwardMomentum?: number;
-  particleCount?: number;
-  cameraShake?: number;
-  /** Per-segment gravity scale applied to the Rapier world (1.0 = normal). */
-  gravityMultiplier?: number;
-  /** When true, entering this segment triggers the journey-complete sequence. */
-  journeyComplete?: boolean;
-  /** Authored decoration positions (array) or procedural density counts (number). */
-  decorations?: Record<string, number | DecorationPlacement[]>;
-  /** Optional launch-shelf gameplay trigger for waterfall set-pieces. */
-  launchShelf?: LaunchShelfConfig;
-  /**
-   * When true, the segment is an air corridor — no floor trimesh collider.
-   * Pair with a splash/pond landing segment for a playable gap jump.
-   */
-  openFloor?: boolean;
-  /**
-   * Surface slipperiness 0–1. 0 = normal grip, 1 = frictionless ice.
-   * Consumed by WaterFlowForces / RaftVehicle to reduce lateral drag and
-   * add a persistent downstream slide bias when > 0.
-   * TODO: wire into Rapier contact material override per segment.
-   */
-  slipperiness?: number;
-}
-
-export const DEFAULT_SEGMENT_PROGRESSION: SegmentProgressionConfig = {
-  biome: DEFAULT_BIOME_ID,
-  type: 'normal',
-  width: 35,
-  waterWidth: 10,
-  meanderStrength: 1.2,
-  verticalBias: -0.5,
-  flowSpeed: 1,
-  treeDensity: 1,
-  rockDensity: 'low',
-  slipperiness: 0,
-};
-
-/**
- * A single entry in a segment-progression override table.
- * Ranges are inclusive on both ends. If `indexTo` is omitted, the entry
- * matches all indices >= indexFrom (open-ended catch-all).
- * getChunkConfig uses "first match wins" — place more-specific ranges before
- * broader ones in the array.
- */
-export interface SegmentRange {
-  indexFrom: number;
-  indexTo?: number;
-  config: Partial<SegmentProgressionConfig>;
-}
-
-// =============================================================================
-// CHUNK GENERATION UTILITIES
-// =============================================================================
-
-/**
- * Seeded random number generator for reproducible chunks
- */
-export class SeededRandom {
-  private seed: number;
-
-  constructor(seed: number) {
-    this.seed = seed;
-  }
-
-  next(): number {
-    this.seed = (this.seed * 9301 + 49297) % 233280;
-    return this.seed / 233280;
-  }
-
-  nextRange(min: number, max: number): number {
-    return min + this.next() * (max - min);
-  }
-
-  nextInt(min: number, max: number): number {
-    return Math.floor(this.nextRange(min, max + 1));
-  }
-}
-
-/**
- * Generate a smooth river path with controlled meandering
- * SWARM: Override this in biome-specific generators for different path styles
- */
-export function generateRiverPath(
-  startPoint: THREE.Vector3,
-  startDirection: THREE.Vector3,
-  config: MapConfig,
-  seed: number,
-  meanderStrength: number = 1.0
-): THREE.Vector3[] {
-  const rng = new SeededRandom(seed);
-  const points: THREE.Vector3[] = [startPoint.clone()];
-
-  let currentPos = startPoint.clone();
-  let direction = startDirection.clone().normalize();
-
-  // Generate 4 control points for Catmull-Rom curve
-  for (let i = 0; i < 3; i++) {
-    // Meandering based on sine waves + randomness
-    const meanderPhase = seed + i * 0.5;
-    const turnFactor = Math.sin(meanderPhase) * meanderStrength * 0.3;
-
-    // Add random variation
-    direction.x += turnFactor + (rng.next() - 0.5) * 0.2;
-    direction.y += (rng.next() * 0.2 - 0.1); // Slight elevation changes
-
-    // Clamp upward slope
-    if (direction.y > -0.1) direction.y = -0.1;
-
-    // Ensure forward progress
-    if (direction.z > -0.3) direction.z = -0.3;
-
-    direction.normalize();
-
-    // Step forward
-    const stepDistance = config.chunkLength * (0.8 + rng.next() * 0.4);
-    const step = direction.clone().multiplyScalar(stepDistance);
-    currentPos.add(step);
-
-    points.push(currentPos.clone());
-  }
-
-  return points;
-}
-
-/**
- * Generate a river path for a single treadmill segment.
- *
- * This is the ChunkManager-compatible variant of `generateRiverPath`:
- * it uses the segment's authored progression (meanderStrength, verticalBias,
- * type) and a configurable step distance to produce 4 Catmull-Rom control
- * points that connect end-to-end with the previous segment.
- */
-export function generateSegmentPath(
-  index: number,
-  startPoint: THREE.Vector3,
-  startDirection: THREE.Vector3,
-  progression: SegmentProgressionConfig,
-  seed: number,
-  options: {
-    stepCount?: number;
-    stepDistanceMin?: number;
-    stepDistanceMax?: number;
-  } = {}
-): THREE.Vector3[] {
-  const rng = new SeededRandom(seed);
-  const points: THREE.Vector3[] = [startPoint.clone()];
-
-  let currentPos = startPoint.clone();
-  let direction = startDirection.clone().normalize();
-
-  const meanderStrength = progression.meanderStrength ?? DEFAULT_SEGMENT_PROGRESSION.meanderStrength;
-  const verticalBias = progression.verticalBias ?? DEFAULT_SEGMENT_PROGRESSION.verticalBias;
-  const type = progression.type ?? DEFAULT_SEGMENT_PROGRESSION.type;
-
-  const stepCount = options.stepCount ?? 3;
-  const stepDistanceMin = options.stepDistanceMin ?? 30;
-  const stepDistanceMax = options.stepDistanceMax ?? 40;
-
-  for (let step = 0; step < stepCount; step += 1) {
-    const turnFactor = Math.sin(index * 0.5 + step) * meanderStrength;
-    direction.x += turnFactor * 0.3 + (rng.next() - 0.5) * 0.2;
-    direction.y += rng.next() * 0.2 + verticalBias * 0.2;
-
-    const maxUpward = type === 'pond' ? -0.01 : -0.1;
-    if (direction.y > maxUpward) direction.y = maxUpward;
-
-    direction.normalize();
-
-    if (type !== 'waterfall') {
-      if (direction.z > -0.5) direction.z = -0.5;
-    } else {
-      direction.z = -0.12;
-      direction.y = Math.min(direction.y, -0.92);
-    }
-
-    direction.normalize();
-
-    const distance = stepDistanceMin + rng.next() * (stepDistanceMax - stepDistanceMin);
-    currentPos.add(direction.clone().multiplyScalar(distance));
-    points.push(currentPos.clone());
-  }
-
-  return points;
-}
-
-/**
- * Calculate spawn positions along a river path
- * SWARM: Add new object types here
- */
-export function calculateSpawns(
-  curve: THREE.CatmullRomCurve3,
-  chunkIndex: number,
-  config: MapConfig,
-  seed: number,
-  density: { trees: number; rocks: number; collectibles: number }
-): SpawnData[] {
-  const rng = new SeededRandom(seed + chunkIndex * 1000);
-  const spawns: SpawnData[] = [];
-
-  const pathLength = curve.getLength();
-  const steps = Math.floor(pathLength / 2); // Sample every 2 meters
-
-  for (let i = 0; i < steps; i++) {
-    const t = i / steps;
-    const point = curve.getPoint(t);
-    const tangent = curve.getTangent(t).normalize();
-    const up = new THREE.Vector3(0, 1, 0);
-    const binormal = new THREE.Vector3().crossVectors(tangent, up).normalize();
-
-    // Spawn on both sides
-    for (const side of [-1, 1]) {
-      const bankStart = config.waterWidth / 2;
-
-      // Trees
-      if (rng.next() < density.trees / steps) {
-        const dist = bankStart + 4 + rng.next() * 8;
-        const offset = binormal.clone().multiplyScalar(side * dist);
-        const pos = point.clone().add(offset);
-
-        // Height based on distance from center (bank slope)
-        const normalizedDist = Math.abs(side * dist) / (config.canyonWidth * 0.45);
-        const height = Math.pow(Math.max(0, normalizedDist), 2.5) * 12;
-        pos.y += height - 0.5;
-
-        spawns.push({
-          type: 'tree',
-          position: pos,
-          rotation: new THREE.Euler(0, rng.next() * Math.PI * 2, 0),
-          scale: new THREE.Vector3(1.5, 1.5, 1.5).multiplyScalar(1 + rng.next() * 0.5),
-          meta: { variant: rng.nextInt(0, 3) }
-        });
-      }
-
-      // Rocks (obstacles)
-      if (rng.next() < density.rocks / steps) {
-        const dist = bankStart + 1 + rng.next() * 4;
-        const offset = binormal.clone().multiplyScalar(side * dist);
-        const pos = point.clone().add(offset);
-
-        const normalizedDist = Math.abs(side * dist) / (config.canyonWidth * 0.45);
-        const height = Math.pow(Math.max(0, normalizedDist), 2.5) * 12;
-        pos.y += height;
-
-        spawns.push({
-          type: 'rock',
-          position: pos,
-          rotation: new THREE.Euler(
-            rng.next() * Math.PI,
-            rng.next() * Math.PI,
-            rng.next() * Math.PI
-          ),
-          scale: new THREE.Vector3(1, 1, 1).multiplyScalar(0.8 + rng.next() * 0.8),
-          meta: { collider: true }
-        });
-      }
-    }
-  }
-
-  return spawns;
-}
-
-/**
- * Calculate spawn positions for a segment using its authored progression.
- *
- * Tree/rock counts are taken from `progression.decorations` when available
- * (matching the JSON level format), otherwise derived from `treeDensity` /
- * `rockDensity`. This is the shared helper used by both DefaultMapManager and
- * JSONMapManager so spawn placement has a single deterministic source.
- */
-export function calculateSegmentSpawns(
-  curve: THREE.CatmullRomCurve3,
-  progression: SegmentProgressionConfig,
-  index: number,
-  seed: number
-): SpawnData[] {
-  const rng = new SeededRandom(seed + index * 1000);
-  const spawns: SpawnData[] = [];
-
-  const pathLength = curve.getLength();
-  const steps = Math.max(1, Math.floor(pathLength / 2));
-
-  const canyonWidth = progression.width ?? DEFAULT_SEGMENT_PROGRESSION.width;
-  const waterWidth = progression.waterWidth ?? DEFAULT_SEGMENT_PROGRESSION.waterWidth;
-  const decorations = progression.decorations || {};
-
-  // Resolve counts. JSON-authored maps use integer decoration counts;
-  // procedural fallback uses treeDensity / rockDensity normalized to counts.
-  const treeCount =
-    typeof decorations.trees === 'number'
-      ? decorations.trees
-      : Math.round((progression.treeDensity ?? DEFAULT_SEGMENT_PROGRESSION.treeDensity) * 8);
-  const rockCount =
-    typeof decorations.rocks === 'number'
-      ? decorations.rocks
-      : progression.rockDensity === 'high'
-      ? 12
-      : progression.rockDensity === 'medium'
-      ? 6
-      : 2;
-
-  for (let i = 0; i < steps; i++) {
-    const t = i / steps;
-    const point = curve.getPoint(t);
-    const tangent = curve.getTangent(t).normalize();
-    const up = new THREE.Vector3(0, 1, 0);
-    const binormal = new THREE.Vector3().crossVectors(tangent, up).normalize();
-
-    for (const side of [-1, 1]) {
-      const bankStart = waterWidth / 2;
-
-      // Trees
-      const treeChance = treeCount / steps;
-      if (rng.next() < treeChance) {
-        const dist = bankStart + 4 + rng.next() * 8;
-        const offset = binormal.clone().multiplyScalar(side * dist);
-        const pos = point.clone().add(offset);
-
-        const normalizedDist = Math.abs(side * dist) / (canyonWidth * 0.45);
-        const height = Math.pow(Math.max(0, normalizedDist), 2.5) * 12;
-        pos.y += height - 0.5;
-
-        spawns.push({
-          type: 'tree',
-          position: pos,
-          rotation: new THREE.Euler(0, rng.next() * Math.PI * 2, 0),
-          scale: new THREE.Vector3(1.5, 1.5, 1.5).multiplyScalar(1 + rng.next() * 0.5),
-          meta: { variant: rng.nextInt(0, 3) }
-        });
-      }
-
-      // Rocks
-      const rockChance = rockCount / steps;
-      if (rng.next() < rockChance) {
-        const dist = bankStart + 1 + rng.next() * 4;
-        const offset = binormal.clone().multiplyScalar(side * dist);
-        const pos = point.clone().add(offset);
-
-        const normalizedDist = Math.abs(side * dist) / (canyonWidth * 0.45);
-        const height = Math.pow(Math.max(0, normalizedDist), 2.5) * 12;
-        pos.y += height;
-
-        spawns.push({
-          type: 'rock',
-          position: pos,
-          rotation: new THREE.Euler(
-            rng.next() * Math.PI,
-            rng.next() * Math.PI,
-            rng.next() * Math.PI
-          ),
-          scale: new THREE.Vector3(1, 1, 1).multiplyScalar(0.8 + rng.next() * 0.8),
-          meta: { collider: true }
-        });
-      }
-    }
-  }
-
-  return spawns;
-}
-
-// =============================================================================
-// TREADMILL SEGMENT BUILDER (shared by ChunkManager + DefaultMapManager)
-// =============================================================================
-
-function createSegmentCurve(
-  points: THREE.Vector3[],
-  type: SegmentProgressionConfig['type'],
-): THREE.CatmullRomCurve3 {
-  const tension = type === 'pond' ? 0.1 : 0.5;
-  return new THREE.CatmullRomCurve3(points, false, 'catmullrom', tension);
-}
-
-/**
- * Forces the new segment's start tangent to match the previous segment's end
- * tangent. Eliminates NaNs in Catmull-Rom derivative math at segment joints.
- */
-export function ensureTangentContinuity(
-  prevPoints: THREE.Vector3[],
-  newPoints: THREE.Vector3[],
-): THREE.Vector3[] {
-  if (!prevPoints || prevPoints.length < 2 || newPoints.length < 2) {
-    return newPoints;
-  }
-
-  const lastTwo = prevPoints.slice(-2);
-  const prevTangent = new THREE.Vector3()
-    .subVectors(lastTwo[1], lastTwo[0])
-    .normalize();
-
-  if (!prevTangent.lengthSq() || !isFinite(prevTangent.x)) {
-    console.warn('[ensureTangentContinuity] Invalid previous tangent, skipping');
-    return newPoints;
-  }
-
-  const desiredStart = newPoints[0].clone().add(prevTangent.multiplyScalar(0.01));
-  newPoints[0] = desiredStart;
-  return newPoints;
-}
-
-export interface BuildProceduralSegmentOptions {
-  seed?: number;
-  baseSeed?: number;
-  ensureContinuity?: boolean;
-  initialPoints?: THREE.Vector3[];
-}
-
-/**
- * Build a single treadmill segment using MapManager progression config and
- * deterministic SeededRandom path/spawn placement.
- */
-export function buildProceduralSegment(
-  index: number,
-  previousPoints: THREE.Vector3[] | null,
-  mapManager: MapManager,
-  options: BuildProceduralSegmentOptions = {},
-): { chunk: BaseMapChunk; progression: SegmentProgressionConfig } {
-  const progression = mapManager.getChunkConfig(index);
-  const baseSeed = options.baseSeed ?? DEFAULT_MAP_CONFIG.seed;
-  const seed = options.seed ?? baseSeed + index * 1000;
-  const initialPoints = options.initialPoints ?? INITIAL_TREADMILL_POINTS;
-
-  const lastPoints = previousPoints ?? initialPoints;
-  const lastPoint = lastPoints[lastPoints.length - 1].clone();
-  const prevPoint = (lastPoints[lastPoints.length - 2] ?? initialPoints[0]).clone();
-  const startDirection = new THREE.Vector3().subVectors(lastPoint, prevPoint).normalize();
-
-  let points = generateSegmentPath(index, lastPoint, startDirection, progression, seed);
-
-  if (options.ensureContinuity && previousPoints) {
-    points = ensureTangentContinuity(previousPoints, points);
-  }
-
-  const curve = createSegmentCurve(points, progression.type);
-  const pathLength = curve.getLength();
-  const centerPoint = curve.getPoint(0.5);
-  const spawns = calculateSegmentSpawns(curve, progression, index, seed);
-
-  const chunk: BaseMapChunk = {
-    id: `chunk-${index}`,
-    index,
-    position: centerPoint,
-    pathPoints: points,
-    curve,
-    length: pathLength,
-    biome: progression.biome,
-    flowSpeed: progression.flowSpeed,
-    waterLevel: 0.5,
-    waterWidth: progression.waterWidth,
-    canyonWidth: progression.width,
-    spawns,
-    config:
-      progression.decorations || progression.launchShelf || progression.openFloor
-        ? {
-            decorations: progression.decorations,
-            launchShelf: progression.launchShelf,
-            openFloor: progression.openFloor,
-          }
-        : undefined,
-    active: true,
-  };
-
-  return { chunk, progression };
-}
-
-// =============================================================================
-// MAP MANAGER INTERFACE
-// =============================================================================
-
-export interface MapManager {
-  /** Current active chunks */
-  chunks: BaseMapChunk[];
-  /** Current player chunk index */
-  currentChunkIndex: number;
-  /** Get chunk at world position */
-  getChunkAtPosition(position: THREE.Vector3): BaseMapChunk | null;
-  /** Generate new chunk ahead */
-  generateChunk(index: number): BaseMapChunk;
-  /** Update chunk treadmill based on player position */
-  update(playerPosition: THREE.Vector3): void;
-  /** Get flow direction at position */
-  getFlowAtPosition(position: THREE.Vector3): THREE.Vector3;
-  /**
-   * Return the lightweight progression config for a given segment index.
-   * TrackManager uses this instead of inline getProgressionConfig() to determine
-   * biome, type, width, meander, etc. for each generated segment.
-   */
-  getChunkConfig(index: number): SegmentProgressionConfig;
-}
+  buildProceduralSegment,
+  calculateSegmentSpawns,
+  DEFAULT_MAP_CONFIG,
+  DEFAULT_SEGMENT_PROGRESSION,
+} from './MapSystem.generation';
+
+// Re-export types and generation helpers (public API unchanged).
+export type {
+  BaseMapChunk,
+  DecorationPlacement,
+  LaunchShelfConfig,
+  LevelData,
+  LevelMetadata,
+  LevelSegment,
+  LevelSpawns,
+  LevelWorld,
+  MapConfig,
+  MapManager,
+  SegmentProgressionConfig,
+  SegmentRange,
+  SpawnData,
+} from './MapSystem.types';
+
+export {
+  buildProceduralSegment,
+  calculateSegmentSpawns,
+  calculateSpawns,
+  DEFAULT_MAP_CONFIG,
+  DEFAULT_SEGMENT_PROGRESSION,
+  ensureTangentContinuity,
+  generateRiverPath,
+  generateSegmentPath,
+  INITIAL_TREADMILL_POINTS,
+  SeededRandom,
+  type BuildProceduralSegmentOptions,
+} from './MapSystem.generation';
 
 // =============================================================================
 // PLACEHOLDER IMPLEMENTATION
@@ -885,7 +199,7 @@ export class JSONLevelLoader {
     const segments = [...data.segments].sort((a: LevelSegment, b: LevelSegment) => a.index - b.index);
 
     // Normalize waypoints to Vector3
-    const waypoints = data.world.track.waypoints.map((wp: number[]) => 
+    const waypoints = data.world.track.waypoints.map((wp: number[]) =>
       new THREE.Vector3(wp[0], wp[1], wp[2])
     );
 
@@ -974,7 +288,7 @@ export class JSONMapManager implements MapManager {
 
     const segmentConfig = this.levelData.segments.find(s => s.index === index);
     const totalSegments = this.levelData.world.track.totalSegments;
-    
+
     if (!segmentConfig && index < totalSegments) {
       console.warn(`[MapSystem] No config for segment ${index}, using defaults`);
     }
@@ -1051,7 +365,7 @@ export class JSONMapManager implements MapManager {
     if (this.levelData) {
       const maxIndex = Math.max(...this.chunks.map(c => c.index), 0);
       const totalSegments = this.levelData.world.track.totalSegments;
-      
+
       if (maxIndex < this.currentChunkIndex + 3 && maxIndex < totalSegments - 1) {
         this.chunks.push(this.generateChunk(maxIndex + 1));
       }
@@ -1236,4 +550,3 @@ export class ChunkPool {
     return this.pool.length;
   }
 }
-

--- a/src/systems/MapSystem.types.ts
+++ b/src/systems/MapSystem.types.ts
@@ -1,0 +1,288 @@
+/**
+ * MapSystem type contracts — JSON level format, chunk shapes, progression config.
+ *
+ * Extracted from MapSystem.ts (issue #313) so map/registry PRs can touch types
+ * without churning manager implementations. Re-exported from MapSystem.ts.
+ */
+
+import * as THREE from 'three';
+import type { RapierRigidBody } from '@react-three/rapier';
+import type { BiomeId } from '../configs/biomes';
+
+// =============================================================================
+// JSON LEVEL FORMAT INTERFACES
+// =============================================================================
+
+export interface LevelMetadata {
+  name: string;
+  author: string;
+  description?: string;
+  difficulty: 'beginner' | 'intermediate' | 'expert' | 'custom';
+  estimatedDuration: number;
+  version: string;
+  tags?: string[];
+}
+
+export interface LevelWorld {
+  track: {
+    waypoints: number[][];
+    segmentLength: number;
+    totalSegments: number;
+    width?: number;
+    wallHeight?: number;
+  };
+  biome: {
+    baseType: string;
+    sky: { color: string; cloudDensity?: number; cloudColor?: string };
+    fog: { color: string; near: number; far: number; density?: number };
+    lighting: {
+      sunIntensity: number;
+      sunAngle: number;
+      sunColor?: string;
+      ambientIntensity?: number;
+      hemiSkyColor?: string;
+      hemiGroundColor?: string;
+    };
+    water: { tint: string; flowSpeed: number; opacity?: number; surfaceRoughness?: number };
+  };
+}
+
+export interface DecorationPlacement {
+  localX: number;
+  localZ: number;
+  scale?: number;
+  rotation?: number;
+  rockType?: 'boulder' | 'slab' | 'column';
+}
+
+export interface LevelSegment {
+  index: number;
+  name?: string;
+  type?: 'normal' | 'waterfall' | 'pond' | 'splash' | 'rapids';
+  biomeOverride?: string;
+  difficulty: number;
+  width?: number;
+  waterWidth?: number;
+  lengthMultiplier?: number;
+  meanderStrength?: number;
+  verticalBias?: number;
+  forwardMomentum?: number;
+  decorations?: Record<string, number | DecorationPlacement[]>;
+  physics?: {
+    gravityMultiplier?: number;
+    waterFlowIntensity?: number;
+    friction?: number;
+    restitution?: number;
+  };
+  safeZone?: { yMin: number; yMax: number; respawnAt?: number };
+  effects?: {
+    particleCount?: number;
+    cameraShake?: number;
+    fogDensity?: number;
+    transitionDuration?: number;
+  };
+  launchShelf?: LaunchShelfConfig;
+  journeyComplete?: boolean;
+  slipperiness?: number;
+  treeDensity?: number;
+  rockDensity?: 'low' | 'medium' | 'high';
+  /**
+   * When true, TrackSegment skips the floor trimesh collider so the player
+   * flies an air corridor (gap / broken trestle set-pieces).
+   */
+  openFloor?: boolean;
+}
+
+export interface LevelSpawns {
+  start: {
+    position: number[];
+    rotation?: number[];
+    velocity?: number[];
+  };
+  checkpoints?: Array<{
+    segment: number;
+    position: number[];
+    radius?: number;
+  }>;
+}
+
+export interface LevelData {
+  metadata: LevelMetadata;
+  world: LevelWorld;
+  segments: LevelSegment[];
+  spawns: LevelSpawns;
+  decorationPools?: Record<string, string[]>;
+}
+
+// =============================================================================
+// CORE INTERFACES
+// =============================================================================
+
+export interface BaseMapChunk {
+  /** Unique chunk identifier */
+  id: string;
+  /** Chunk sequence number (0 = start) */
+  index: number;
+  /** World-space center position */
+  position: THREE.Vector3;
+  /** Bezier/Catmull-Rom path points for river flow */
+  pathPoints: THREE.Vector3[];
+  /** Path curve (computed from pathPoints) */
+  curve?: THREE.CatmullRomCurve3;
+  /** Chunk length along Z axis */
+  length: number;
+  /** Canonical biome identifier */
+  biome: BiomeId;
+  /** Flow speed multiplier (1.0 = normal) */
+  flowSpeed: number;
+  /** Water surface Y level */
+  waterLevel: number;
+  /** River width at water surface */
+  waterWidth: number;
+  /** Total canyon width (including banks) */
+  canyonWidth: number;
+  /** Pre-calculated spawn data for objects */
+  spawns: SpawnData[];
+  /** Authored decoration / launch-shelf / gap config passed through to TrackSegment */
+  config?: {
+    decorations?: Record<string, number | DecorationPlacement[]>;
+    launchShelf?: LaunchShelfConfig;
+    openFloor?: boolean;
+  };
+  /** Reference to physics collider */
+  collider?: RapierRigidBody;
+  /** Is this chunk currently visible/active */
+  active: boolean;
+}
+
+export interface SpawnData {
+  /** Object type identifier */
+  type: string;
+  /** Spawn position */
+  position: THREE.Vector3;
+  /** Spawn rotation */
+  rotation: THREE.Euler;
+  /** Spawn scale */
+  scale: THREE.Vector3;
+  /** Additional type-specific data */
+  meta?: Record<string, any>;
+}
+
+export interface MapConfig {
+  /** Number of chunks to keep ahead of player */
+  chunksAhead: number;
+  /** Number of chunks to keep behind player */
+  chunksBehind: number;
+  /** Base chunk length in meters */
+  chunkLength: number;
+  /** River width at water level */
+  waterWidth: number;
+  /** Total canyon width */
+  canyonWidth: number;
+  /** Default flow speed */
+  baseFlowSpeed: number;
+  /** Maximum slope angle (degrees) */
+  maxSlope: number;
+  /** Seed for reproducible generation */
+  seed: number;
+}
+
+// =============================================================================
+// SEGMENT PROGRESSION CONFIG
+// =============================================================================
+
+/**
+ * Per-segment configuration consumed by TrackManager to drive treadmill generation.
+ * This is intentionally separate from BaseMapChunk: it is a lightweight config
+ * object that describes HOW a segment should be built, not the built geometry.
+ */
+export interface LaunchShelfConfig {
+  /** Reference to the authored rock that acts as the launch shelf.
+   *  The trigger zone is derived from this rock's local placement. */
+  rockRef: {
+    localX: number;
+    localZ: number;
+    scale: number;
+  };
+  /** Trigger box half-extents in meters. */
+  triggerHalfWidth: number;
+  triggerHalfLength: number;
+  triggerHeight: number;
+  /** Distance downstream from the rock center to the trigger plane. */
+  triggerDownstreamOffset: number;
+  /** Vertical offset of the trigger center above the path surface. */
+  triggerYOffset: number;
+}
+
+export interface SegmentProgressionConfig {
+  biome: BiomeId;
+  type: 'normal' | 'waterfall' | 'splash' | 'pond' | 'rapids';
+  width: number;
+  waterWidth: number;
+  meanderStrength: number;
+  verticalBias: number;
+  flowSpeed: number;
+  treeDensity: number;
+  rockDensity: 'low' | 'medium' | 'high';
+  forwardMomentum?: number;
+  particleCount?: number;
+  cameraShake?: number;
+  /** Per-segment gravity scale applied to the Rapier world (1.0 = normal). */
+  gravityMultiplier?: number;
+  /** When true, entering this segment triggers the journey-complete sequence. */
+  journeyComplete?: boolean;
+  /** Authored decoration positions (array) or procedural density counts (number). */
+  decorations?: Record<string, number | DecorationPlacement[]>;
+  /** Optional launch-shelf gameplay trigger for waterfall set-pieces. */
+  launchShelf?: LaunchShelfConfig;
+  /**
+   * When true, the segment is an air corridor — no floor trimesh collider.
+   * Pair with a splash/pond landing segment for a playable gap jump.
+   */
+  openFloor?: boolean;
+  /**
+   * Surface slipperiness 0–1. 0 = normal grip, 1 = frictionless ice.
+   * Consumed by WaterFlowForces / RaftVehicle to reduce lateral drag and
+   * add a persistent downstream slide bias when > 0.
+   * TODO: wire into Rapier contact material override per segment.
+   */
+  slipperiness?: number;
+}
+
+/**
+ * A single entry in a segment-progression override table.
+ * Ranges are inclusive on both ends. If `indexTo` is omitted, the entry
+ * matches all indices >= indexFrom (open-ended catch-all).
+ * getChunkConfig uses "first match wins" — place more-specific ranges before
+ * broader ones in the array.
+ */
+export interface SegmentRange {
+  indexFrom: number;
+  indexTo?: number;
+  config: Partial<SegmentProgressionConfig>;
+}
+
+// =============================================================================
+// MAP MANAGER INTERFACE
+// =============================================================================
+
+export interface MapManager {
+  /** Current active chunks */
+  chunks: BaseMapChunk[];
+  /** Current player chunk index */
+  currentChunkIndex: number;
+  /** Get chunk at world position */
+  getChunkAtPosition(position: THREE.Vector3): BaseMapChunk | null;
+  /** Generate new chunk ahead */
+  generateChunk(index: number): BaseMapChunk;
+  /** Update chunk treadmill based on player position */
+  update(playerPosition: THREE.Vector3): void;
+  /** Get flow direction at position */
+  getFlowAtPosition(position: THREE.Vector3): THREE.Vector3;
+  /**
+   * Return the lightweight progression config for a given segment index.
+   * TrackManager uses this instead of inline getProgressionConfig() to determine
+   * biome, type, width, meander, etc. for each generated segment.
+   */
+  getChunkConfig(index: number): SegmentProgressionConfig;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issue **#313** (Foundation / DX / Refactor) is largely complete on `main` via #319. This PR finishes the remaining optional item: splitting `MapSystem.ts` into focused sibling modules without changing the public export surface.

### Already on `main` (#319)

- **pnpm-only lockfile policy** — `packageManager` field set, `package-lock.json` gitignored, README/AGENTS note
- **Registry contract guard** — `registry.contract.ts` (compile-time) + `registry.contract.test.ts` (runtime + ajv shape drift)
- **Typed residual surface** — `RiverShader.ts`, `materials/*.ts`, typed facades for `FlowingWater` / `EnhancedSky`

### This PR

- **`MapSystem.types.ts`** — JSON level format, chunk interfaces, progression config, `MapManager` contract
- **`MapSystem.generation.ts`** — defaults, `SeededRandom`, path/spawn helpers, `buildProceduralSegment`
- **`MapSystem.ts`** — managers (`DefaultMapManager`, `JSONMapManager`, `ProceduralMapManager`), `JSONLevelLoader`, `ChunkPool`; re-exports all public symbols so existing `from '../systems/MapSystem'` imports are unchanged
- **`docs/reference/TESTING.md`** — points at `registry.contract.*` as the canonical drift guard

## Acceptance criteria

- [x] Only one lockfile policy enforced (pnpm) — already on main
- [x] Registry/menu contract tests fail on drift — already on main
- [x] RiverShader + core materials on typed surface — already on main
- [x] `pnpm typecheck` and `pnpm test` green (430 passed / 2 skipped)
- [x] No intentional gameplay/visual behavior change

## Verification

```bash
pnpm install --frozen-lockfile
pnpm typecheck   # exit 0
pnpm test        # 430 passed / 2 skipped
```

## Follow-ups (out of scope)

- Drop `TrackSegmentMeshes.tsx` `UntypedSceneComponent` cast on `FlowingWater` to activate facade prop checking
- Resolve `KNOWN_SCHEMA_DEBT` in authored map JSON (omitted `decorations`, meander negative pre-roll indices)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa877e27-b662-4351-b4ae-df2d39df7e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa877e27-b662-4351-b4ae-df2d39df7e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

