### PR TITLE
feat(audio): speed-based wind bed for feel-of-velocity (#316)

### DIFF
--- a/src/components/ReactiveAudio.test.tsx
+++ b/src/components/ReactiveAudio.test.tsx
@@ -100,6 +100,15 @@ describe('ReactiveAudio', () => {
     expect(sourceFile).toContain('isFinite(rawFlowSpeed) ? rawFlowSpeed : 1');
   });
 
+  it('mounts SpeedWindAudio for the continuous speed wind bed', () => {
+    const sourceFile = fs.readFileSync(
+      path.join(__dirname, 'ReactiveAudio.tsx'),
+      'utf-8'
+    );
+    expect(sourceFile).toContain("import SpeedWindAudio from './SpeedWindAudio'");
+    expect(sourceFile).toContain('<SpeedWindAudio targetRef={targetRef}');
+  });
+
   describe('Math validation', () => {
     it('should correctly evaluate isFinite for NaN values', () => {
       // Unit test to verify isFinite behavior with non-finite values

--- a/src/components/ReactiveAudio.tsx
+++ b/src/components/ReactiveAudio.tsx
@@ -6,6 +6,7 @@
  * - SFX loop scales rapids roar with current strength
  * - Positional audio for transition segments (waterfall roar)
  * - Splash one-shots triggered by speed + turbulence
+ * - Speed-based wind bed via SpeedWindAudio (feel-of-velocity)
  *
  * Uses Three.js native Audio / PositionalAudio with buffers from AssetCache.audioBuffers
  * and falls back to AudioManager SOUND_LIBRARY for local dev.
@@ -22,6 +23,7 @@ import { useGameStore } from '../systems/GameState';
 import { useLOD } from '../systems/LODManager';
 import { PILLAR_BREAK_EVENT } from '../components/Obstacles/pillarBreakEvents';
 import { isGlacialBiome } from '../configs/TrackBiomes';
+import SpeedWindAudio from './SpeedWindAudio';
 import type { ReachManifest } from '../systems/ReachStreamer';
 import type { NormalizedSegment } from '../systems/ReachNormalizer';
 
@@ -479,5 +481,6 @@ export default function ReactiveAudio({
     }
   });
 
-  return null;
+  // Speed-based wind bed — shared component; does not alter other channels.
+  return <SpeedWindAudio targetRef={targetRef} />;
 }

--- a/src/components/SpeedWindAudio.tsx
+++ b/src/components/SpeedWindAudio.tsx
@@ -1,0 +1,164 @@
+/**
+ * SpeedWindAudio.tsx
+ *
+ * Continuous speed-based wind bed for the feel-of-velocity.
+ * - Loops ambient_wind (stub asset; swap later without changing this path)
+ * - Gain scales with vehicle horizontal speed (linvel), lerped to avoid zipper
+ * - Optional BiquadFilter lowpass brightens with speed
+ * - Final volume = windGain * maxVolume * SFX * master (settings multipliers)
+ *
+ * Mounted by ReactiveAudio (reach path) and InnerExperience (default TrackManager).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { getAudioManager } from '../systems/AudioSystem';
+import { AUDIO_CONFIG } from '../constants/audioConfig';
+import {
+  mapSpeedToWind,
+  sanitizeAudioGain,
+  sanitizeCutoffHz,
+} from '../systems/speedWind';
+
+interface SpeedWindAudioProps {
+  /** Vehicle rigid body ref — same speed source as ReactiveAudio whoosh ducking. */
+  targetRef: React.RefObject<any>;
+  enabled?: boolean;
+}
+
+export default function SpeedWindAudio({
+  targetRef,
+  enabled = true,
+}: SpeedWindAudioProps) {
+  const windRef = useRef<THREE.Audio | null>(null);
+  const lowpassRef = useRef<BiquadFilterNode | null>(null);
+  const gainRef = useRef(0);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const am = getAudioManager();
+    if (!am) {
+      console.warn('[SpeedWindAudio] AudioManager not initialized.');
+      return;
+    }
+
+    let cancelled = false;
+
+    const setup = async () => {
+      await am.loadSound(AUDIO_CONFIG.defaultSfxTracks.speedWind);
+      if (cancelled) return;
+
+      const buf = am.getBuffer(AUDIO_CONFIG.defaultSfxTracks.speedWind);
+      if (!buf) return;
+
+      const listener = am.getListener();
+      const wind = new THREE.Audio(listener);
+      wind.setBuffer(buf);
+      wind.setLoop(true);
+      wind.setVolume(0);
+      wind.play();
+
+      // Dedicated lowpass — brighter as speed rises. Owned here so canyon
+      // acoustics on other ReactiveAudio layers never overwrite it.
+      const ctx = listener.context;
+      if (ctx) {
+        const lowpass = ctx.createBiquadFilter();
+        lowpass.type = 'lowpass';
+        lowpass.frequency.value = AUDIO_CONFIG.wind.cutoffAtRest;
+        lowpass.Q.value = 0.7;
+        wind.setFilters([lowpass]);
+        lowpassRef.current = lowpass;
+      }
+
+      windRef.current = wind;
+      setReady(true);
+    };
+
+    setup();
+
+    return () => {
+      cancelled = true;
+      if (windRef.current) {
+        windRef.current.stop();
+        windRef.current.setFilters([]);
+        windRef.current.disconnect();
+        windRef.current = null;
+      }
+      lowpassRef.current = null;
+      setReady(false);
+    };
+  }, [enabled]);
+
+  // Fade with end-of-run / wipeout audio reset (vehicle is also zeroed → stays silent).
+  useEffect(() => {
+    const onRunReset = () => {
+      gainRef.current = 0;
+      if (windRef.current) {
+        windRef.current.setVolume(0);
+      }
+      if (lowpassRef.current) {
+        lowpassRef.current.frequency.value = AUDIO_CONFIG.wind.cutoffAtRest;
+      }
+    };
+    window.addEventListener('watershed-run-reset', onRunReset);
+    return () => window.removeEventListener('watershed-run-reset', onRunReset);
+  }, []);
+
+  useFrame((_, delta) => {
+    if (!enabled || !ready || !windRef.current || !targetRef?.current) return;
+    if (!Number.isFinite(delta) || delta <= 0) return;
+
+    const body = targetRef.current;
+    if (typeof body.linvel !== 'function') return;
+
+    const vel = body.linvel();
+    const velX = Number.isFinite(vel?.x) ? vel.x : 0;
+    const velZ = Number.isFinite(vel?.z) ? vel.z : 0;
+    const playerSpeed = Math.sqrt(velX * velX + velZ * velZ);
+
+    const mapped = mapSpeedToWind(playerSpeed, {
+      startSpeed: AUDIO_CONFIG.wind.startSpeed,
+      fullSpeed: AUDIO_CONFIG.wind.fullSpeed,
+      cutoffAtRest: AUDIO_CONFIG.wind.cutoffAtRest,
+      cutoffAtFull: AUDIO_CONFIG.wind.cutoffAtFull,
+    });
+
+    const lerp = AUDIO_CONFIG.wind.crossfadeSpeed * delta;
+    if (!Number.isFinite(lerp) || lerp < 0) return;
+
+    gainRef.current += (mapped.gain - gainRef.current) * Math.min(1, lerp);
+    if (!Number.isFinite(gainRef.current)) gainRef.current = 0;
+
+    // Settings SFX × master baseline — same layering as ReactiveAudio SFX beds.
+    const am = getAudioManager();
+    const sfxMult =
+      AUDIO_CONFIG.masterVolume * (am?.getSfxVolume() ?? 1);
+    const windVol = sanitizeAudioGain(
+      gainRef.current * AUDIO_CONFIG.wind.maxVolume * sfxMult,
+    );
+
+    if (Number.isFinite(windVol)) {
+      windRef.current.setVolume(windVol);
+    }
+
+    if (lowpassRef.current) {
+      const cutoff = sanitizeCutoffHz(
+        mapped.cutoffHz,
+        AUDIO_CONFIG.wind.cutoffAtRest,
+      );
+      // Smooth cutoff slightly so filter moves don't click.
+      const current = lowpassRef.current.frequency.value;
+      const next = current + (cutoff - current) * Math.min(1, lerp);
+      if (Number.isFinite(next)) {
+        lowpassRef.current.frequency.value = next;
+      }
+    }
+
+    am?.setReactiveVolumes({ wind: gainRef.current });
+  });
+
+  return null;
+}

