### PR TITLE
feat(survival): Track A MVP — wetness, loadout, checkpoints

### DIFF
--- a/docs/reference/DOCUMENTATION_INDEX.md
+++ b/docs/reference/DOCUMENTATION_INDEX.md
@@ -41,6 +41,7 @@
 |-----|----------------|
 | [`PHYSICS_CONSTANTS.md`](./PHYSICS_CONSTANTS.md) | Tunable physics values |
 | [`MAPSYSTEM_STEP5_CONTRACT.md`](./MAPSYSTEM_STEP5_CONTRACT.md) | MapSystem ↔ TrackManager contract |
+| [`SURVIVAL_LAYER.md`](./SURVIVAL_LAYER.md) | Wetness, exposure, loadout, checkpoints (Track A) |
 | [`IMPROVEMENT_PLAN.md`](../archive/IMPROVEMENT_PLAN.md) | Longer-term engineering backlog (aspirational) |
 | [`plan.md`](./plan.md) | Biome / feature roadmap |
 | [`river_plan.md`](./river_plan.md) | River systems planning notes |

--- a/docs/reference/SURVIVAL_LAYER.md
+++ b/docs/reference/SURVIVAL_LAYER.md
@@ -1,0 +1,100 @@
+# Survival Layer (Track A)
+
+Living design note for the survival gameplay foundation. Track B (WebGPU / TSL) is intentionally deferred until this MVP is stable.
+
+## Goals
+
+- **Wetness** (0–1): water and spray in; sun and wind out.
+- **Temperature / exposure**: biome ambient cold/heat plus loadout insulation.
+- **Gear loadout**: pre-run selection on StartMenu (mass vs insulation).
+- **Checkpoints**: authored per map; latest checkpoint at or behind the player anchors respawn.
+
+State lives in **pure TS modules** (`src/systems/survival/`) and **runSession** — not per-frame Zustand writes.
+
+## Module map
+
+| Module | Role |
+|--------|------|
+| `survival/loadout.ts` | `trail-light` / `balanced` / `expedition` presets |
+| `survival/survivalState.ts` | Wetness + core temp tick + gameplay modifiers |
+| `survival/checkpointTable.ts` | `resolveRespawnSegment()` pure resolver |
+| `maps/survivalMetadata.ts` | Per-map checkpoints, caches, portage routes |
+| `runSession.ts` | Run-scoped survival instance + `tickRunSurvival()` |
+
+## State transitions
+
+### Wetness
+
+```
+DRY ──(in water)──► WET ──(sun + wind dry)──► DRY
+         │                                      ▲
+         └── spray near surface ────────────────┘
+```
+
+Rates (see `survivalState.ts`):
+
+- **Gain in water:** `WETNESS_GAIN_IN_WATER` per second while `pos.y < WATER_LEVEL + 0.55`.
+- **Dry:** base rate × sun factor (launch hour) × wind (horizontal speed).
+- **Gameplay:** wetness reduces sprint stamina regen; high wetness slightly muffles SFX (modifier exported, audio wiring deferred to settings #301 multiply).
+
+### Core temperature
+
+```
+ambient(biome) + insulation(loadout) - wetnessColdDrag ──lerp──► coreTemp (0–1)
+```
+
+- **Cold biomes** (`glacier`, `glacialMelt`): low ambient → core temp drops unless expedition kit.
+- **Exposure stress** (0–1): derived from core temp, biome cold bias, and wetness.
+
+### Gameplay modifiers (runner)
+
+Applied in `RunnerPhysicsStep.ts` via `tickRunSurvival()`:
+
+| Modifier | Cold biome effect | Wetness effect |
+|----------|-------------------|----------------|
+| Stamina drain | +up to 45% at max stress | — |
+| Stamina regen | −up to 35% at max stress | −25% at full wet |
+| Movement speed | −up to 8% at max stress | — |
+| Loadout | insulation + mass | regen/drain baselines |
+
+## Checkpoint graph (meander)
+
+Authored in `survivalMetadata.ts` (mirrors `meander_to_waterfall.json` spawns):
+
+| Segment | Label | Respawn window |
+|---------|-------|----------------|
+| 13 | Approach shelf | Segments 13–14 |
+| 15 | Splash pool | Segment 15+ |
+
+On `segment-enter`, `useExperienceLifecycle` calls:
+
+```ts
+resolveRespawnSegment(checkpoints, enteredSegment)
+```
+
+Returns the **latest** checkpoint segment ≤ entered segment; falls back to entered segment when none apply.
+
+## Pre-run loadout
+
+StartMenu → `LoadoutPicker` → `initRunSession({ loadoutId })`.
+
+HUD shows `LOADOUT <shortLabel>` (top-left) plus WET / EXPOSURE bars (bottom-left stack, imperative DOM).
+
+## Testing
+
+- `src/systems/__tests__/survivalState.test.ts` — wetness dry cycle, cold biome, modifier bounds.
+- `src/systems/__tests__/checkpointTable.test.ts` — meander checkpoint graph.
+
+## Future (post-MVP)
+
+- Raft wetness / paddle stamina coupling.
+- FlowForecast mid-run cache restock synergy.
+- Speed-based wind audio (plan.md).
+- `safeZone` OOB replacement for fixed `y < -80` wipeout.
+- Track B: NodeMaterial water/canyon under WebGL before WebGPU toggle.
+
+## Related
+
+- [`plan.md`](./plan.md) — roadmap / respawn backlog item
+- [`PHYSICS_CONSTANTS.md`](./PHYSICS_CONSTANTS.md) — runner tuning
+- Issue #301 — audio channel settings (SFX multiply for wetness)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -250,13 +250,14 @@ function App() {
   const handleStart = useCallback(
     (
       mapId: MapRegistryId = selectedMapId,
-      options?: { launchHour?: number; placedCacheIds?: string[] },
+      options?: { launchHour?: number; placedCacheIds?: string[]; loadoutId?: string },
     ) => {
       handleSelectMap(mapId);
       initRunSession({
         mapId,
         launchHour: options?.launchHour,
         placedCacheIds: options?.placedCacheIds,
+        loadoutId: options?.loadoutId,
       });
       setActiveLaunchHour(options?.launchHour ?? getLaunchHour());
       setPhase('playing');

--- a/src/components/GameHUD.tsx
+++ b/src/components/GameHUD.tsx
@@ -2,6 +2,13 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { usePlayerBiome, useGameStore } from '../systems/GameState';
 import { getActiveLaunchAirSeconds } from '../systems/LaunchScoringSession';
 import {
+  getActiveLoadoutId,
+  getActiveSurvivalModifiers,
+  getActiveSurvivalState,
+  getRunSession,
+} from '../systems/runSession';
+import { getLoadoutDefinition } from '../systems/survival';
+import {
   calculateBuoyancyAndDragFallback,
   getWasm,
   type NativeWaterForceResult,
@@ -61,6 +68,10 @@ export const GameHUD: React.FC<GameHUDProps> = ({
   const staminaFillRef = useRef<HTMLDivElement>(null);
   const staminaBarRef = useRef<HTMLDivElement>(null);
   const exhaustedRef = useRef(false);
+
+  const wetnessFillRef = useRef<HTMLDivElement>(null);
+  const exposureFillRef = useRef<HTMLDivElement>(null);
+  const loadoutLabelRef = useRef<HTMLSpanElement>(null);
 
   // Shelf launch popups — imperative DOM + CSS animation; no per-frame React state.
   const launchPopupRef = useRef<HTMLDivElement>(null);
@@ -144,6 +155,39 @@ export const GameHUD: React.FC<GameHUDProps> = ({
           el.classList.remove('launch-airtime-hud--visible');
         }
       }
+      raf = window.requestAnimationFrame(tick);
+    };
+    raf = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(raf);
+  }, []);
+
+  useEffect(() => {
+    let raf = 0;
+    const tick = () => {
+      const loadoutEl = loadoutLabelRef.current;
+      if (loadoutEl) {
+        const loadout = getLoadoutDefinition(getActiveLoadoutId());
+        loadoutEl.textContent = loadout.shortLabel;
+      }
+
+      const survival = getActiveSurvivalState();
+      const mods = getActiveSurvivalModifiers(useGameStore.getState().currentBiome);
+      const wetFill = wetnessFillRef.current;
+      const exposureFill = exposureFillRef.current;
+
+      if (survival && wetFill) {
+        wetFill.style.width = `${Math.round(survival.wetness * 100)}%`;
+        wetFill.style.backgroundColor =
+          survival.wetness > 0.65 ? '#38bdf8' : survival.wetness > 0.3 ? '#7dd3fc' : '#94a3b8';
+      }
+
+      if (mods && exposureFill) {
+        const stress = mods.exposureStress;
+        exposureFill.style.width = `${Math.round(stress * 100)}%`;
+        exposureFill.style.backgroundColor =
+          stress > 0.6 ? '#ef4444' : stress > 0.3 ? '#fbbf24' : '#86efac';
+      }
+
       raf = window.requestAnimationFrame(tick);
     };
     raf = window.requestAnimationFrame(tick);
@@ -382,7 +426,10 @@ export const GameHUD: React.FC<GameHUDProps> = ({
   return (
     <>
       <div className="fixed top-4 left-4 md:top-6 md:left-6 text-xs font-mono text-white/50 tracking-[0.12em]">
-        {biomeLabel}
+        <div>{biomeLabel}</div>
+        <div className="survival-loadout-badge">
+          LOADOUT <span ref={loadoutLabelRef}>—</span>
+        </div>
       </div>
 
       <div className="fixed top-4 right-4 md:top-6 md:right-6 bg-black/55 backdrop-blur-md text-right px-4 py-3 md:px-5 md:py-4 rounded-2xl border border-white/10 shadow-lg font-mono text-[#f5f1e8] min-w-[220px]">
@@ -437,11 +484,30 @@ export const GameHUD: React.FC<GameHUDProps> = ({
       </div>
 
       {vehicleType === 'runner' && (
-        <div className="stamina-bar" ref={staminaBarRef}>
-          <div className="stamina-bar__label">SPRINT</div>
-          <div className="stamina-bar__track">
-            <div className="stamina-fill" ref={staminaFillRef} style={{ width: '100%', backgroundColor: '#f8fafc' }} />
+        <div className="survival-hud-stack">
+          <div className="stamina-bar" ref={staminaBarRef}>
+            <div className="stamina-bar__label">SPRINT</div>
+            <div className="stamina-bar__track">
+              <div className="stamina-fill" ref={staminaFillRef} style={{ width: '100%', backgroundColor: '#f8fafc' }} />
+            </div>
           </div>
+
+          {getRunSession() && (
+            <>
+              <div className="survival-bar">
+                <div className="survival-bar__label">WET</div>
+                <div className="survival-bar__track">
+                  <div className="survival-fill" ref={wetnessFillRef} style={{ width: '0%' }} />
+                </div>
+              </div>
+              <div className="survival-bar">
+                <div className="survival-bar__label">EXPOSURE</div>
+                <div className="survival-bar__track">
+                  <div className="survival-fill" ref={exposureFillRef} style={{ width: '0%' }} />
+                </div>
+              </div>
+            </>
+          )}
         </div>
       )}
     </>

--- a/src/components/LoadoutPicker.tsx
+++ b/src/components/LoadoutPicker.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {
+  LOADOUT_LIST,
+  type LoadoutId,
+} from '../systems/survival';
+
+type LoadoutPickerProps = {
+  selectedId: LoadoutId;
+  onSelect: (id: LoadoutId) => void;
+};
+
+export default function LoadoutPicker({ selectedId, onSelect }: LoadoutPickerProps) {
+  return (
+    <div className="start-menu-loadout-panel">
+      <div className="start-menu-map-select-label">Gear Loadout</div>
+      <p className="start-menu-map-hint">
+        Mass vs insulation — affects cold exposure and sprint recovery.
+      </p>
+      {LOADOUT_LIST.map((loadout) => {
+        const selected = selectedId === loadout.id;
+        return (
+          <button
+            key={loadout.id}
+            type="button"
+            className={`start-menu-loadout-option ${selected ? 'active' : ''}`}
+            onClick={() => onSelect(loadout.id)}
+          >
+            <span className="start-menu-loadout-option-title">{loadout.label}</span>
+            <span className="start-menu-loadout-option-meta">{loadout.description}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -20,10 +20,15 @@ import {
 import { DAM_RELEASE_SCHEDULE } from '../experience/constants';
 import LaunchHourPicker from './LaunchHourPicker';
 import CachePlacementPanel from './CachePlacementPanel';
+import LoadoutPicker from './LoadoutPicker';
 import { DEFAULT_MAX_CACHE_PLACEMENTS } from '../systems/portageCache';
+import { DEFAULT_LOADOUT_ID, type LoadoutId } from '../systems/survival';
 
 interface StartMenuProps {
-  onStart: (mapId: MapRegistryId, options: { launchHour: number; placedCacheIds: string[] }) => void;
+  onStart: (
+    mapId: MapRegistryId,
+    options: { launchHour: number; placedCacheIds: string[]; loadoutId: LoadoutId },
+  ) => void;
   selectedMapId: MapRegistryId;
   onSelectMap: (mapId: MapRegistryId) => void;
   /** Open the full Options panel (audio, controls/rebinding, graphics). */
@@ -58,6 +63,7 @@ export const StartMenu: React.FC<StartMenuProps> = ({
   const maps = useMemo(() => listMapsForMenu(), []);
   const [launchHour, setLaunchHourLocal] = useState(() => getLaunchHour());
   const [placedCacheIds, setPlacedCacheIds] = useState<string[]>([]);
+  const [loadoutId, setLoadoutId] = useState<LoadoutId>(DEFAULT_LOADOUT_ID);
 
   const survivalMeta = useMemo(
     () => getMapSurvivalMetadata(selectedMapId),
@@ -145,6 +151,8 @@ export const StartMenu: React.FC<StartMenuProps> = ({
               damReleaseSchedule={DAM_RELEASE_SCHEDULE}
             />
 
+            <LoadoutPicker selectedId={loadoutId} onSelect={setLoadoutId} />
+
             {showSurvival && (
               <CachePlacementPanel
                 slots={survivalMeta.cacheSlots ?? []}
@@ -156,7 +164,7 @@ export const StartMenu: React.FC<StartMenuProps> = ({
 
             <button
               className="start-menu-start-btn"
-              onClick={() => onStart(selectedMapId, { launchHour, placedCacheIds })}
+              onClick={() => onStart(selectedMapId, { launchHour, placedCacheIds, loadoutId })}
               aria-label="Start Game - Click or Press Enter"
               autoFocus
             >

--- a/src/experience/hooks/useExperienceLifecycle.ts
+++ b/src/experience/hooks/useExperienceLifecycle.ts
@@ -20,6 +20,7 @@ import { isElevatedRisk } from '../../systems/flowForecast';
 import { getMapSurvivalMetadata } from '../../maps/survivalMetadata';
 import { countLostCaches, requiresPortageForSegment } from '../../systems/portageCache';
 import { dispatchPortageCacheEvent, getRunSession } from '../../systems/runSession';
+import { resolveRespawnSegment } from '../../systems/survival';
 import type { DebugStageController } from '../../debug/debugStages';
 import type { VehicleRigidBodyRef } from '../types';
 
@@ -189,7 +190,8 @@ export function useExperienceLifecycle({
         };
 
         setCurrentSegmentIndex(index);
-        setRespawnSegmentIndex(index);
+        const respawnSegment = resolveRespawnSegment(survivalMeta.checkpoints ?? [], index);
+        setRespawnSegmentIndex(respawnSegment);
 
         if (detail?.gravityMultiplier !== undefined) {
           setWaterfallGravityMultiplier(detail.gravityMultiplier);

--- a/src/experience/hooks/useExperienceWorld.ts
+++ b/src/experience/hooks/useExperienceWorld.ts
@@ -378,6 +378,7 @@ export function useExperienceWorld({
           mapId: targetMapId,
           launchHour: getActiveLaunchHour(),
           placedCacheIds: getRunSession()?.placedCacheIds ?? [],
+          loadoutId: getRunSession()?.loadoutId,
         });
         useGameStore.getState().resetGameState();
         setIsWipeout(false);

--- a/src/maps/survivalMetadata.ts
+++ b/src/maps/survivalMetadata.ts
@@ -4,15 +4,32 @@
 
 import type { MapRegistryId } from './registry';
 import type { CacheSlotDefinition, PortageRouteDefinition } from '../systems/portageCache';
+import type { CheckpointDefinition } from '../systems/survival';
 
 export interface MapSurvivalMetadata {
   maxCachePlacements?: number;
   cacheSlots?: CacheSlotDefinition[];
   portageRoutes?: PortageRouteDefinition[];
+  /** Authored respawn anchors — latest segment at or behind player wins. */
+  checkpoints?: CheckpointDefinition[];
 }
 
 const SURVIVAL_BY_MAP: Partial<Record<MapRegistryId, MapSurvivalMetadata>> = {
   meander: {
+    checkpoints: [
+      {
+        segment: 13,
+        label: 'Approach shelf',
+        position: [0, -20, -300],
+        radius: 30,
+      },
+      {
+        segment: 15,
+        label: 'Splash pool',
+        position: [0, -35, -700],
+        radius: 40,
+      },
+    ],
     maxCachePlacements: 1,
     cacheSlots: [
       {
@@ -37,5 +54,9 @@ export function getMapSurvivalMetadata(mapId: MapRegistryId): MapSurvivalMetadat
 
 export function mapHasSurvivalFeatures(mapId: MapRegistryId): boolean {
   const meta = getMapSurvivalMetadata(mapId);
-  return Boolean(meta.cacheSlots?.length || meta.portageRoutes?.length);
+  return Boolean(
+    meta.cacheSlots?.length ||
+      meta.portageRoutes?.length ||
+      meta.checkpoints?.length,
+  );
 }

--- a/src/style.css
+++ b/src/style.css
@@ -600,6 +600,46 @@ canvas {
   color: rgba(255, 255, 255, 0.55);
 }
 
+.start-menu-loadout-panel {
+  width: 100%;
+  margin-bottom: 12px;
+  padding: 12px;
+  border-radius: 10px;
+  background: rgba(120, 180, 255, 0.06);
+  border: 1px solid rgba(120, 180, 255, 0.18);
+}
+
+.start-menu-loadout-option {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  margin-top: 8px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(0, 0, 0, 0.18);
+  color: #f4efe3;
+  cursor: pointer;
+  text-align: left;
+}
+
+.start-menu-loadout-option.active {
+  border-color: rgba(120, 180, 255, 0.65);
+  background: rgba(120, 180, 255, 0.14);
+}
+
+.start-menu-loadout-option-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.start-menu-loadout-option-meta {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.55);
+}
+
 .start-menu-title-group {
   margin-bottom: 32px;
 }
@@ -1216,6 +1256,62 @@ canvas {
 @keyframes stamina-pulse {
   from { opacity: 0.3; }
   to   { opacity: 1.0; }
+}
+
+/* ===== SURVIVAL HUD (wetness / exposure) ===== */
+.survival-hud-stack {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+@media (min-width: 768px) {
+  .survival-hud-stack {
+    bottom: 1.5rem;
+    left: 1.5rem;
+  }
+}
+
+.survival-hud-stack .stamina-bar {
+  position: static;
+}
+
+.survival-loadout-badge {
+  margin-top: 6px;
+  font-size: 0.55rem;
+  letter-spacing: 0.14em;
+  color: rgba(255, 255, 255, 0.38);
+}
+
+.survival-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.survival-bar__label {
+  font-size: 0.55rem;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.38);
+  text-transform: uppercase;
+}
+
+.survival-bar__track {
+  width: 120px;
+  height: 3px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.survival-fill {
+  height: 100%;
+  border-radius: 2px;
+  will-change: width;
 }
 
 /* ===== SHELF LAUNCH AIR-TIME POPUPS ===== */

--- a/src/systems/__tests__/checkpointTable.test.ts
+++ b/src/systems/__tests__/checkpointTable.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  activeCheckpoint,
+  resolveRespawnSegment,
+  type CheckpointDefinition,
+} from '../survival/checkpointTable';
+
+const MEANDER_CHECKPOINTS: CheckpointDefinition[] = [
+  { segment: 13, label: 'Approach shelf' },
+  { segment: 15, label: 'Splash pool' },
+];
+
+describe('checkpointTable', () => {
+  it('returns entered segment when no checkpoints exist', () => {
+    expect(resolveRespawnSegment([], 7)).toBe(7);
+  });
+
+  it('keeps entered segment before the first authored checkpoint', () => {
+    expect(resolveRespawnSegment(MEANDER_CHECKPOINTS, 5)).toBe(5);
+    expect(resolveRespawnSegment(MEANDER_CHECKPOINTS, 12)).toBe(12);
+  });
+
+  it('anchors respawn at approach shelf through the waterfall', () => {
+    expect(resolveRespawnSegment(MEANDER_CHECKPOINTS, 13)).toBe(13);
+    expect(resolveRespawnSegment(MEANDER_CHECKPOINTS, 14)).toBe(13);
+  });
+
+  it('advances respawn to splash pool after segment 15', () => {
+    expect(resolveRespawnSegment(MEANDER_CHECKPOINTS, 15)).toBe(15);
+    expect(resolveRespawnSegment(MEANDER_CHECKPOINTS, 18)).toBe(15);
+    expect(resolveRespawnSegment(MEANDER_CHECKPOINTS, 22)).toBe(15);
+  });
+
+  it('reports the active checkpoint label for HUD/debug', () => {
+    expect(activeCheckpoint(MEANDER_CHECKPOINTS, 14)?.label).toBe('Approach shelf');
+    expect(activeCheckpoint(MEANDER_CHECKPOINTS, 16)?.label).toBe('Splash pool');
+    expect(activeCheckpoint(MEANDER_CHECKPOINTS, 2)).toBeNull();
+  });
+});

--- a/src/systems/__tests__/survivalState.test.ts
+++ b/src/systems/__tests__/survivalState.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { getLoadoutDefinition } from '../survival/loadout';
+import {
+  createSurvivalState,
+  getBiomeAmbientTemp,
+  getSurvivalModifiers,
+  tickSurvivalState,
+} from '../survival/survivalState';
+
+describe('survivalState transitions', () => {
+  it('ramps wetness while in water and dries in sun', () => {
+    const loadout = getLoadoutDefinition('balanced');
+    let state = createSurvivalState();
+
+    state = tickSurvivalState(
+      state,
+      {
+        dt: 1,
+        biomeId: 'canyonSummer',
+        inWater: true,
+        windSpeed: 0,
+        launchHour: 12,
+      },
+      loadout,
+    );
+    expect(state.wetness).toBeGreaterThan(0.4);
+
+    state = tickSurvivalState(
+      state,
+      {
+        dt: 4,
+        biomeId: 'canyonSummer',
+        inWater: false,
+        windSpeed: 18,
+        launchHour: 12,
+      },
+      loadout,
+    );
+    expect(state.wetness).toBeLessThan(0.35);
+  });
+
+  it('drops core temp in glacier biomes, mitigated by expedition kit', () => {
+    const light = getLoadoutDefinition('trail-light');
+    const expedition = getLoadoutDefinition('expedition');
+
+    let lightState = createSurvivalState();
+    let expeditionState = createSurvivalState();
+
+    for (let i = 0; i < 20; i += 1) {
+      lightState = tickSurvivalState(
+        lightState,
+        {
+          dt: 0.5,
+          biomeId: 'glacier',
+          inWater: false,
+          windSpeed: 4,
+          launchHour: 6,
+        },
+        light,
+      );
+      expeditionState = tickSurvivalState(
+        expeditionState,
+        {
+          dt: 0.5,
+          biomeId: 'glacier',
+          inWater: false,
+          windSpeed: 4,
+          launchHour: 6,
+        },
+        expedition,
+      );
+    }
+
+    expect(lightState.coreTemp).toBeLessThan(expeditionState.coreTemp);
+    expect(getBiomeAmbientTemp('glacier')).toBeLessThan(getBiomeAmbientTemp('canyonSummer'));
+  });
+
+  it('applies cold biome stamina penalties and wetness regen loss', () => {
+    const loadout = getLoadoutDefinition('balanced');
+    const dry = getSurvivalModifiers(
+      { wetness: 0, coreTemp: 0.9 },
+      'canyonSummer',
+      loadout,
+    );
+    const coldWet = getSurvivalModifiers(
+      { wetness: 0.8, coreTemp: 0.35 },
+      'glacier',
+      loadout,
+    );
+
+    expect(coldWet.staminaDrainMultiplier).toBeGreaterThan(dry.staminaDrainMultiplier);
+    expect(coldWet.staminaRegenMultiplier).toBeLessThan(dry.staminaRegenMultiplier);
+    expect(coldWet.exposureStress).toBeGreaterThan(0.2);
+    expect(coldWet.sfxWetnessMultiplier).toBeLessThan(1);
+  });
+});

--- a/src/systems/runSession.ts
+++ b/src/systems/runSession.ts
@@ -1,8 +1,8 @@
 /**
- * runSession.ts — Per-run session state (launch hour, cache placements).
+ * runSession.ts — Per-run session state (launch hour, cache placements, survival).
  *
  * Not written to Zustand each frame; initialized at run start from persistence +
- * StartMenu choices, then read by forecast / scoring systems.
+ * StartMenu choices, then read by forecast / scoring / physics systems.
  */
 
 import type { MapRegistryId } from '../maps/registry';
@@ -16,12 +16,25 @@ import {
   DEFAULT_MAX_CACHE_PLACEMENTS,
 } from './portageCache';
 import { getLaunchHour } from './PersistenceSystem';
+import {
+  createSurvivalState,
+  getLoadoutDefinition,
+  getSurvivalModifiers,
+  resolveLoadoutId,
+  tickSurvivalState,
+  type LoadoutId,
+  type SurvivalModifiers,
+  type SurvivalState,
+  type SurvivalTickInput,
+} from './survival';
 
 export interface RunSessionSnapshot {
   mapId: MapRegistryId;
   launchHour: number;
   placedCacheIds: string[];
+  loadoutId: LoadoutId;
   portageCache: PortageCacheRunState;
+  survival: SurvivalState;
 }
 
 let activeSession: RunSessionSnapshot | null = null;
@@ -31,10 +44,12 @@ export function initRunSession(options: {
   mapId: MapRegistryId;
   launchHour?: number;
   placedCacheIds?: string[];
+  loadoutId?: LoadoutId | string;
 }): RunSessionSnapshot {
   const survival = getMapSurvivalMetadata(options.mapId);
   const launchHour = normalizeHour(options.launchHour ?? getLaunchHour());
   const maxPlacements = survival.maxCachePlacements ?? DEFAULT_MAX_CACHE_PLACEMENTS;
+  const loadoutId = resolveLoadoutId(options.loadoutId);
 
   let portageCache = createPortageCacheRunState({
     cacheSlots: survival.cacheSlots,
@@ -55,7 +70,9 @@ export function initRunSession(options: {
     mapId: options.mapId,
     launchHour,
     placedCacheIds,
+    loadoutId,
     portageCache,
+    survival: createSurvivalState(),
   };
   awardedCacheSegments = new Set();
   return activeSession;
@@ -67,6 +84,37 @@ export function getRunSession(): RunSessionSnapshot | null {
 
 export function getActiveLaunchHour(): number {
   return activeSession?.launchHour ?? getLaunchHour();
+}
+
+export function getActiveLoadoutId(): LoadoutId {
+  return activeSession?.loadoutId ?? resolveLoadoutId(undefined);
+}
+
+export function getActiveSurvivalState(): SurvivalState | null {
+  return activeSession?.survival ?? null;
+}
+
+export function getActiveSurvivalModifiers(biomeId: SurvivalTickInput['biomeId']): SurvivalModifiers | null {
+  if (!activeSession) return null;
+  return getSurvivalModifiers(
+    activeSession.survival,
+    biomeId,
+    getLoadoutDefinition(activeSession.loadoutId),
+  );
+}
+
+export function tickRunSurvival(input: Omit<SurvivalTickInput, 'launchHour'>): SurvivalModifiers | null {
+  if (!activeSession) return null;
+  const loadout = getLoadoutDefinition(activeSession.loadoutId);
+  activeSession = {
+    ...activeSession,
+    survival: tickSurvivalState(
+      activeSession.survival,
+      { ...input, launchHour: activeSession.launchHour },
+      loadout,
+    ),
+  };
+  return getSurvivalModifiers(activeSession.survival, input.biomeId, loadout);
 }
 
 export function dispatchPortageCacheEvent(event: PortageCacheEvent): PortageCacheRunState | null {

--- a/src/systems/survival/checkpointTable.ts
+++ b/src/systems/survival/checkpointTable.ts
@@ -1,0 +1,56 @@
+/**
+ * checkpointTable.ts — Pure checkpoint graph for OOB / void-fall respawn.
+ *
+ * Authored per map in survivalMetadata; runtime picks the latest checkpoint
+ * at or behind the player's current segment.
+ */
+
+export interface CheckpointDefinition {
+  segment: number;
+  label: string;
+  position?: readonly [number, number, number];
+  radius?: number;
+}
+
+export type CheckpointTable = ReadonlyArray<CheckpointDefinition>;
+
+/**
+ * Given a segment enter event, return the respawn segment index.
+ * Falls back to `enteredSegment` when no checkpoints are defined.
+ */
+export function resolveRespawnSegment(
+  checkpoints: CheckpointTable,
+  enteredSegment: number,
+): number {
+  if (!checkpoints.length) return enteredSegment;
+
+  let best: number | null = null;
+  for (const cp of checkpoints) {
+    if (cp.segment <= enteredSegment) {
+      if (best === null || cp.segment > best) {
+        best = cp.segment;
+      }
+    }
+  }
+  return best ?? enteredSegment;
+}
+
+/**
+ * Returns the checkpoint that would be used for respawn at `enteredSegment`.
+ */
+export function activeCheckpoint(
+  checkpoints: CheckpointTable,
+  enteredSegment: number,
+): CheckpointDefinition | null {
+  if (!checkpoints.length) return null;
+
+  let best: CheckpointDefinition | null = null;
+  for (const cp of checkpoints) {
+    if (cp.segment <= enteredSegment) {
+      if (!best || cp.segment > best.segment) {
+        best = cp;
+      }
+    }
+  }
+  return best;
+}

--- a/src/systems/survival/index.ts
+++ b/src/systems/survival/index.ts
@@ -1,0 +1,29 @@
+export {
+  type LoadoutId,
+  type LoadoutDefinition,
+  LOADOUT_DEFINITIONS,
+  LOADOUT_LIST,
+  DEFAULT_LOADOUT_ID,
+  isLoadoutId,
+  resolveLoadoutId,
+  getLoadoutDefinition,
+} from './loadout';
+
+export {
+  type CheckpointDefinition,
+  type CheckpointTable,
+  resolveRespawnSegment,
+  activeCheckpoint,
+} from './checkpointTable';
+
+export {
+  type SurvivalState,
+  type SurvivalTickInput,
+  type SurvivalModifiers,
+  SURVIVAL_INITIAL,
+  createSurvivalState,
+  tickSurvivalState,
+  getBiomeAmbientTemp,
+  computeExposureStress,
+  getSurvivalModifiers,
+} from './survivalState';

--- a/src/systems/survival/loadout.ts
+++ b/src/systems/survival/loadout.ts
@@ -1,0 +1,72 @@
+/**
+ * loadout.ts — Pre-run gear presets (mass vs insulation vs raft kit).
+ *
+ * Pure data + helpers; selection lives in StartMenu and runSession.
+ */
+
+export type LoadoutId = 'trail-light' | 'balanced' | 'expedition';
+
+export interface LoadoutDefinition {
+  id: LoadoutId;
+  label: string;
+  shortLabel: string;
+  description: string;
+  /** Multiplier on movement impulse (lower = heavier kit). */
+  movementMultiplier: number;
+  /** Insulation bonus subtracted from ambient cold stress (0–1 scale). */
+  insulation: number;
+  /** Base sprint stamina regen multiplier. */
+  staminaRegenMultiplier: number;
+  /** Base sprint stamina drain multiplier. */
+  staminaDrainMultiplier: number;
+}
+
+export const LOADOUT_DEFINITIONS: Record<LoadoutId, LoadoutDefinition> = {
+  'trail-light': {
+    id: 'trail-light',
+    label: 'Trail Light',
+    shortLabel: 'LIGHT',
+    description: 'Minimal kit — fast drying, weak cold protection.',
+    movementMultiplier: 1.06,
+    insulation: 0.05,
+    staminaRegenMultiplier: 1.1,
+    staminaDrainMultiplier: 1.0,
+  },
+  balanced: {
+    id: 'balanced',
+    label: 'Balanced',
+    shortLabel: 'BALANCED',
+    description: 'Standard runner kit for mixed canyon biomes.',
+    movementMultiplier: 1.0,
+    insulation: 0.2,
+    staminaRegenMultiplier: 1.0,
+    staminaDrainMultiplier: 1.0,
+  },
+  expedition: {
+    id: 'expedition',
+    label: 'Expedition',
+    shortLabel: 'EXPED',
+    description: 'Insulated layers — slower but resists glacial cold.',
+    movementMultiplier: 0.94,
+    insulation: 0.45,
+    staminaRegenMultiplier: 0.92,
+    staminaDrainMultiplier: 0.88,
+  },
+};
+
+export const DEFAULT_LOADOUT_ID: LoadoutId = 'balanced';
+
+export const LOADOUT_LIST: LoadoutDefinition[] = Object.values(LOADOUT_DEFINITIONS);
+
+export function isLoadoutId(value: string): value is LoadoutId {
+  return value in LOADOUT_DEFINITIONS;
+}
+
+export function resolveLoadoutId(value: string | undefined): LoadoutId {
+  if (value && isLoadoutId(value)) return value;
+  return DEFAULT_LOADOUT_ID;
+}
+
+export function getLoadoutDefinition(id: LoadoutId): LoadoutDefinition {
+  return LOADOUT_DEFINITIONS[id];
+}

--- a/src/systems/survival/survivalState.ts
+++ b/src/systems/survival/survivalState.ts
@@ -1,0 +1,156 @@
+/**
+ * survivalState.ts — Pure wetness / temperature transitions for Track A.
+ *
+ * Run-scoped instance lives in runSession; tick from physics, not Zustand.
+ */
+
+import type { BiomeId } from '../../configs/biomes';
+import type { LoadoutDefinition } from './loadout';
+
+/** Normalized comfort: 1 = warm/optimal, 0 = hypothermic. */
+export interface SurvivalState {
+  wetness: number;
+  coreTemp: number;
+}
+
+export interface SurvivalTickInput {
+  dt: number;
+  biomeId: BiomeId;
+  /** Player feet/body in or very near water. */
+  inWater: boolean;
+  /** Horizontal speed (m/s) — drives wind drying. */
+  windSpeed: number;
+  /** Launch hour 0–23 — midday dries faster. */
+  launchHour: number;
+}
+
+export interface SurvivalModifiers {
+  staminaDrainMultiplier: number;
+  staminaRegenMultiplier: number;
+  movementMultiplier: number;
+  /** 0–1 cold/heat stress for HUD (higher = worse). */
+  exposureStress: number;
+  /** Wetness-based SFX attenuation (1 = dry, lower = muffled). */
+  sfxWetnessMultiplier: number;
+}
+
+export const SURVIVAL_INITIAL: SurvivalState = {
+  wetness: 0,
+  coreTemp: 1,
+};
+
+/** Ambient target core temp per biome (0–1). */
+const BIOME_AMBIENT_TEMP: Partial<Record<BiomeId, number>> = {
+  glacier: 0.35,
+  glacialMelt: 0.42,
+  canyonSummer: 0.88,
+  canyonAutumn: 0.78,
+  slotCanyon: 0.82,
+  delta: 0.9,
+  alpineSpring: 0.72,
+  cavern: 0.55,
+  midnightMist: 0.5,
+  lumberFlume: 0.7,
+  hydroDam: 0.65,
+};
+
+const DEFAULT_AMBIENT_TEMP = 0.75;
+
+const WETNESS_GAIN_IN_WATER = 0.55;
+const WETNESS_SPRAY_GAIN = 0.12;
+const WETNESS_DRY_BASE = 0.08;
+const WETNESS_WIND_DRY_SCALE = 0.025;
+const TEMP_LERP_RATE = 0.35;
+const WETNESS_COLD_PENALTY = 0.18;
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function sunDryingFactor(launchHour: number): number {
+  const hour = ((launchHour % 24) + 24) % 24;
+  const noonDistance = Math.abs(hour - 12) / 12;
+  return 0.35 + (1 - noonDistance) * 0.65;
+}
+
+export function getBiomeAmbientTemp(biomeId: BiomeId): number {
+  return BIOME_AMBIENT_TEMP[biomeId] ?? DEFAULT_AMBIENT_TEMP;
+}
+
+export function createSurvivalState(): SurvivalState {
+  return { ...SURVIVAL_INITIAL };
+}
+
+export function tickSurvivalState(
+  state: SurvivalState,
+  input: SurvivalTickInput,
+  loadout: LoadoutDefinition,
+): SurvivalState {
+  const next: SurvivalState = { ...state };
+  const ambient = getBiomeAmbientTemp(input.biomeId);
+  const insulatedAmbient = clamp01(ambient + loadout.insulation * 0.25);
+
+  if (input.inWater) {
+    next.wetness = clamp01(next.wetness + WETNESS_GAIN_IN_WATER * input.dt);
+  } else if (next.wetness > 0.05) {
+    const dryRate =
+      (WETNESS_DRY_BASE + input.windSpeed * WETNESS_WIND_DRY_SCALE) *
+      sunDryingFactor(input.launchHour);
+    next.wetness = clamp01(next.wetness - dryRate * input.dt);
+  }
+
+  if (input.inWater && next.wetness > 0.6) {
+    next.wetness = clamp01(next.wetness + WETNESS_SPRAY_GAIN * input.dt * 0.25);
+  }
+
+  const wetColdDrag = next.wetness * WETNESS_COLD_PENALTY;
+  const targetTemp = clamp01(insulatedAmbient - wetColdDrag);
+  const lerp = 1 - Math.exp(-TEMP_LERP_RATE * input.dt);
+  next.coreTemp = clamp01(next.coreTemp + (targetTemp - next.coreTemp) * lerp);
+
+  return next;
+}
+
+export function computeExposureStress(
+  state: SurvivalState,
+  biomeId: BiomeId,
+): number {
+  const ambient = getBiomeAmbientTemp(biomeId);
+  const coldStress = clamp01((0.55 - state.coreTemp) * 1.4);
+  const heatStress = clamp01((state.coreTemp - 0.95) * 2);
+  const biomeColdBias = ambient < 0.5 ? (0.5 - ambient) * 0.6 : 0;
+  return clamp01(coldStress + heatStress + biomeColdBias + state.wetness * 0.15);
+}
+
+export function getSurvivalModifiers(
+  state: SurvivalState,
+  biomeId: BiomeId,
+  loadout: LoadoutDefinition,
+): SurvivalModifiers {
+  const exposureStress = computeExposureStress(state, biomeId);
+  const isColdBiome = getBiomeAmbientTemp(biomeId) < 0.5;
+
+  let staminaDrainMul = loadout.staminaDrainMultiplier;
+  let staminaRegenMul = loadout.staminaRegenMultiplier;
+
+  if (isColdBiome) {
+    staminaDrainMul *= 1 + exposureStress * 0.45;
+    staminaRegenMul *= 1 - exposureStress * 0.35;
+  }
+
+  staminaRegenMul *= 1 - state.wetness * 0.25;
+
+  const movementMul =
+    loadout.movementMultiplier *
+    (1 - (isColdBiome ? exposureStress * 0.08 : 0));
+
+  const sfxWetnessMultiplier = 1 - state.wetness * 0.35;
+
+  return {
+    staminaDrainMultiplier: staminaDrainMul,
+    staminaRegenMultiplier: staminaRegenMul,
+    movementMultiplier: movementMul,
+    exposureStress,
+    sfxWetnessMultiplier,
+  };
+}

--- a/src/vehicles/RunnerVehicle/hooks/RunnerPhysicsStep.ts
+++ b/src/vehicles/RunnerVehicle/hooks/RunnerPhysicsStep.ts
@@ -22,7 +22,8 @@ import {
   hasActiveLaunch,
 } from '../../../systems/LaunchScoringSession';
 import { emitShelfLaunch } from '../../../systems/shelfLaunchEvents';
-import { isAutumnLike } from '../../../configs/biomes';
+import { isAutumnLike, isBiomeId, type BiomeId } from '../../../configs/biomes';
+import { tickRunSurvival } from '../../../systems/runSession';
 
 type Vec3 = { x: number; y: number; z: number };
 
@@ -400,6 +401,20 @@ export function updateRunnerPhysics({
     const storeState = useGameStore.getState();
     let stamina = storeState.sprintStamina;
 
+    const biomeId: BiomeId = isBiomeId(storeState.currentBiome)
+      ? storeState.currentBiome
+      : 'canyonSummer';
+    const horizontalSpeed = Math.sqrt(vel.x * vel.x + vel.z * vel.z);
+    const survivalMods = tickRunSurvival({
+      dt,
+      biomeId,
+      inWater: pos.y < WATER_LEVEL + 0.55,
+      windSpeed: horizontalSpeed,
+    });
+    const staminaDrainMul = survivalMods?.staminaDrainMultiplier ?? 1;
+    const staminaRegenMul = survivalMods?.staminaRegenMultiplier ?? 1;
+    const movementMul = survivalMods?.movementMultiplier ?? 1;
+
     // Hysteresis: once exhausted, lock sprint until RECOVERY_THRESHOLD is reached
     if (stamina <= RUNNER_SPRINT.EXHAUSTION_THRESHOLD) {
       sprintLockedRef.current = true;
@@ -413,13 +428,13 @@ export function updateRunnerPhysics({
 
     if (isSprinting) {
       // Drain while grounded and sprinting
-      stamina = Math.max(0, stamina - RUNNER_SPRINT.DRAIN_RATE * dt);
+      stamina = Math.max(0, stamina - RUNNER_SPRINT.DRAIN_RATE * staminaDrainMul * dt);
     } else if (isAirborne) {
       // Faster recovery while airborne
-      stamina = Math.min(1, stamina + RUNNER_SPRINT.REGEN_AIRBORNE * dt);
+      stamina = Math.min(1, stamina + RUNNER_SPRINT.REGEN_AIRBORNE * staminaRegenMul * dt);
     } else {
       // Normal grounded recovery when not sprinting
-      stamina = Math.min(1, stamina + RUNNER_SPRINT.REGEN_GROUNDED * dt);
+      stamina = Math.min(1, stamina + RUNNER_SPRINT.REGEN_GROUNDED * staminaRegenMul * dt);
     }
     storeState.setSprintStamina(stamina);
 
@@ -620,7 +635,7 @@ export function updateRunnerPhysics({
 
     const baseSpeed = VEHICLE_TUNING.baseSpeed;
     const sprintMultiplier = isSprinting ? RUNNER_SPRINT.SPEED_MULTIPLIER : 1.0;
-    const speed = baseSpeed * flowMultiplier * recoveryFactor * sprintMultiplier;
+    const speed = baseSpeed * flowMultiplier * recoveryFactor * sprintMultiplier * movementMul;
 
     if (forward) {
       applyImpulseWithDebugTracking('forwardInput', {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Track A (Survival layer MVP)** from the P2 epic — gameplay depth before renderer migration.

### What's included

- **Pure TS survival modules** (`src/systems/survival/`): loadout presets, wetness/temperature tick, checkpoint respawn resolver
- **Run-scoped state** in `runSession.ts` — survival ticks from physics, not per-frame Zustand writes
- **Pre-run gear loadout** via new `LoadoutPicker` on StartMenu (`trail-light` / `balanced` / `expedition`)
- **HUD**: loadout badge (top-left) + WET / EXPOSURE bars (bottom-left, imperative DOM)
- **Meander checkpoint table** wired on `segment-enter` — respawn anchors at segments 13 (approach) and 15 (splash pool)
- **Gameplay effect**: cold biomes + wetness modify runner sprint stamina drain/regen and movement speed
- **Design note**: `docs/reference/SURVIVAL_LAYER.md` with state transition diagrams

### Track A acceptance checklist

- [x] Design note in `docs/reference/` with state transitions
- [x] Wetness or temperature affects movement **or** stamina in ≥1 biome (glacier cold → stamina; wetness → regen)
- [x] Loadout selectable pre-run; visible on HUD
- [x] Checkpoint table authored for meander; unit tests for pure transitions
- [x] No regression on typecheck/tests (448 tests pass)

### Deferred (post-MVP / Track B)

- SFX wetness multiply through AudioSystem (#301)
- Speed-based wind audio
- `safeZone` OOB replacement for fixed `y < -80`
- WebGPU / TSL material path (Track B)

### Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (includes `survivalState.test.ts`, `checkpointTable.test.ts`)
- [ ] `pnpm test:visual-smoke` (requires preview server on :4173 — not run in cloud agent env)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92e9450e-d7e1-4cb9-8eb5-6f106deef087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92e9450e-d7e1-4cb9-8eb5-6f106deef087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

