### PR TITLE
feat: launch hour selection and portage cache survival

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,8 @@ import { getActiveRunKey, getActiveMapId } from './utils/runContext';
 import { useGameStore } from './systems/GameState';
 import type { MapRegistryId } from './maps/registry';
 import { syncMapUrl } from './maps/campaign';
-import { setLastMapId } from './systems/PersistenceSystem';
+import { setLastMapId, getLaunchHour } from './systems/PersistenceSystem';
+import { initRunSession } from './systems/runSession';
 
 // ---------------------------------------------------------------------------
 // Editor mode — ?editor=1 in dev only
@@ -77,6 +78,7 @@ function App() {
   }, [settingsOpen]);
   const debug = useDebugStages();
   const [selectedMapId, setSelectedMapId] = useState<MapRegistryId>(() => getActiveMapId());
+  const [activeLaunchHour, setActiveLaunchHour] = useState(() => getLaunchHour());
   const [cleanTest, setCleanTestActive] = useState(() => isCleanTestMode());
   const [physicsDebug, setPhysicsDebug] = useState(() => {
     if (isCleanTestMode()) return false;
@@ -246,8 +248,17 @@ function App() {
   }, []);
 
   const handleStart = useCallback(
-    (mapId: MapRegistryId = selectedMapId) => {
+    (
+      mapId: MapRegistryId = selectedMapId,
+      options?: { launchHour?: number; placedCacheIds?: string[] },
+    ) => {
       handleSelectMap(mapId);
+      initRunSession({
+        mapId,
+        launchHour: options?.launchHour,
+        placedCacheIds: options?.placedCacheIds,
+      });
+      setActiveLaunchHour(options?.launchHour ?? getLaunchHour());
       setPhase('playing');
       // Defer world mount by two frames so StartMenu can unmount and paint
       // before Rapier + 7 track segments block the main thread.
@@ -290,7 +301,7 @@ function App() {
       if (isTypingTarget(e.target)) return;
       if (e.key === 'Enter') {
         e.preventDefault();
-        handleStart(selectedMapId);
+        handleStart(selectedMapId, { launchHour: undefined, placedCacheIds: [] });
       }
     };
     window.addEventListener('keydown', onKeyDown);
@@ -356,6 +367,7 @@ function App() {
                 mapId={selectedMapId}
                 onMapChange={handleMapChange}
                 onReturnToMenu={handleReturnToMenu}
+                launchHour={activeLaunchHour}
               />
             </React.Suspense>
           </Canvas>

--- a/src/Experience.tsx
+++ b/src/Experience.tsx
@@ -30,6 +30,7 @@ export default function Experience({
   mapId,
   onMapChange,
   onReturnToMenu,
+  launchHour,
 }: ExperienceProps) {
   const isDebug = typeof window !== 'undefined' && window.location.search.includes('debug=true');
 
@@ -60,6 +61,7 @@ export default function Experience({
                 mapId={mapId}
                 onMapChange={onMapChange}
                 onReturnToMenu={onReturnToMenu}
+                launchHour={launchHour}
               />
               <PerformanceMonitor visible={import.meta.env.DEV} />
               <RendererDiagnosticsMonitor preference={rendererPreference} />

--- a/src/components/CachePlacementPanel.tsx
+++ b/src/components/CachePlacementPanel.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import type { CacheSlotDefinition } from '../systems/portageCache';
+
+type CachePlacementPanelProps = {
+  slots: ReadonlyArray<CacheSlotDefinition>;
+  selectedIds: string[];
+  maxPlacements: number;
+  onToggle: (slotId: string) => void;
+};
+
+export default function CachePlacementPanel({
+  slots,
+  selectedIds,
+  maxPlacements,
+  onToggle,
+}: CachePlacementPanelProps) {
+  if (!slots.length) return null;
+
+  return (
+    <div className="start-menu-cache-panel">
+      <div className="start-menu-map-select-label">Scout Caches</div>
+      <p className="start-menu-map-hint">
+        Place up to {maxPlacements} cache{maxPlacements === 1 ? '' : 's'} on high ground before launch.
+      </p>
+      {slots.map((slot) => {
+        const selected = selectedIds.includes(slot.id);
+        const disabled = !selected && selectedIds.length >= maxPlacements;
+        return (
+          <button
+            key={slot.id}
+            type="button"
+            className={`start-menu-cache-option ${selected ? 'active' : ''}`}
+            disabled={disabled}
+            onClick={() => onToggle(slot.id)}
+          >
+            <span className="start-menu-cache-option-title">{slot.label}</span>
+            <span className="start-menu-cache-option-meta">
+              Seg {slot.segmentIndex} · +{slot.retrievalBonus} on retrieve
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ForecastHUD.tsx
+++ b/src/components/ForecastHUD.tsx
@@ -4,6 +4,7 @@ import {
   FORECAST_HUD_LOOKAHEAD,
   isElevatedRisk,
   nextDamReleaseCountdown,
+  nextPeakCountdown,
   upcomingRiskStrip,
   type DamReleaseEntry,
   type FlowForecastSample,
@@ -11,6 +12,7 @@ import {
 
 type ForecastHUDProps = {
   samples: FlowForecastSample[];
+  launchHour?: number;
   damReleaseSchedule?: ReadonlyArray<DamReleaseEntry>;
   currentSegmentIndex?: number;
 };
@@ -31,6 +33,7 @@ const STATE_COLORS: Record<FlowForecastState, string> = {
 
 export default function ForecastHUD({
   samples,
+  launchHour,
   damReleaseSchedule = [],
   currentSegmentIndex = 0,
 }: ForecastHUDProps) {
@@ -56,9 +59,11 @@ export default function ForecastHUD({
   );
 
   const damCountdown = useMemo(() => {
-    const currentHour = samples[0]?.hour ?? 0;
+    const currentHour = samples[0]?.hour ?? launchHour ?? 0;
     return nextDamReleaseCountdown(damReleaseSchedule, currentHour);
-  }, [damReleaseSchedule, samples]);
+  }, [damReleaseSchedule, launchHour, samples]);
+
+  const peakCountdown = useMemo(() => nextPeakCountdown(samples), [samples]);
 
   const nextHazard = riskStrip.find((sample, index) => index > 0 && isElevatedRisk(sample.state));
 
@@ -87,6 +92,9 @@ export default function ForecastHUD({
       >
         <div style={{ fontSize: 11, letterSpacing: 2, textTransform: 'uppercase', opacity: 0.8 }}>
           Flow Forecast
+        </div>
+        <div style={{ fontSize: 11, opacity: 0.75, marginTop: 4 }}>
+          Launch H{(launchHour ?? samples[0]?.hour ?? 0).toString().padStart(2, '0')}:00
         </div>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginTop: 6 }}>
           <div
@@ -140,6 +148,7 @@ export default function ForecastHUD({
         <div style={{ marginTop: 8, fontSize: 12, opacity: 0.88 }}>
           Peak {summary.maxFlow.toFixed(2)}x · {summary.highRiskHours} risky hrs
           {nextHazard ? ` · hazard in ${riskStrip.indexOf(nextHazard)} seg` : ''}
+          {peakCountdown ? ` · next peak T+${peakCountdown.hoursUntil}h` : ''}
         </div>
 
         {damCountdown && (

--- a/src/components/LaunchHourPicker.tsx
+++ b/src/components/LaunchHourPicker.tsx
@@ -1,0 +1,79 @@
+import React, { useMemo } from 'react';
+import { FLOW_FORECAST_STATES } from '../constants/game';
+import {
+  buildForecastSamples,
+  classifyFlow,
+  type DamReleaseEntry,
+  type FlowForecastSample,
+} from '../systems/flowForecast';
+
+const STATE_COLORS: Record<string, string> = {
+  [FLOW_FORECAST_STATES.NORMAL]: '#89d18b',
+  [FLOW_FORECAST_STATES.HIGH_FLOW]: '#f3c969',
+  [FLOW_FORECAST_STATES.FLOODED]: '#ff7f6e',
+  [FLOW_FORECAST_STATES.WASHED_OUT]: '#c44bff',
+};
+
+type LaunchHourPickerProps = {
+  value: number;
+  onChange: (hour: number) => void;
+  temperature?: number;
+  snowpackIndex?: number;
+  damReleaseSchedule?: ReadonlyArray<DamReleaseEntry>;
+};
+
+export default function LaunchHourPicker({
+  value,
+  onChange,
+  temperature = 8,
+  snowpackIndex = 0.65,
+  damReleaseSchedule = [],
+}: LaunchHourPickerProps) {
+  const samples = useMemo(
+    () =>
+      buildForecastSamples({
+        temperature,
+        snowpackIndex,
+        damReleaseSchedule,
+        startHour: 0,
+        horizonHours: 24,
+      }),
+    [damReleaseSchedule, snowpackIndex, temperature],
+  );
+
+  const selected = samples[value] ?? samples[0];
+
+  return (
+    <div className="start-menu-launch-hour">
+      <div className="start-menu-map-select-label">Launch Hour</div>
+      <div className="start-menu-launch-hour-value">
+        H{value.toString().padStart(2, '0')}:00 · {selected.state} ({selected.flowRate.toFixed(2)}x)
+      </div>
+      <input
+        type="range"
+        min={0}
+        max={23}
+        step={1}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        aria-label="Select launch hour"
+        className="start-menu-launch-hour-slider"
+      />
+      <div className="start-menu-launch-hour-strip" aria-hidden>
+        {samples.map((sample: FlowForecastSample) => (
+          <button
+            key={`launch-hour-${sample.hour}`}
+            type="button"
+            className={`start-menu-launch-hour-tick ${sample.hour === value ? 'active' : ''}`}
+            style={{ background: STATE_COLORS[classifyFlow(sample.flowRate)] }}
+            title={`H${sample.hour}: ${sample.state}`}
+            onClick={() => onChange(sample.hour)}
+          />
+        ))}
+      </div>
+      <p className="start-menu-map-hint">
+        Launch hour locks flow, width, and hazard level for the entire run.
+      </p>
+    </div>
+  );
+}

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -1,7 +1,7 @@
 // src/components/StartMenu.tsx
 // Pre-game title screen with map select, start, and settings
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   formatDuration,
   isMapUnlocked,
@@ -9,14 +9,21 @@ import {
   type MapMenuEntry,
 } from '../maps/campaign';
 import type { MapRegistryId } from '../maps/registry';
+import { getMapSurvivalMetadata, mapHasSurvivalFeatures } from '../maps/survivalMetadata';
 import {
   getBestScoreForMap,
   getCompletedMaps,
   getLastMapId,
+  getLaunchHour,
+  setLaunchHour,
 } from '../systems/PersistenceSystem';
+import { DAM_RELEASE_SCHEDULE } from '../experience/constants';
+import LaunchHourPicker from './LaunchHourPicker';
+import CachePlacementPanel from './CachePlacementPanel';
+import { DEFAULT_MAX_CACHE_PLACEMENTS } from '../systems/portageCache';
 
 interface StartMenuProps {
-  onStart: (mapId: MapRegistryId) => void;
+  onStart: (mapId: MapRegistryId, options: { launchHour: number; placedCacheIds: string[] }) => void;
   selectedMapId: MapRegistryId;
   onSelectMap: (mapId: MapRegistryId) => void;
   /** Open the full Options panel (audio, controls/rebinding, graphics). */
@@ -49,6 +56,34 @@ export const StartMenu: React.FC<StartMenuProps> = ({
   const completedMaps = useMemo(() => getCompletedMaps(), []);
   const lastMapId = useMemo(() => getLastMapId(), []);
   const maps = useMemo(() => listMapsForMenu(), []);
+  const [launchHour, setLaunchHourLocal] = useState(() => getLaunchHour());
+  const [placedCacheIds, setPlacedCacheIds] = useState<string[]>([]);
+
+  const survivalMeta = useMemo(
+    () => getMapSurvivalMetadata(selectedMapId),
+    [selectedMapId],
+  );
+  const maxCachePlacements = survivalMeta.maxCachePlacements ?? DEFAULT_MAX_CACHE_PLACEMENTS;
+  const showSurvival = mapHasSurvivalFeatures(selectedMapId);
+
+  const handleLaunchHourChange = (hour: number) => {
+    setLaunchHourLocal(hour);
+    setLaunchHour(hour);
+  };
+
+  const handleCacheToggle = (slotId: string) => {
+    setPlacedCacheIds((prev) => {
+      if (prev.includes(slotId)) {
+        return prev.filter((id) => id !== slotId);
+      }
+      if (prev.length >= maxCachePlacements) return prev;
+      return [...prev, slotId];
+    });
+  };
+
+  useEffect(() => {
+    setPlacedCacheIds([]);
+  }, [selectedMapId]);
 
   return (
     <div className="start-menu-overlay">
@@ -104,9 +139,24 @@ export const StartMenu: React.FC<StartMenuProps> = ({
               </p>
             </div>
 
+            <LaunchHourPicker
+              value={launchHour}
+              onChange={handleLaunchHourChange}
+              damReleaseSchedule={DAM_RELEASE_SCHEDULE}
+            />
+
+            {showSurvival && (
+              <CachePlacementPanel
+                slots={survivalMeta.cacheSlots ?? []}
+                selectedIds={placedCacheIds}
+                maxPlacements={maxCachePlacements}
+                onToggle={handleCacheToggle}
+              />
+            )}
+
             <button
               className="start-menu-start-btn"
-              onClick={() => onStart(selectedMapId)}
+              onClick={() => onStart(selectedMapId, { launchHour, placedCacheIds })}
               aria-label="Start Game - Click or Press Enter"
               autoFocus
             >

--- a/src/experience/ExperienceUI.tsx
+++ b/src/experience/ExperienceUI.tsx
@@ -10,6 +10,7 @@ interface ExperienceUIProps {
   enabled: boolean;
   cleanTest: boolean;
   forecastSamples: FlowForecastSample[];
+  launchHour?: number;
   damReleaseSchedule?: ReadonlyArray<DamReleaseEntry>;
   isWipeout: boolean;
   isJourneyComplete: boolean;
@@ -36,6 +37,7 @@ export default function ExperienceUI({
   enabled,
   cleanTest,
   forecastSamples,
+  launchHour,
   damReleaseSchedule = [],
   isWipeout,
   isJourneyComplete,
@@ -66,6 +68,7 @@ export default function ExperienceUI({
       {!cleanTest && (
         <ForecastHUD
           samples={forecastSamples}
+          launchHour={launchHour}
           damReleaseSchedule={damReleaseSchedule}
           currentSegmentIndex={currentSegmentIndex}
         />

--- a/src/experience/InnerExperience.tsx
+++ b/src/experience/InnerExperience.tsx
@@ -33,6 +33,7 @@ export default function InnerExperience({
   mapId,
   onMapChange,
   onReturnToMenu,
+  launchHour,
 }: InnerExperienceProps) {
   const state = useInnerExperience({
     debug,
@@ -41,6 +42,7 @@ export default function InnerExperience({
     mapId,
     onMapChange,
     onReturnToMenu,
+    launchHour,
   });
   const { config: lodConfig, quality: lodQuality } = useLOD();
 
@@ -101,6 +103,7 @@ export default function InnerExperience({
             temperature={8}
             snowpackIndex={0.65}
             damReleaseSchedule={DAM_RELEASE_SCHEDULE}
+            startHour={state.launchHour}
             onForecastChange={state.setForecastSamples}
           />
           {debug.isStageEnabled('dataProcessing') &&
@@ -151,6 +154,7 @@ export default function InnerExperience({
         enabled={debug.isStageEnabled('uiOverlay')}
         cleanTest={cleanTest}
         forecastSamples={state.forecastSamples}
+        launchHour={state.launchHour}
         damReleaseSchedule={DAM_RELEASE_SCHEDULE}
         isWipeout={state.isWipeout}
         isJourneyComplete={state.isJourneyComplete}

--- a/src/experience/hooks/useExperienceLifecycle.ts
+++ b/src/experience/hooks/useExperienceLifecycle.ts
@@ -8,12 +8,18 @@ import {
   awardDodgeBonus,
   awardWaterfallBonus,
   awardFloodSurviveBonus,
+  awardCacheRetrievalBonus,
+  applyCacheLostPenalty,
+  applyPortageFailPenalty,
   resetScoreSystemState,
   cancelLaunch,
 } from '../../systems/ScoreSystem';
 import { useGameStore, batchFrameUpdate } from '../../systems/GameState';
 import { tickGhostRecording } from '../../systems/GhostRecorder';
 import { isElevatedRisk } from '../../systems/flowForecast';
+import { getMapSurvivalMetadata } from '../../maps/survivalMetadata';
+import { countLostCaches, requiresPortageForSegment } from '../../systems/portageCache';
+import { dispatchPortageCacheEvent, getRunSession } from '../../systems/runSession';
 import type { DebugStageController } from '../../debug/debugStages';
 import type { VehicleRigidBodyRef } from '../types';
 
@@ -49,14 +55,36 @@ export function useExperienceLifecycle({
     segmentIndex: number;
     state: string;
     surviveBonus: number;
+    requiresPortage: boolean;
   } | null>(null);
 
   useSegmentAudio(currentSegmentIndex);
 
   useEffect(() => {
-    if (isWipeout) {
-      previousRiskRef.current = null;
+    if (!isWipeout) return;
+    const session = getRunSession();
+    const segmentIndex = useGameStore.getState().currentSegmentIndex;
+    if (session) {
+      const beforeLost = countLostCaches(session.portageCache);
+      const survivalMeta = getMapSurvivalMetadata(session.mapId);
+      const segmentState = previousRiskRef.current?.state ?? 'Normal';
+      const requiresPortage = requiresPortageForSegment(
+        survivalMeta.portageRoutes ?? [],
+        segmentIndex,
+        segmentState,
+      );
+      dispatchPortageCacheEvent({ type: 'WIPEOUT', segmentIndex });
+      const afterSession = getRunSession();
+      const afterLost = afterSession ? countLostCaches(afterSession.portageCache) : beforeLost;
+      const newlyLost = afterLost - beforeLost;
+      if (newlyLost > 0) {
+        applyCacheLostPenalty(newlyLost);
+      }
+      if (requiresPortage || previousRiskRef.current?.requiresPortage) {
+        applyPortageFailPenalty();
+      }
     }
+    previousRiskRef.current = null;
   }, [isWipeout]);
 
   useEffect(() => {
@@ -114,6 +142,13 @@ export function useExperienceLifecycle({
         const index = detail?.segmentIndex ?? 0;
         const segmentState = detail?.segmentState ?? 'Normal';
         const surviveBonus = detail?.surviveBonus ?? 0;
+        const session = getRunSession();
+        const survivalMeta = session ? getMapSurvivalMetadata(session.mapId) : {};
+        const requiresPortage = requiresPortageForSegment(
+          survivalMeta.portageRoutes ?? [],
+          index,
+          segmentState,
+        );
 
         // Award flood-survive bonus when cleanly exiting an elevated-risk segment.
         const previous = previousRiskRef.current;
@@ -124,12 +159,33 @@ export function useExperienceLifecycle({
           previous.surviveBonus > 0 &&
           !useGameStore.getState().isWipeout
         ) {
-          awardFloodSurviveBonus(previous.surviveBonus);
+          awardFloodSurviveBonus(previous.surviveBonus, previous.state);
         }
+        if (previous && previous.segmentIndex !== index) {
+          dispatchPortageCacheEvent({
+            type: 'EXIT_SEGMENT',
+            segmentIndex: previous.segmentIndex,
+            survived: !useGameStore.getState().isWipeout,
+          });
+          if (previous.requiresPortage && useGameStore.getState().isWipeout) {
+            applyPortageFailPenalty();
+          }
+        }
+
+        if (session) {
+          dispatchPortageCacheEvent({
+            type: 'ENTER_SEGMENT',
+            segmentIndex: index,
+            requiresPortage,
+          });
+          awardCacheRetrievalBonus(index);
+        }
+
         previousRiskRef.current = {
           segmentIndex: index,
           state: segmentState,
           surviveBonus,
+          requiresPortage,
         };
 
         setCurrentSegmentIndex(index);

--- a/src/experience/hooks/useExperienceWorld.ts
+++ b/src/experience/hooks/useExperienceWorld.ts
@@ -27,14 +27,22 @@ import { hydrateStoreForRun } from '../../systems/persistenceBootstrap';
 import { getActiveRunKey } from '../../utils/runContext';
 import { ACTIVE_MAP_ID } from '../../maps/registry';
 import { buildForecastSamples } from '../../systems/flowForecast';
+import { initRunSession, getActiveLaunchHour, getRunSession } from '../../systems/runSession';
+import { getLaunchHour } from '../../systems/PersistenceSystem';
 
-const DEFAULT_FORECAST_SAMPLES: FlowForecastSample[] = buildForecastSamples({
+const DEFAULT_FORECAST_OPTIONS = {
   temperature: 8,
   snowpackIndex: 0.65,
   damReleaseSchedule: DAM_RELEASE_SCHEDULE,
-  startHour: 0,
   horizonHours: 24,
-});
+} as const;
+
+function buildDefaultForecastSamples(launchHour: number): FlowForecastSample[] {
+  return buildForecastSamples({
+    ...DEFAULT_FORECAST_OPTIONS,
+    startHour: launchHour,
+  });
+}
 
 function forecastSamplesEqual(
   a: ReadonlyArray<FlowForecastSample>,
@@ -59,6 +67,7 @@ interface UseExperienceWorldOptions {
   mapId?: MapRegistryId;
   onMapChange?: (mapId: MapRegistryId) => void;
   onReturnToMenu?: () => void;
+  launchHour?: number;
 }
 
 function resolveInitialMapId(controlled?: MapRegistryId): MapRegistryId {
@@ -78,7 +87,9 @@ export function useExperienceWorld({
   mapId: controlledMapId,
   onMapChange,
   onReturnToMenu,
+  launchHour: controlledLaunchHour,
 }: UseExperienceWorldOptions) {
+  const launchHour = controlledLaunchHour ?? getActiveLaunchHour() ?? getLaunchHour();
   const { setBiome: setBiomeContext, snapBiome: snapBiomeContext } = useBiome();
 
   const currentSegmentIndex = useGameStore((s) => s.currentSegmentIndex);
@@ -95,7 +106,7 @@ export function useExperienceWorld({
   const [isLoadingLevel, setIsLoadingLevel] = useState(false);
   const [loadedLevelState, setLoadedLevelState] = useState<unknown>(null);
   const [forecastSamples, setForecastSamples] = useState<FlowForecastSample[]>(
-    () => DEFAULT_FORECAST_SAMPLES,
+    () => buildDefaultForecastSamples(launchHour),
   );
   const [reachId, setReachId] = useState<string | null>(null);
   const [reachLoading, setReachLoading] = useState(false);
@@ -121,6 +132,10 @@ export function useExperienceWorld({
     () => (isFinalMap ? getGhostBestScoreForMap(activeDefaultMapId) : 0),
     [activeDefaultMapId, isFinalMap, isJourneyComplete],
   );
+
+  useEffect(() => {
+    setForecastSamples(buildDefaultForecastSamples(launchHour));
+  }, [launchHour]);
 
   // Keep local map state in sync when App / StartMenu changes selection.
   useEffect(() => {
@@ -359,6 +374,11 @@ export function useExperienceWorld({
         syncMapUrl(targetMapId);
         setLastMapId(targetMapId);
         hydrateStoreForRun(getActiveRunKey(targetMapId));
+        initRunSession({
+          mapId: targetMapId,
+          launchHour: getActiveLaunchHour(),
+          placedCacheIds: getRunSession()?.placedCacheIds ?? [],
+        });
         useGameStore.getState().resetGameState();
         setIsWipeout(false);
         setActiveDefaultMapId(targetMapId);
@@ -368,7 +388,7 @@ export function useExperienceWorld({
         setWaterfallGravityMultiplier(1.0);
         snapBiomeContext(targetMap.initialBiome);
         useGameStore.setState({ currentBiome: targetMap.initialBiome, isPaused: false });
-        setForecastSamples(DEFAULT_FORECAST_SAMPLES);
+        setForecastSamples(buildDefaultForecastSamples(launchHour));
         awardedWaterfallSegmentsRef.current?.clear();
         resetScoreSystemState();
         resetRunSession({
@@ -443,6 +463,7 @@ export function useExperienceWorld({
     levelLoadError,
     isLoadingLevel,
     forecastSamples,
+    launchHour,
     reachId,
     reachLoading,
     reachError,

--- a/src/experience/hooks/useInnerExperience.ts
+++ b/src/experience/hooks/useInnerExperience.ts
@@ -20,7 +20,11 @@ export function useInnerExperience({
   mapId,
   onMapChange,
   onReturnToMenu,
-}: Pick<InnerExperienceProps, 'physicsDebug' | 'cleanTest' | 'mapId' | 'onMapChange' | 'onReturnToMenu'> & {
+  launchHour,
+}: Pick<
+  InnerExperienceProps,
+  'physicsDebug' | 'cleanTest' | 'mapId' | 'onMapChange' | 'onReturnToMenu' | 'launchHour'
+> & {
   debug: DebugStageController;
 }) {
   const [vehicleType, setVehicleTypeLocal] = useState<VehicleType>(readVehicleTypeFromUrl);
@@ -78,6 +82,7 @@ export function useInnerExperience({
     mapId,
     onMapChange,
     onReturnToMenu,
+    launchHour,
   });
 
   return {

--- a/src/experience/types.ts
+++ b/src/experience/types.ts
@@ -29,6 +29,8 @@ export interface InnerExperienceProps {
   onMapChange?: (mapId: import('../maps/registry').MapRegistryId) => void;
   /** Journey-complete → return to StartMenu. */
   onReturnToMenu?: () => void;
+  /** Frozen launch hour selected pre-run (0–23). */
+  launchHour?: number;
 }
 
 export interface ExperienceProps extends InnerExperienceProps {

--- a/src/formats/persistence.schema.json
+++ b/src/formats/persistence.schema.json
@@ -45,6 +45,11 @@
       },
       "uniqueItems": true
     },
+    "launchHour": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 23
+    },
     "runs": {
       "type": "object",
       "additionalProperties": {

--- a/src/maps/meander_to_waterfall.json
+++ b/src/maps/meander_to_waterfall.json
@@ -104,7 +104,7 @@
     { "index": 8,  "difficulty": 0.35, "meanderStrength": 0.30, "verticalBias": -0.50, "waterWidth": 16, "decorations": { "trees": 7,  "rocks": 5 } },
     { "index": 9,  "difficulty": 0.48, "meanderStrength": 0.65, "verticalBias": -0.70, "waterWidth": 15, "decorations": { "trees": 6,  "rocks": 6 } },
     { "index": 10, "difficulty": 0.58, "meanderStrength": 0.75, "verticalBias": -0.85, "waterWidth": 13, "decorations": { "trees": 5,  "rocks": 7 } },
-    { "index": 11, "difficulty": 0.62, "meanderStrength": 0.50, "verticalBias": -1.00, "waterWidth": 11, "decorations": { "trees": 3,  "rocks": 8 } },
+    { "index": 11, "difficulty": 0.62, "meanderStrength": 0.50, "verticalBias": -1.00, "waterWidth": 11, "hasBridge": true, "decorations": { "trees": 3,  "rocks": 8 } },
     { "index": 12, "difficulty": 0.65, "meanderStrength": 0.30, "verticalBias": -1.10, "waterWidth": 10, "decorations": { "trees": 2,  "rocks": 10 } },
     { "index": 13, "difficulty": 0.3, "meanderStrength": 0.2, "verticalBias": -1.2, "waterWidth": 10, "physics": { "waterFlowIntensity": 1.15 } },
     {

--- a/src/maps/survivalMetadata.ts
+++ b/src/maps/survivalMetadata.ts
@@ -1,0 +1,41 @@
+/**
+ * survivalMetadata.ts — Portage routes and cache slots per map.
+ */
+
+import type { MapRegistryId } from './registry';
+import type { CacheSlotDefinition, PortageRouteDefinition } from '../systems/portageCache';
+
+export interface MapSurvivalMetadata {
+  maxCachePlacements?: number;
+  cacheSlots?: CacheSlotDefinition[];
+  portageRoutes?: PortageRouteDefinition[];
+}
+
+const SURVIVAL_BY_MAP: Partial<Record<MapRegistryId, MapSurvivalMetadata>> = {
+  meander: {
+    maxCachePlacements: 1,
+    cacheSlots: [
+      {
+        id: 'meander-ridge-10',
+        segmentIndex: 10,
+        label: 'Rim shelf above the trestle',
+        retrievalBonus: 250,
+      },
+    ],
+    portageRoutes: [
+      {
+        segmentIndex: 11,
+        label: 'High-line portage past the trestle',
+      },
+    ],
+  },
+};
+
+export function getMapSurvivalMetadata(mapId: MapRegistryId): MapSurvivalMetadata {
+  return SURVIVAL_BY_MAP[mapId] ?? {};
+}
+
+export function mapHasSurvivalFeatures(mapId: MapRegistryId): boolean {
+  const meta = getMapSurvivalMetadata(mapId);
+  return Boolean(meta.cacheSlots?.length || meta.portageRoutes?.length);
+}

--- a/src/style.css
+++ b/src/style.css
@@ -515,6 +515,91 @@ canvas {
   line-height: 1.4;
 }
 
+.start-menu-launch-hour {
+  width: 100%;
+  margin-bottom: 12px;
+  padding: 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.start-menu-launch-hour-value {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.82);
+  margin: 6px 0 10px;
+}
+
+.start-menu-launch-hour-slider {
+  width: 100%;
+}
+
+.start-menu-launch-hour-strip {
+  display: grid;
+  grid-template-columns: repeat(24, minmax(0, 1fr));
+  gap: 3px;
+  margin-top: 10px;
+}
+
+.start-menu-launch-hour-tick {
+  height: 14px;
+  border: none;
+  border-radius: 3px;
+  padding: 0;
+  cursor: pointer;
+  opacity: 0.75;
+}
+
+.start-menu-launch-hour-tick.active {
+  outline: 1px solid rgba(255, 255, 255, 0.8);
+  opacity: 1;
+}
+
+.start-menu-cache-panel {
+  width: 100%;
+  margin-bottom: 12px;
+  padding: 12px;
+  border-radius: 10px;
+  background: rgba(255, 140, 80, 0.06);
+  border: 1px solid rgba(255, 140, 80, 0.18);
+}
+
+.start-menu-cache-option {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  margin-top: 8px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(0, 0, 0, 0.18);
+  color: #f4efe3;
+  cursor: pointer;
+  text-align: left;
+}
+
+.start-menu-cache-option.active {
+  border-color: rgba(255, 180, 120, 0.65);
+  background: rgba(255, 140, 80, 0.14);
+}
+
+.start-menu-cache-option:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.start-menu-cache-option-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.start-menu-cache-option-meta {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.55);
+}
+
 .start-menu-title-group {
   margin-bottom: 32px;
 }

--- a/src/systems/MapSystem.generation.ts
+++ b/src/systems/MapSystem.generation.ts
@@ -453,11 +453,12 @@ export function buildProceduralSegment(
     canyonWidth: progression.width,
     spawns,
     config:
-      progression.decorations || progression.launchShelf || progression.openFloor
+      progression.decorations || progression.launchShelf || progression.openFloor || progression.hasBridge
         ? {
             decorations: progression.decorations,
             launchShelf: progression.launchShelf,
             openFloor: progression.openFloor,
+            hasBridge: progression.hasBridge,
           }
         : undefined,
     active: true,

--- a/src/systems/MapSystem.ts
+++ b/src/systems/MapSystem.ts
@@ -342,11 +342,12 @@ export class JSONMapManager implements MapManager {
       waterWidth: config.waterWidth ?? this.levelData.world.track.width ?? DEFAULT_MAP_CONFIG.waterWidth,
       canyonWidth: config.width || this.levelData.world.track.width || DEFAULT_MAP_CONFIG.canyonWidth,
       spawns,
-      config: progression.decorations || progression.launchShelf || progression.openFloor
+      config: progression.decorations || progression.launchShelf || progression.openFloor || progression.hasBridge
         ? {
             decorations: progression.decorations,
             launchShelf: progression.launchShelf,
             openFloor: progression.openFloor,
+            hasBridge: progression.hasBridge,
           }
         : undefined,
       active: true,
@@ -439,6 +440,7 @@ export class JSONMapManager implements MapManager {
       journeyComplete: seg.journeyComplete,
       slipperiness: seg.slipperiness,
       openFloor: seg.openFloor,
+      hasBridge: seg.hasBridge,
     };
   }
 }

--- a/src/systems/MapSystem.types.ts
+++ b/src/systems/MapSystem.types.ts
@@ -91,6 +91,8 @@ export interface LevelSegment {
    * flies an air corridor (gap / broken trestle set-pieces).
    */
   openFloor?: boolean;
+  /** Authored bridge/trestle — WashedOut forecast can force a gap. */
+  hasBridge?: boolean;
 }
 
 export interface LevelSpawns {
@@ -148,6 +150,7 @@ export interface BaseMapChunk {
     decorations?: Record<string, number | DecorationPlacement[]>;
     launchShelf?: LaunchShelfConfig;
     openFloor?: boolean;
+    hasBridge?: boolean;
   };
   /** Reference to physics collider */
   collider?: RapierRigidBody;
@@ -240,6 +243,8 @@ export interface SegmentProgressionConfig {
    * Pair with a splash/pond landing segment for a playable gap jump.
    */
   openFloor?: boolean;
+  /** Authored bridge/trestle — WashedOut forecast can force a gap. */
+  hasBridge?: boolean;
   /**
    * Surface slipperiness 0–1. 0 = normal grip, 1 = frictionless ice.
    * Consumed by WaterFlowForces / RaftVehicle to reduce lateral drag and

--- a/src/systems/PersistenceSystem.test.ts
+++ b/src/systems/PersistenceSystem.test.ts
@@ -5,11 +5,13 @@ import {
   getCompletedMaps,
   getDefaultPersistence,
   getLastMapId,
+  getLaunchHour,
   getRunBest,
   loadPersistence,
   markMapCompleted,
   resetPersistenceForTests,
   setLastMapId,
+  setLaunchHour,
   STORAGE_KEY,
   updateRunBest,
 } from './PersistenceSystem';
@@ -96,5 +98,12 @@ describe('PersistenceSystem', () => {
     const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
     expect(stored.completedMaps).toEqual(['glacial', 'meander']);
     expect(stored.lastMapId).toBe('meander');
+  });
+
+  it('persists launch hour in campaign progress', () => {
+    expect(setLaunchHour(17)).toBe(17);
+    expect(getLaunchHour()).toBe(17);
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+    expect(stored.launchHour).toBe(17);
   });
 });

--- a/src/systems/PersistenceSystem.ts
+++ b/src/systems/PersistenceSystem.ts
@@ -35,6 +35,8 @@ export interface PersistencePayload {
   lastMapId?: string;
   /** Soft-lock progress for campaign maps. */
   completedMaps?: string[];
+  /** Last selected pre-run launch hour (0–23). */
+  launchHour?: number;
   runs: Record<string, RunBest>;
 }
 
@@ -66,6 +68,7 @@ export function getDefaultPersistence(): PersistencePayload {
     ghostEnabled: true,
     lastMapId: undefined,
     completedMaps: [],
+    launchHour: 6,
     runs: {},
   };
 }
@@ -88,6 +91,11 @@ function normalizePayload(raw: unknown): PersistencePayload | null {
   const payload = raw as unknown as PersistencePayload;
   if (!Array.isArray(payload.completedMaps)) {
     payload.completedMaps = [];
+  }
+  if (payload.launchHour === undefined) {
+    payload.launchHour = 6;
+  } else {
+    payload.launchHour = Math.max(0, Math.min(23, Math.floor(payload.launchHour)));
   }
   return payload;
 }
@@ -257,6 +265,19 @@ export function markMapCompleted(mapId: string): string[] {
   });
   flushPersistence();
   return next;
+}
+
+export function getLaunchHour(): number {
+  return loadPersistence().launchHour ?? 6;
+}
+
+export function setLaunchHour(hour: number): number {
+  const normalized = Math.max(0, Math.min(23, Math.floor(hour)));
+  touchCache((data) => {
+    data.launchHour = normalized;
+  });
+  flushPersistence();
+  return normalized;
 }
 
 /** Best score across all seeds for a map id (`mapId:*` run keys). */

--- a/src/systems/ScoreSystem.ts
+++ b/src/systems/ScoreSystem.ts
@@ -3,6 +3,13 @@ import { resetLaunchScoringSession, cancelLaunch } from './LaunchScoringSession'
 import { getRunBest, updateRunBest } from './PersistenceSystem';
 import { persistGhostRecording, startGhostRecording } from './GhostRecorder';
 import { getActiveRunKey } from '../utils/runContext';
+import { launchHourScoreMultiplier } from './flowForecast';
+import {
+  CACHE_LOST_PENALTY,
+  PORTAGE_FAIL_PENALTY,
+  pendingRetrievalBonus,
+} from './portageCache';
+import { getRunSession, markCacheBonusAwarded } from './runSession';
 
 const HIGH_SPEED_THRESHOLD = 15;
 const RESET_SPEED_THRESHOLD = 8;
@@ -137,21 +144,69 @@ export function awardDodgeBonus(): void {
 }
 
 /** Survive HighFlow / Flooded / WashedOut without wipeout — points from forecast effects table. */
-export function awardFloodSurviveBonus(points: number): void {
+export function awardFloodSurviveBonus(points: number, segmentState?: string): void {
   if (points <= 0) return;
   const state = useGameStore.getState();
   if (state.isWipeout) return;
 
-  addScoreBonus(points);
+  const multiplier = segmentState ? launchHourScoreMultiplier(segmentState) : 1;
+  const scaled = Math.round(points * multiplier);
+  addScoreBonus(scaled);
   useGameStore.setState({
     latestReward: {
       tier: 'FloodSurvive',
-      score: Math.round(points),
+      score: scaled,
       clean: true,
       id: Date.now(),
-      label: 'FLOOD SURVIVE',
+      label: multiplier > 1 ? `FLOOD SURVIVE x${multiplier.toFixed(2)}` : 'FLOOD SURVIVE',
     },
   });
+}
+
+export function awardCacheRetrievalBonus(segmentIndex: number): void {
+  const session = getRunSession();
+  if (!session) return;
+  if (!markCacheBonusAwarded(segmentIndex)) return;
+
+  const bonus = pendingRetrievalBonus(session.portageCache, segmentIndex);
+  if (bonus <= 0) return;
+
+  addScoreBonus(bonus);
+  useGameStore.setState({
+    latestReward: {
+      tier: 'CacheRetrieve',
+      score: bonus,
+      clean: true,
+      id: Date.now(),
+      label: 'CACHE RETRIEVED',
+    },
+  });
+}
+
+export function applySurvivalPenalty(points: number, label: string): void {
+  const state = useGameStore.getState();
+  if (state.isWipeout) return;
+
+  const nextScore = Math.max(0, state.score - points);
+  useGameStore.setState({
+    score: nextScore,
+    latestReward: {
+      tier: 'SurvivalPenalty',
+      score: -points,
+      clean: false,
+      id: Date.now(),
+      label,
+    },
+  });
+}
+
+export function applyCacheLostPenalty(lostCount: number): void {
+  if (lostCount <= 0) return;
+  applySurvivalPenalty(lostCount * CACHE_LOST_PENALTY, 'GEAR LOST');
+}
+
+export function applyPortageFailPenalty(): void {
+  applySurvivalPenalty(PORTAGE_FAIL_PENALTY, 'PORTAGE FAILED');
 }
 
 /** Commit journey-end score to per-run persistence. */

--- a/src/systems/__tests__/launchHour.test.ts
+++ b/src/systems/__tests__/launchHour.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { FLOW_FORECAST_STATES } from '../../constants/game';
+import {
+  applyForecastToSegmentParams,
+  buildLaunchForecast,
+  launchHourScoreMultiplier,
+  nextPeakCountdown,
+  segmentParamsAtLaunchHour,
+} from '../flowForecast';
+
+const BASE_PARAMS = {
+  type: 'normal' as const,
+  width: 40,
+  waterWidth: 20,
+  flowSpeed: 1,
+  particleCount: 100,
+  rockDensity: 'low' as const,
+  cameraShake: 0,
+};
+
+const FORECAST_OPTIONS = {
+  temperature: 8,
+  snowpackIndex: 0.65,
+  damReleaseSchedule: [
+    { hour: 6, release: 0.08 },
+    { hour: 14, release: 0.12 },
+  ],
+} as const;
+
+describe('launch hour determinism', () => {
+  it('produces different segment params for different launch hours on the same segment', () => {
+    const calmOptions = {
+      temperature: 1,
+      snowpackIndex: 0.1,
+      damReleaseSchedule: [] as const,
+    };
+    const damOptions = {
+      temperature: 1,
+      snowpackIndex: 0.1,
+      damReleaseSchedule: [{ hour: 14, release: 0.9 }] as const,
+    };
+
+    const calmLaunch = segmentParamsAtLaunchHour(BASE_PARAMS, 3, 0, calmOptions);
+    const damLaunch = segmentParamsAtLaunchHour(BASE_PARAMS, 14, 0, damOptions);
+
+    expect(calmLaunch).toEqual(
+      segmentParamsAtLaunchHour(BASE_PARAMS, 3, 0, calmOptions),
+    );
+    expect(calmLaunch.flowSpeed).not.toBe(damLaunch.flowSpeed);
+    expect(calmLaunch.segmentState).not.toBe(damLaunch.segmentState);
+  });
+
+  it('freezes forecast samples from the selected launch hour', () => {
+    const samples = buildLaunchForecast({
+      ...FORECAST_OPTIONS,
+      startHour: 14,
+      horizonHours: 8,
+    });
+    expect(samples[0].hour).toBe(14);
+    expect(samples).toEqual(
+      buildLaunchForecast({
+        ...FORECAST_OPTIONS,
+        startHour: 14,
+        horizonHours: 8,
+      }),
+    );
+  });
+
+  it('applies harder-hour score multipliers for elevated risk', () => {
+    expect(launchHourScoreMultiplier(FLOW_FORECAST_STATES.NORMAL)).toBe(1);
+    expect(launchHourScoreMultiplier(FLOW_FORECAST_STATES.HIGH_FLOW)).toBe(1.1);
+    expect(launchHourScoreMultiplier(FLOW_FORECAST_STATES.FLOODED)).toBe(1.25);
+    expect(launchHourScoreMultiplier(FLOW_FORECAST_STATES.WASHED_OUT)).toBe(1.5);
+  });
+
+  it('finds the next peak in the lookahead strip', () => {
+    const samples = buildLaunchForecast({
+      temperature: 18,
+      snowpackIndex: 1.2,
+      damReleaseSchedule: [{ hour: 2, release: 0.8 }],
+      startHour: 0,
+      horizonHours: 8,
+    });
+    const peak = nextPeakCountdown(samples);
+    expect(peak).not.toBeNull();
+    expect(peak!.hoursUntil).toBeGreaterThan(0);
+    expect(peak!.flowRate).toBeGreaterThan(samples[0].flowRate);
+  });
+
+  it('maps washed-out launch hours to bridge gaps', () => {
+    const applied = applyForecastToSegmentParams(
+      { ...BASE_PARAMS, hasBridge: true },
+      FLOW_FORECAST_STATES.WASHED_OUT,
+    );
+    expect(applied.washedOutGap).toBe(true);
+  });
+});

--- a/src/systems/__tests__/portageCache.test.ts
+++ b/src/systems/__tests__/portageCache.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CACHE_LOST_PENALTY,
+  canPlaceCache,
+  countLostCaches,
+  createPortageCacheRunState,
+  pendingRetrievalBonus,
+  placeCache,
+  reducePortageCacheState,
+  requiresPortageForSegment,
+  totalCacheRetrievalBonus,
+} from '../portageCache';
+
+const FIXTURE = {
+  cacheSlots: [
+    {
+      id: 'ridge-10',
+      segmentIndex: 10,
+      label: 'Rim shelf',
+      retrievalBonus: 250,
+    },
+    {
+      id: 'ledge-12',
+      segmentIndex: 12,
+      label: 'Side ledge',
+      retrievalBonus: 180,
+    },
+  ],
+  portageRoutes: [{ segmentIndex: 11, label: 'High-line portage' }],
+};
+
+describe('portageCache state machine', () => {
+  it('places up to the configured max caches', () => {
+    const initial = createPortageCacheRunState(FIXTURE);
+    expect(canPlaceCache(initial, 'ridge-10', 1)).toBe(true);
+    const placed = placeCache(initial, 'ridge-10', 1);
+    expect(canPlaceCache(placed, 'ledge-12', 1)).toBe(false);
+    expect(placed.cacheSlots.find((slot) => slot.id === 'ridge-10')?.status).toBe('placed');
+  });
+
+  it('retrieves placed caches on segment enter and tracks bonuses', () => {
+    let state = placeCache(createPortageCacheRunState(FIXTURE), 'ridge-10', 1);
+    state = reducePortageCacheState(state, {
+      type: 'ENTER_SEGMENT',
+      segmentIndex: 10,
+      requiresPortage: false,
+    });
+
+    const slot = state.cacheSlots.find((entry) => entry.id === 'ridge-10');
+    expect(slot?.status).toBe('retrieved');
+    expect(pendingRetrievalBonus(state, 10)).toBe(250);
+    expect(totalCacheRetrievalBonus(state)).toBe(250);
+  });
+
+  it('marks caches lost and portage failed on wipeout', () => {
+    let state = placeCache(createPortageCacheRunState(FIXTURE), 'ridge-10', 1);
+    state = reducePortageCacheState(state, {
+      type: 'ENTER_SEGMENT',
+      segmentIndex: 11,
+      requiresPortage: true,
+    });
+    state = reducePortageCacheState(state, { type: 'WIPEOUT', segmentIndex: 11 });
+
+    expect(countLostCaches(state)).toBe(0);
+    expect(state.portageRoutes[0]?.status).toBe('failed');
+
+    state = reducePortageCacheState(state, { type: 'WIPEOUT', segmentIndex: 10 });
+    expect(countLostCaches(state)).toBe(1);
+    expect(CACHE_LOST_PENALTY).toBeGreaterThan(0);
+  });
+
+  it('requires portage only for elevated flow on authored segments', () => {
+    expect(
+      requiresPortageForSegment(FIXTURE.portageRoutes, 11, 'Normal'),
+    ).toBe(false);
+    expect(
+      requiresPortageForSegment(FIXTURE.portageRoutes, 11, 'Flooded'),
+    ).toBe(true);
+    expect(
+      requiresPortageForSegment(FIXTURE.portageRoutes, 10, 'Flooded'),
+    ).toBe(false);
+  });
+});

--- a/src/systems/flowForecast.ts
+++ b/src/systems/flowForecast.ts
@@ -309,3 +309,64 @@ export function upcomingRiskStrip(
 export function isElevatedRisk(state: FlowForecastState | string): boolean {
   return coerceForecastState(state) !== FLOW_FORECAST_STATES.NORMAL;
 }
+
+/** Score multiplier for launching during elevated forecast risk at segment 0. */
+export function launchHourScoreMultiplier(state: FlowForecastState | string): number {
+  const normalized = coerceForecastState(state);
+  if (normalized === FLOW_FORECAST_STATES.WASHED_OUT) return 1.5;
+  if (normalized === FLOW_FORECAST_STATES.FLOODED) return 1.25;
+  if (normalized === FLOW_FORECAST_STATES.HIGH_FLOW) return 1.1;
+  return 1;
+}
+
+export type ForecastBuildOptions = {
+  temperature: number;
+  snowpackIndex: number;
+  damReleaseSchedule?: ReadonlyArray<DamReleaseEntry>;
+  startHour?: number;
+  horizonHours?: number;
+};
+
+/** Build the frozen hourly forecast for a run starting at `launchHour`. */
+export function buildLaunchForecast(options: ForecastBuildOptions): FlowForecastSample[] {
+  return buildForecastSamples(options);
+}
+
+/**
+ * Deterministic segment params for a launch hour + segment index.
+ * Segment index maps 1:1 to forecast sample offset from launch hour.
+ */
+export function segmentParamsAtLaunchHour(
+  base: ForecastSegmentParams,
+  launchHour: number,
+  segmentIndex: number,
+  forecastOptions: Omit<ForecastBuildOptions, 'startHour'>,
+): AppliedForecastParams {
+  const samples = buildLaunchForecast({
+    ...forecastOptions,
+    startHour: launchHour,
+    horizonHours: Math.max(24, segmentIndex + 1),
+  });
+  const state = samples[segmentIndex]?.state ?? FLOW_FORECAST_STATES.NORMAL;
+  return applyForecastToSegmentParams(base, state);
+}
+
+/** Next peak flow in the lookahead strip (hours until higher flow than now). */
+export function nextPeakCountdown(
+  samples: ReadonlyArray<FlowForecastSample>,
+): { hour: number; flowRate: number; hoursUntil: number } | null {
+  if (samples.length < 2) return null;
+
+  const current = samples[0];
+  let best: { hour: number; flowRate: number; hoursUntil: number } | null = null;
+
+  for (let i = 1; i < samples.length; i += 1) {
+    const sample = samples[i];
+    if (sample.flowRate <= current.flowRate + 0.02) continue;
+    if (!best || sample.flowRate > best.flowRate) {
+      best = { hour: sample.hour, flowRate: sample.flowRate, hoursUntil: i };
+    }
+  }
+
+  return best;
+}

--- a/src/systems/portageCache.ts
+++ b/src/systems/portageCache.ts
@@ -1,0 +1,189 @@
+/**
+ * portageCache.ts — Pure cache placement / retrieval state machine for a single run.
+ *
+ * Run-scoped state lives in runSession.ts; this module is pure logic + tests.
+ */
+
+export type CacheSlotStatus = 'unplaced' | 'placed' | 'retrieved' | 'lost';
+
+export type PortageRouteStatus = 'idle' | 'required' | 'in_progress' | 'completed' | 'failed';
+
+export interface CacheSlotDefinition {
+  id: string;
+  segmentIndex: number;
+  label: string;
+  retrievalBonus: number;
+}
+
+export interface PortageRouteDefinition {
+  segmentIndex: number;
+  label: string;
+}
+
+export interface CacheSlotState {
+  id: string;
+  segmentIndex: number;
+  status: CacheSlotStatus;
+  retrievalBonus: number;
+}
+
+export interface PortageRouteState {
+  segmentIndex: number;
+  status: PortageRouteStatus;
+}
+
+export interface PortageCacheRunState {
+  cacheSlots: CacheSlotState[];
+  portageRoutes: PortageRouteState[];
+}
+
+export type PortageCacheEvent =
+  | { type: 'PLACE_CACHE'; slotId: string }
+  | { type: 'ENTER_SEGMENT'; segmentIndex: number; requiresPortage: boolean }
+  | { type: 'EXIT_SEGMENT'; segmentIndex: number; survived: boolean }
+  | { type: 'WIPEOUT'; segmentIndex: number };
+
+export const DEFAULT_MAX_CACHE_PLACEMENTS = 1;
+
+export const CACHE_LOST_PENALTY = 300;
+export const PORTAGE_FAIL_PENALTY = 200;
+
+function cloneState(state: PortageCacheRunState): PortageCacheRunState {
+  return {
+    cacheSlots: state.cacheSlots.map((slot) => ({ ...slot })),
+    portageRoutes: state.portageRoutes.map((route) => ({ ...route })),
+  };
+}
+
+export function createPortageCacheRunState(options: {
+  cacheSlots?: ReadonlyArray<CacheSlotDefinition>;
+  portageRoutes?: ReadonlyArray<PortageRouteDefinition>;
+}): PortageCacheRunState {
+  return {
+    cacheSlots: (options.cacheSlots ?? []).map((slot) => ({
+      id: slot.id,
+      segmentIndex: slot.segmentIndex,
+      status: 'unplaced',
+      retrievalBonus: slot.retrievalBonus,
+    })),
+    portageRoutes: (options.portageRoutes ?? []).map((route) => ({
+      segmentIndex: route.segmentIndex,
+      status: 'idle',
+    })),
+  };
+}
+
+export function countPlacedCaches(state: PortageCacheRunState): number {
+  return state.cacheSlots.filter((slot) => slot.status === 'placed').length;
+}
+
+export function canPlaceCache(
+  state: PortageCacheRunState,
+  slotId: string,
+  maxPlacements = DEFAULT_MAX_CACHE_PLACEMENTS,
+): boolean {
+  const slot = state.cacheSlots.find((entry) => entry.id === slotId);
+  if (!slot || slot.status !== 'unplaced') return false;
+  return countPlacedCaches(state) < maxPlacements;
+}
+
+export function placeCache(
+  state: PortageCacheRunState,
+  slotId: string,
+  maxPlacements = DEFAULT_MAX_CACHE_PLACEMENTS,
+): PortageCacheRunState {
+  if (!canPlaceCache(state, slotId, maxPlacements)) return state;
+  const next = cloneState(state);
+  const slot = next.cacheSlots.find((entry) => entry.id === slotId);
+  if (slot) slot.status = 'placed';
+  return next;
+}
+
+export function reducePortageCacheState(
+  state: PortageCacheRunState,
+  event: PortageCacheEvent,
+): PortageCacheRunState {
+  const next = cloneState(state);
+
+  switch (event.type) {
+    case 'PLACE_CACHE': {
+      const slot = next.cacheSlots.find((entry) => entry.id === event.slotId);
+      if (slot && slot.status === 'unplaced') {
+        slot.status = 'placed';
+      }
+      return next;
+    }
+
+    case 'ENTER_SEGMENT': {
+      for (const slot of next.cacheSlots) {
+        if (slot.segmentIndex === event.segmentIndex && slot.status === 'placed') {
+          slot.status = 'retrieved';
+        }
+      }
+
+      if (event.requiresPortage) {
+        const route = next.portageRoutes.find((entry) => entry.segmentIndex === event.segmentIndex);
+        if (route && route.status === 'idle') {
+          route.status = 'required';
+        }
+        if (route && (route.status === 'required' || route.status === 'idle')) {
+          route.status = 'in_progress';
+        }
+      }
+      return next;
+    }
+
+    case 'EXIT_SEGMENT': {
+      const route = next.portageRoutes.find((entry) => entry.segmentIndex === event.segmentIndex);
+      if (!route) return next;
+      if (route.status === 'in_progress' || route.status === 'required') {
+        route.status = event.survived ? 'completed' : 'failed';
+      }
+      return next;
+    }
+
+    case 'WIPEOUT': {
+      for (const slot of next.cacheSlots) {
+        if (slot.segmentIndex === event.segmentIndex && slot.status === 'placed') {
+          slot.status = 'lost';
+        }
+      }
+
+      const route = next.portageRoutes.find((entry) => entry.segmentIndex === event.segmentIndex);
+      if (route && (route.status === 'in_progress' || route.status === 'required')) {
+        route.status = 'failed';
+      }
+      return next;
+    }
+
+    default:
+      return state;
+  }
+}
+
+export function requiresPortageForSegment(
+  portageRoutes: ReadonlyArray<PortageRouteDefinition>,
+  segmentIndex: number,
+  segmentState: string,
+): boolean {
+  const elevated =
+    segmentState === 'Flooded' || segmentState === 'WashedOut' || segmentState === 'HighFlow';
+  if (!elevated) return false;
+  return portageRoutes.some((route) => route.segmentIndex === segmentIndex);
+}
+
+export function totalCacheRetrievalBonus(state: PortageCacheRunState): number {
+  return state.cacheSlots
+    .filter((slot) => slot.status === 'retrieved')
+    .reduce((sum, slot) => sum + slot.retrievalBonus, 0);
+}
+
+export function countLostCaches(state: PortageCacheRunState): number {
+  return state.cacheSlots.filter((slot) => slot.status === 'lost').length;
+}
+
+export function pendingRetrievalBonus(state: PortageCacheRunState, segmentIndex: number): number {
+  return state.cacheSlots
+    .filter((slot) => slot.segmentIndex === segmentIndex && slot.status === 'retrieved')
+    .reduce((sum, slot) => sum + slot.retrievalBonus, 0);
+}

--- a/src/systems/runSession.ts
+++ b/src/systems/runSession.ts
@@ -1,0 +1,96 @@
+/**
+ * runSession.ts — Per-run session state (launch hour, cache placements).
+ *
+ * Not written to Zustand each frame; initialized at run start from persistence +
+ * StartMenu choices, then read by forecast / scoring systems.
+ */
+
+import type { MapRegistryId } from '../maps/registry';
+import { getMapSurvivalMetadata } from '../maps/survivalMetadata';
+import {
+  createPortageCacheRunState,
+  placeCache,
+  reducePortageCacheState,
+  type PortageCacheEvent,
+  type PortageCacheRunState,
+  DEFAULT_MAX_CACHE_PLACEMENTS,
+} from './portageCache';
+import { getLaunchHour } from './PersistenceSystem';
+
+export interface RunSessionSnapshot {
+  mapId: MapRegistryId;
+  launchHour: number;
+  placedCacheIds: string[];
+  portageCache: PortageCacheRunState;
+}
+
+let activeSession: RunSessionSnapshot | null = null;
+let awardedCacheSegments = new Set<number>();
+
+export function initRunSession(options: {
+  mapId: MapRegistryId;
+  launchHour?: number;
+  placedCacheIds?: string[];
+}): RunSessionSnapshot {
+  const survival = getMapSurvivalMetadata(options.mapId);
+  const launchHour = normalizeHour(options.launchHour ?? getLaunchHour());
+  const maxPlacements = survival.maxCachePlacements ?? DEFAULT_MAX_CACHE_PLACEMENTS;
+
+  let portageCache = createPortageCacheRunState({
+    cacheSlots: survival.cacheSlots,
+    portageRoutes: survival.portageRoutes,
+  });
+
+  const placedCacheIds: string[] = [];
+  for (const slotId of options.placedCacheIds ?? []) {
+    if (portageCache.cacheSlots.some((slot) => slot.id === slotId && slot.status === 'unplaced')) {
+      portageCache = placeCache(portageCache, slotId, maxPlacements);
+      if (portageCache.cacheSlots.find((slot) => slot.id === slotId)?.status === 'placed') {
+        placedCacheIds.push(slotId);
+      }
+    }
+  }
+
+  activeSession = {
+    mapId: options.mapId,
+    launchHour,
+    placedCacheIds,
+    portageCache,
+  };
+  awardedCacheSegments = new Set();
+  return activeSession;
+}
+
+export function getRunSession(): RunSessionSnapshot | null {
+  return activeSession;
+}
+
+export function getActiveLaunchHour(): number {
+  return activeSession?.launchHour ?? getLaunchHour();
+}
+
+export function dispatchPortageCacheEvent(event: PortageCacheEvent): PortageCacheRunState | null {
+  if (!activeSession) return null;
+  activeSession = {
+    ...activeSession,
+    portageCache: reducePortageCacheState(activeSession.portageCache, event),
+  };
+  return activeSession.portageCache;
+}
+
+export function markCacheBonusAwarded(segmentIndex: number): boolean {
+  if (awardedCacheSegments.has(segmentIndex)) return false;
+  awardedCacheSegments.add(segmentIndex);
+  return true;
+}
+
+export function resetRunSessionForTests(): void {
+  activeSession = null;
+  awardedCacheSegments = new Set();
+}
+
+function normalizeHour(hour: number): number {
+  if (!Number.isFinite(hour)) return 0;
+  const wrapped = Math.floor(hour) % 24;
+  return wrapped < 0 ? wrapped + 24 : wrapped;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Converts FlowForecast from a passive spectator into a pre-run decision system.

### Phase A — Launch hour
- **StartMenu** launch hour picker (slider + 24h risk strip) persists choice via `launchHour` in campaign saves
- Selected hour freezes the forecast curve for the run (`FlowForecast.startHour` → ChunkManager / ReachNormalizer)
- **ForecastHUD** shows chosen launch hour, next peak countdown, and existing dam-release countdown
- Harder-hour **score multipliers** on flood-survive bonuses (1.1× / 1.25× / 1.5×)

### Phase B — Portage & caches
- **Meander** map: trestle bridge on segment 11 (`hasBridge`), portage route + cache slot metadata in `survivalMetadata.ts`
- Pure **cache state machine** (`portageCache.ts`) with run-scoped session (`runSession.ts`) — not hot Zustand writes
- StartMenu **scout cache placement** (≤1 slot on meander)
- Scoring: cache retrieval bonus, gear-lost penalty on wipeout, portage-fail penalty on flooded segments

## Tests
- `launchHour.test.ts` — hour→params determinism, peak countdown, score multipliers
- `portageCache.test.ts` — place / retrieve / wipeout state machine
- `PersistenceSystem.test.ts` — launch hour persistence

## Verification
- `pnpm typecheck` ✅
- `pnpm test` ✅ (440 passed)

## Acceptance mapping
- [x] Launch hour selection → different segment params per hour
- [x] ForecastHUD shows launch hour + next peak / dam countdown
- [x] Meander defines portage route + cache slot
- [x] Place/retrieve cache affects score for the run
- [x] Unit tests for hour determinism + cache state machine
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c2eea9d-a258-4ad4-9182-9e9374f0fe41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c2eea9d-a258-4ad4-9182-9e9374f0fe41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Choose a launch hour before starting a run; forecasts, hazards, and scoring now reflect that selection.
  * Configure cache placements on supported maps for retrieval bonuses and survival strategies.
  * Added portage routes, cache loss penalties, and failure consequences during challenging segments.
  * Forecast displays now show upcoming peak-flow countdowns and improved launch-hour context.
* **Improvements**
  * Added bridge-aware map progression for more accurate washed-out segment behavior.
  * Launch-hour and run setup choices are preserved between sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->