--- a/src/constants/audioConfig.ts
+++ b/src/constants/audioConfig.ts
@@ -40,6 +40,25 @@ export const AUDIO_CONFIG = {
     whooshFullSpeed: 28.0,
   },
 
+  /**
+   * Continuous speed-based wind bed (feel-of-velocity).
+   * Distinct from glacial coldWind (biome-gated) and whoosh (high-speed rush).
+   */
+  wind: {
+    /** Peak wind loop volume at fullSpeed (before SFX/master multipliers). */
+    maxVolume: 0.42,
+    /** Horizontal speed where wind becomes audible. */
+    startSpeed: 0.75,
+    /** Horizontal speed where wind gain reaches 1. */
+    fullSpeed: 22,
+    /** Volume lerp rate — keep high enough to track speed, low enough to avoid zipper. */
+    crossfadeSpeed: 3.2,
+    /** Lowpass cutoff (Hz) while stopped. */
+    cutoffAtRest: 380,
+    /** Lowpass cutoff (Hz) at fullSpeed — brighter rush. */
+    cutoffAtFull: 5200,
+  },
+
   positional: {
     /** Reference distance for transition (waterfall) positional audio */
     transitionRefDistance: 18,
@@ -73,6 +92,8 @@ export const AUDIO_CONFIG = {
     splash: 'collide_water',
     whoosh: 'water_whoosh',
     coldWind: 'ambient_wind',
+    /** Continuous speed wind bed — stub reuses ambient_wind until a dedicated loop lands. */
+    speedWind: 'ambient_wind',
     iceCrack: 'collide_rock',
   },
 

--- a/src/experience/InnerExperience.tsx
+++ b/src/experience/InnerExperience.tsx
@@ -4,6 +4,7 @@ import EnhancedSky from '../components/EnhancedSky';
 import FlowForecast from '../components/FlowForecast';
 import { PostProcessingPipeline } from '../components/PostProcessingPipeline';
 import TrackManager from '../components/TrackManager';
+import SpeedWindAudio from '../components/SpeedWindAudio';
 import LevelLoader from '../systems/LevelLoader';
 import ReachManager from '../systems/ReachManager';
 import { useLOD } from '../systems/LODManager';
@@ -128,15 +129,19 @@ export default function InnerExperience({
                 retryKey={state.reachRetryKey}
               />
             ) : (
-              <TrackManager
-                ref={state.trackManagerRef}
-                key={state.defaultMapRunKey}
-                onBiomeChange={state.handleBiomeChange}
-                raftRef={state.vehicleRef}
-                forecastSamples={state.forecastSamples}
-                startIndex={state.activeDefaultMap.startIndex}
-                mapId={state.activeDefaultMapId}
-              />
+              <>
+                <TrackManager
+                  ref={state.trackManagerRef}
+                  key={state.defaultMapRunKey}
+                  onBiomeChange={state.handleBiomeChange}
+                  raftRef={state.vehicleRef}
+                  forecastSamples={state.forecastSamples}
+                  startIndex={state.activeDefaultMap.startIndex}
+                  mapId={state.activeDefaultMapId}
+                />
+                {/* Speed wind for default (non-Reach) maps — Reach path gets it via ReactiveAudio. */}
+                <SpeedWindAudio targetRef={state.vehicleRef} />
+              </>
             ))}
         </Physics>
       )}

--- a/src/systems/AudioSystem.ts
+++ b/src/systems/AudioSystem.ts
@@ -45,6 +45,8 @@ interface ReactiveVolumes {
   rapids: number;
   whoosh: number;
   transition: number;
+  /** Normalized speed-wind gain 0–1 (pre SFX/master multipliers). */
+  wind?: number;
 }
 
 // Default sound library
@@ -124,8 +126,16 @@ export class AudioManager {
   // Load status tracking
   private failedSounds: Set<string> = new Set();
   
-  // Reactive audio volumes (populated by ReactiveAudio if mounted)
-  private reactiveVolumes: ReactiveVolumes = { low: 0, mid: 0, high: 0, rapids: 0, whoosh: 0, transition: 0 };
+  // Reactive audio volumes (populated by ReactiveAudio / SpeedWindAudio if mounted)
+  private reactiveVolumes: ReactiveVolumes = {
+    low: 0,
+    mid: 0,
+    high: 0,
+    rapids: 0,
+    whoosh: 0,
+    transition: 0,
+    wind: 0,
+  };
 
   // Canyon acoustic state
   private canyonAcoustics = {

--- a/src/systems/__tests__/speedWind.test.ts
+++ b/src/systems/__tests__/speedWind.test.ts
@@ -1,0 +1,71 @@
+/**
+ * speedWind.test.ts — Pure speed → wind gain / cutoff mapping
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_SPEED_WIND,
+  mapSpeedToWind,
+  sanitizeAudioGain,
+  sanitizeCutoffHz,
+} from '../speedWind';
+
+describe('mapSpeedToWind', () => {
+  it('is silent at rest and for non-finite speeds', () => {
+    expect(mapSpeedToWind(0).gain).toBe(0);
+    expect(mapSpeedToWind(-3).gain).toBe(0);
+    expect(mapSpeedToWind(NaN).gain).toBe(0);
+    expect(mapSpeedToWind(Infinity).gain).toBe(0);
+    expect(mapSpeedToWind(0).cutoffHz).toBe(DEFAULT_SPEED_WIND.cutoffAtRest);
+  });
+
+  it('stays silent below startSpeed', () => {
+    const result = mapSpeedToWind(DEFAULT_SPEED_WIND.startSpeed - 0.1);
+    expect(result.gain).toBe(0);
+  });
+
+  it('ramps gain smoothly between start and full speed', () => {
+    const low = mapSpeedToWind(4);
+    const mid = mapSpeedToWind(12);
+    const high = mapSpeedToWind(DEFAULT_SPEED_WIND.fullSpeed);
+    expect(low.gain).toBeGreaterThan(0);
+    expect(mid.gain).toBeGreaterThan(low.gain);
+    expect(high.gain).toBe(1);
+    expect(high.gain).toBeLessThanOrEqual(1);
+  });
+
+  it('brightens the lowpass cutoff as speed increases', () => {
+    const slow = mapSpeedToWind(3);
+    const fast = mapSpeedToWind(20);
+    expect(fast.cutoffHz).toBeGreaterThan(slow.cutoffHz);
+    expect(fast.cutoffHz).toBeLessThanOrEqual(DEFAULT_SPEED_WIND.cutoffAtFull);
+  });
+
+  it('never returns non-finite gain or cutoff', () => {
+    for (const speed of [NaN, Infinity, -Infinity, -1, 0, 1, 50, 1e9]) {
+      const result = mapSpeedToWind(speed);
+      expect(Number.isFinite(result.gain)).toBe(true);
+      expect(Number.isFinite(result.cutoffHz)).toBe(true);
+      expect(result.gain).toBeGreaterThanOrEqual(0);
+      expect(result.gain).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe('sanitizeAudioGain / sanitizeCutoffHz', () => {
+  it('clamps and rejects non-finite gains', () => {
+    expect(sanitizeAudioGain(NaN)).toBe(0);
+    expect(sanitizeAudioGain(Infinity)).toBe(0);
+    expect(sanitizeAudioGain(-0.5)).toBe(0);
+    expect(sanitizeAudioGain(1.5)).toBe(1);
+    expect(sanitizeAudioGain(0.4)).toBe(0.4);
+  });
+
+  it('clamps cutoff into a safe audible band', () => {
+    expect(sanitizeCutoffHz(NaN, 400)).toBe(400);
+    expect(sanitizeCutoffHz(0, 400)).toBe(400);
+    expect(sanitizeCutoffHz(5, 400)).toBe(20);
+    expect(sanitizeCutoffHz(50000, 400)).toBe(20000);
+    expect(sanitizeCutoffHz(1200, 400)).toBe(1200);
+  });
+});

--- a/src/systems/speedWind.ts
+++ b/src/systems/speedWind.ts
@@ -1,0 +1,78 @@
+/**
+ * speedWind.ts — Pure speed → wind gain / lowpass mapping.
+ *
+ * Shared by SpeedWindAudio (runtime) and unit tests. No Three.js / Audio
+ * imports so Vitest can exercise the curve without a Web Audio context.
+ */
+
+export interface SpeedWindOptions {
+  /** Horizontal speed where wind becomes audible. */
+  startSpeed?: number;
+  /** Horizontal speed where wind gain reaches 1. */
+  fullSpeed?: number;
+  /** Lowpass cutoff (Hz) at rest / below startSpeed. */
+  cutoffAtRest?: number;
+  /** Lowpass cutoff (Hz) at fullSpeed. */
+  cutoffAtFull?: number;
+}
+
+export interface SpeedWindResult {
+  /** Normalized wind intensity 0–1 (pre channel/master multipliers). */
+  gain: number;
+  /** Suggested BiquadFilter lowpass frequency in Hz. */
+  cutoffHz: number;
+}
+
+export const DEFAULT_SPEED_WIND: Required<SpeedWindOptions> = {
+  startSpeed: 0.75,
+  fullSpeed: 22,
+  cutoffAtRest: 380,
+  cutoffAtFull: 5200,
+};
+
+/**
+ * Map horizontal player speed to wind gain + brightness.
+ *
+ * Non-finite / negative speeds collapse to silence at the rest cutoff.
+ * Gain is clamped to [0, 1]; cutoff is clamped between the rest/full ends.
+ */
+export function mapSpeedToWind(
+  speed: number,
+  options: SpeedWindOptions = {},
+): SpeedWindResult {
+  const startSpeed = options.startSpeed ?? DEFAULT_SPEED_WIND.startSpeed;
+  const fullSpeed = options.fullSpeed ?? DEFAULT_SPEED_WIND.fullSpeed;
+  const cutoffAtRest = options.cutoffAtRest ?? DEFAULT_SPEED_WIND.cutoffAtRest;
+  const cutoffAtFull = options.cutoffAtFull ?? DEFAULT_SPEED_WIND.cutoffAtFull;
+
+  if (!Number.isFinite(speed) || speed <= 0) {
+    return { gain: 0, cutoffHz: cutoffAtRest };
+  }
+
+  const span = Math.max(1e-6, fullSpeed - startSpeed);
+  const t = Math.min(1, Math.max(0, (speed - startSpeed) / span));
+  // Ease-in so low speeds stay soft (no zipper at the threshold).
+  const gain = t * t;
+
+  if (!Number.isFinite(gain)) {
+    return { gain: 0, cutoffHz: cutoffAtRest };
+  }
+
+  const cutoffHz = cutoffAtRest + (cutoffAtFull - cutoffAtRest) * t;
+  return {
+    gain: Math.min(1, Math.max(0, gain)),
+    cutoffHz: Number.isFinite(cutoffHz) ? cutoffHz : cutoffAtRest,
+  };
+}
+
+/** Sanitize a gain before it reaches a Web Audio / Three.js volume node. */
+export function sanitizeAudioGain(value: number, fallback = 0): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(1, Math.max(0, value));
+}
+
+/** Sanitize a filter frequency (Hz) before writing to a BiquadFilter. */
+export function sanitizeCutoffHz(value: number, fallback: number): number {
+  if (!Number.isFinite(value) || value <= 0) return fallback;
+  return Math.min(20000, Math.max(20, value));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the missing **speed-based wind** bed so kinetic speed is audible.

- Pure `mapSpeedToWind(speed)` → gain + lowpass cutoff (unit-tested, `isFinite`-safe)
- `SpeedWindAudio` loops existing `ambient_wind.mp3` stub; gain lerps with vehicle `linvel` (same source as ReactiveAudio whoosh); BiquadFilter brightens with speed
- Final volume = windGain × maxVolume × SFX × master (settings multipliers; does not override biome ducking on other channels)
- Mounted on Reach path (via `ReactiveAudio`) and default TrackManager path (`InnerExperience`)
- Fades to silence on `watershed-run-reset` (wipeout / end-of-run)

## Open questions (resolved in code)

| Question | Choice |
|----------|--------|
| Speed source? | Vehicle rigid body `linvel()` — same as existing whoosh ducking |
| Asset? | Reuse `ambient_wind.mp3` stub (swap later via `AUDIO_CONFIG.defaultSfxTracks.speedWind`) |
| Wipeout / journey end? | Fade with `watershed-run-reset` |

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (incl. `speedWind.test.ts`)
- [ ] Manual: stand still → no wind; accelerate → wind rises smoothly
- [ ] Manual: SFX slider ducks wind; other channels unchanged
- [ ] Manual: wipeout/respawn silence then wind returns with motion

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d2deeb6-31e2-47f3-b0ad-7aa9cdf30110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d2deeb6-31e2-47f3-b0ad-7aa9cdf30110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

