### PR TITLE
Wire quality contract through SceneLighting shadows (#337)

### DIFF
--- a/.swarm-state.md
+++ b/.swarm-state.md
@@ -1,45 +1,32 @@
-# Swarm state — adaptive WebGL quality contract
+# Swarm state — adaptive WebGL quality contract (#337)
 
-## Iteration 1 — 2026-08-05T18:43:00Z
+## Iteration 2 — 2026-08-05 (follow-up after #344)
+
+PR #344 landed the core contract on `main`. This iteration closes remaining gaps so quality presets drive per-light shadow cost and the logarithmic-depth evaluation is documented.
 
 ### Changed
 | File | Why |
 |------|-----|
-| `src/rendering/deriveRendererContextOptions.ts` | Pure quality → DPR/shadow/tone-mapping matrix |
-| `src/rendering/deriveRendererContextOptions.test.ts` | Unit tests for matrix + helpers |
-| `src/rendering/applyRendererContextOptions.ts` | Apply tone mapping, color space, shadows at setup |
-| `src/rendering/createRenderer.ts` | Wire context options into WebGLRenderer creation |
-| `src/rendering/createRenderer.test.ts` | Assert tone mapping + shadow config applied |
-| `src/rendering/rendererConfig.ts` | `isVisualCaptureMode()` gate for preserveDrawingBuffer |
-| `src/rendering/rendererConfig.test.ts` | Capture-mode URL tests |
-| `src/rendering/index.ts` | Export new symbols |
-| `src/App.tsx` | Canvas dpr/shadows/gl wiring, quality remount key, context-loss recovery toast |
-| `docs/reference/RENDERER.md` | Document quality matrix + recovery path |
+| `src/experience/SceneLighting.tsx` | `castShadow` + `shadow-mapSize` from `deriveRendererContextOptions` |
+| `src/systems/LODManager.tsx` | Align medium/high `shadowMapSize` with contract (1024 / 2048) |
+| `src/rendering/deriveRendererContextOptions.ts` | `LOGARITHMIC_DEPTH_BUFFER_ENABLED = false` + rationale |
+| `src/rendering/deriveRendererContextOptions.test.ts` | LOD ↔ derive alignment + log-depth guard |
+| `src/rendering/createRenderer.test.ts` | Assert logarithmicDepthBuffer stays off |
+| `src/rendering/index.ts` | Export `getRendererShadowMapSize`, `LOGARITHMIC_DEPTH_BUFFER_ENABLED` |
+| `docs/reference/RENDERER.md` | Log-depth decision + SceneLighting wiring |
 
-### Checks
-| Check | Status |
-|-------|--------|
-| `pnpm typecheck` | ✅ exit 0 |
-| `pnpm test` | ✅ 497 passed, 2 skipped |
-| `pnpm build` | ✅ exit 0 |
-| invariant grep (no WebGPURenderer construction; preserveDrawingBuffer gated) | ✅ |
+### Already on main (PR #344)
+- `deriveRendererContextOptions` matrix (DPR / AA / shadows / tone mapping / color space)
+- Canvas remount on quality change + context-loss toast
+- `preserveDrawingBuffer` gated to `?screenshot=1` / `?capture=1`
+- Unit tests + RENDERER.md quality matrix
+- WebGL-only invariant preserved
 
-### Quality → options matrix (as implemented)
-
-| Preset | dprMax | antialias | shadowMode | shadowMapSize | toneMapping | outputColorSpace | exposure |
-|--------|--------|-----------|------------|---------------|-------------|------------------|----------|
-| low | 1.0 | false | off | null | ACESFilmic | SRGB | 1.0 |
-| medium | 1.25 | true | basic | 1024 | ACESFilmic | SRGB | 1.0 |
-| high | 2 | true | soft | 2048 | ACESFilmic | SRGB | 1.0 |
-| ultra | devicePixelRatio | true | soft | 2048 (1×) / 4096 (≥2×) | ACESFilmic | SRGB | 1.0 |
-
-All presets: `powerPreference = 'high-performance'`. Canvas `dpr={[1, dprMax]}`.
-
-### Deviations
-- Shadow map size stored in a `WeakMap` (`getRendererShadowMapSize`) because `THREE.WebGLRenderer` has no typed `userData`. Per-light sizes still come from `LODManager` / `SceneLighting` (out of scope).
-- `GameState` default quality remains `medium`; `high` is the documented visual baseline matching pre-contract hard-coded Canvas (`dpr [1,2]`, soft shadows, antialias on).
-
-### Open follow-ups
-- Wire `getRendererShadowMapSize()` into `SceneLighting` so renderer contract and per-light map sizes share one source (requires touching `src/experience/SceneLighting.tsx`).
-- Expose current DPR/shadow mode in DebugPanel diagnostics.
-- Consider remounting Canvas when settings hydration completes if persisted quality differs from initial render.
+### Acceptance criteria
+- [x] Quality preset changes DPR and/or shadow configuration (testable)
+- [x] Tone mapping + color space set once at renderer setup
+- [x] Screenshot/visual-smoke `preserveDrawingBuffer` path
+- [x] Context-loss recovery (toast + Canvas remount)
+- [x] Unit tests for `deriveRendererContextOptions`
+- [x] RENDERER.md updated; no WebGPU flip
+- [x] logarithmicDepthBuffer evaluated → deferred (documented)

--- a/docs/reference/RENDERER.md
+++ b/docs/reference/RENDERER.md
@@ -19,7 +19,13 @@ Derived by the pure function `deriveRendererContextOptions()` in `src/rendering/
 
 All presets set `outputColorSpace = SRGBColorSpace`, `toneMapping = ACESFilmicToneMapping`, and `toneMappingExposure = 1.0` once at renderer setup via `applyRendererContextOptions()`.
 
-Per-light shadow map sizes in `SceneLighting` still follow `LODManager.QUALITY_SETTINGS`; the renderer contract stores the configured size via `getRendererShadowMapSize()` for diagnostics and tests.
+Per-light shadow map sizes in `SceneLighting` follow the same contract: `deriveRendererContextOptions(quality)` drives `castShadow` and `shadow-mapSize`, with `LODManager.QUALITY_SETTINGS.shadowMapSize` kept as an aligned static fallback (ultra table stores the 4096 retina max; live path is DPR-aware). The configured size is also stored via `getRendererShadowMapSize()` for diagnostics and tests.
+
+## Logarithmic depth buffer
+
+**Decision: leave `logarithmicDepthBuffer` off** (`LOGARITHMIC_DEPTH_BUFFER_ENABLED = false`).
+
+Evaluated for long canyon Z ranges. The track treadmill keeps ~7 active segments (hundreds of units of Z, not kilometers), fog far is typically ≤220, and the sun shadow camera uses `far = 200`. Turning on logarithmic depth would require log-depth shader chunks in every custom `ShaderMaterial` / `onBeforeCompile` path (`FlowingWater`, `CanyonMaterial`, `RiverShader`) for little practical Z-fighting relief. Revisit only if a non-treadmill long-haul camera path ships.
 
 ## Quick Start
 
@@ -105,6 +111,8 @@ Module-level stores cross the Canvas boundary:
 | `src/rendering/rendererConfig.ts` | URL param + localStorage parsing, capture-mode gate |
 | `src/rendering/rendererState.ts` | Active backend diagnostics |
 | `src/rendering/WireframeDebug.tsx` | Scene wireframe helper |
+| `src/experience/SceneLighting.tsx` | Per-light shadows from quality contract |
+| `src/systems/LODManager.tsx` | LOD budgets; shadowMapSize aligned with contract |
 | `src/components/DebugPanel.tsx` | Debug UI controls |
 | `src/App.tsx` | Canvas wiring, quality remount, context-loss recovery |
 | `docs/reference/RENDERER_CONTRACT.md` | Contract enforced by the regression guard |

--- a/src/experience/SceneLighting.tsx
+++ b/src/experience/SceneLighting.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, type RefObject } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { useLOD } from '../systems/LODManager';
 import { useSunPosition } from '../systems/SunPositionSystem';
+import { deriveRendererContextOptions } from '../rendering';
 import { BIOME_LIGHTING } from './constants';
 
 interface SceneLightingProps {
@@ -36,8 +37,19 @@ export default function SceneLighting({
   playerVelocityRef,
   enabled,
 }: SceneLightingProps) {
-  const { config: lodConfig } = useLOD();
+  const { quality, config: lodConfig } = useLOD();
   const { sunWorldPosition } = useSunPosition();
+
+  // Prefer the renderer quality contract (DPR-aware ultra map size; shadows off on low).
+  const shadowContract = useMemo(
+    () =>
+      deriveRendererContextOptions(quality, {
+        devicePixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio : 1,
+      }),
+    [quality],
+  );
+  const castShadows = shadowContract.shadowMode !== 'off';
+  const shadowMapSize = shadowContract.shadowMapSize ?? lodConfig.shadowMapSize;
 
   const L = BIOME_LIGHTING[biome] ?? BIOME_LIGHTING.canyonSummer;
   const isTightCanyon = currentSegmentIndex >= 20 && currentSegmentIndex <= 22;
@@ -111,8 +123,8 @@ export default function SceneLighting({
         color={L.dirColor}
         position={sharedSunPosition}
         intensity={L.dirIntensity}
-        castShadow
-        shadow-mapSize={[lodConfig.shadowMapSize, lodConfig.shadowMapSize]}
+        castShadow={castShadows}
+        shadow-mapSize={[shadowMapSize, shadowMapSize]}
         shadow-bias={lodConfig.shadowBias}
         shadow-normalBias={lodConfig.shadowNormalBias}
         shadow-camera-near={1}

--- a/src/rendering/createRenderer.test.ts
+++ b/src/rendering/createRenderer.test.ts
@@ -316,6 +316,7 @@ describe('createGameRenderer', () => {
     expect(renderer.shadowMap.enabled).toBe(true);
     expect(renderer.shadowMap.type).toBe(THREE.PCFSoftShadowMap);
     expect(getRendererShadowMapSize(renderer)).toBe(2048);
+    expect(renderer.logarithmicDepthBuffer).toBeFalsy();
     renderer.dispose();
   });
 

--- a/src/rendering/deriveRendererContextOptions.test.ts
+++ b/src/rendering/deriveRendererContextOptions.test.ts
@@ -1,6 +1,8 @@
 import * as THREE from 'three';
+import { QUALITY_SETTINGS } from '../systems/LODManager';
 import {
   DEFAULT_TONE_MAPPING_EXPOSURE,
+  LOGARITHMIC_DEPTH_BUFFER_ENABLED,
   deriveRendererContextOptions,
   resolveCanvasDpr,
   shadowModeToCanvasProp,
@@ -58,6 +60,27 @@ describe('deriveRendererContextOptions', () => {
     const opts = deriveRendererContextOptions('ultra', { devicePixelRatio: 1 });
     expect(opts.shadowMapSize).toBe(2048);
     expect(opts.dprMax).toBe(1);
+  });
+
+  it('keeps logarithmic depth disabled (evaluated, deferred)', () => {
+    expect(LOGARITHMIC_DEPTH_BUFFER_ENABLED).toBe(false);
+  });
+});
+
+describe('LOD ↔ renderer shadow map contract', () => {
+  it('aligns static LOD shadowMapSize baselines with deriveRendererContextOptions', () => {
+    expect(QUALITY_SETTINGS.medium.shadowMapSize).toBe(
+      deriveRendererContextOptions('medium').shadowMapSize
+    );
+    expect(QUALITY_SETTINGS.high.shadowMapSize).toBe(
+      deriveRendererContextOptions('high').shadowMapSize
+    );
+    // Ultra LOD table stores the retina max; live lights use derive (DPR-aware).
+    expect(QUALITY_SETTINGS.ultra.shadowMapSize).toBe(
+      deriveRendererContextOptions('ultra', { devicePixelRatio: 2 }).shadowMapSize
+    );
+    expect(deriveRendererContextOptions('low').shadowMapSize).toBeNull();
+    expect(QUALITY_SETTINGS.low.shadowMapSize).toBe(1024);
   });
 });
 

--- a/src/rendering/deriveRendererContextOptions.ts
+++ b/src/rendering/deriveRendererContextOptions.ts
@@ -26,6 +26,18 @@ export interface RendererContextOptions {
 export const DEFAULT_TONE_MAPPING_EXPOSURE = 1.0;
 
 /**
+ * Logarithmic depth is intentionally off for all presets.
+ *
+ * Evaluated for long canyon Z ranges (#337): the track treadmill keeps only
+ * ~7 active segments (~hundreds of units of Z), fog far is typically ≤220, and
+ * shadow cameras use far=200. Enabling `logarithmicDepthBuffer` would require
+ * log-depth chunks in every custom ShaderMaterial (FlowingWater, CanyonMaterial,
+ * RiverShader injections) for modest Z-fighting benefit. Keep the THREE default
+ * (false); revisit only if a non-treadmill long-haul camera path ships.
+ */
+export const LOGARITHMIC_DEPTH_BUFFER_ENABLED = false;
+
+/**
  * Pure quality → WebGL context options. No React or DOM side effects.
  *
  * `high` matches the pre-contract Canvas defaults: antialias on, soft shadows,

--- a/src/rendering/index.ts
+++ b/src/rendering/index.ts
@@ -4,11 +4,15 @@ export {
   resolveCanvasDpr,
   shadowModeToCanvasProp,
   DEFAULT_TONE_MAPPING_EXPOSURE,
+  LOGARITHMIC_DEPTH_BUFFER_ENABLED,
   type RendererContextOptions,
   type RendererContextSettings,
   type ShadowMode,
 } from './deriveRendererContextOptions';
-export { applyRendererContextOptions } from './applyRendererContextOptions';
+export {
+  applyRendererContextOptions,
+  getRendererShadowMapSize,
+} from './applyRendererContextOptions';
 export {
   parseRendererPreference,
   persistRendererPreference,

--- a/src/systems/LODManager.tsx
+++ b/src/systems/LODManager.tsx
@@ -40,9 +40,15 @@ export interface LODConfig {
 }
 
 /** Per-quality budgets — exported for wiring guard tests. */
+/**
+ * Per-quality budgets. `shadowMapSize` baselines match
+ * `deriveRendererContextOptions()` (see RENDERER.md). Live lights prefer the
+ * derived size (DPR-aware on ultra); these values are the static LOD fallback.
+ */
 export const QUALITY_SETTINGS: Record<QualityLevel, LODConfig> = {
   low: {
     particleDensity: 0.4,
+    // Shadows off at Canvas for low; size retained for adaptive upgrades.
     shadowMapSize: 1024,
     shadowBias: -0.0015,
     shadowNormalBias: 0.025,
@@ -60,7 +66,7 @@ export const QUALITY_SETTINGS: Record<QualityLevel, LODConfig> = {
   },
   medium: {
     particleDensity: 0.7,
-    shadowMapSize: 2048,
+    shadowMapSize: 1024,
     shadowBias: -0.0009,
     shadowNormalBias: 0.018,
     enableReflections: false,
@@ -77,7 +83,7 @@ export const QUALITY_SETTINGS: Record<QualityLevel, LODConfig> = {
   },
   high: {
     particleDensity: 1.0,
-    shadowMapSize: 3072,
+    shadowMapSize: 2048,
     shadowBias: -0.0006,
     shadowNormalBias: 0.012,
     enableReflections: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes remaining gaps for **#337** (adaptive WebGL quality contract) after #344 landed the core derive/Canvas path.

## What changed

- **`SceneLighting`** now drives `castShadow` and `shadow-mapSize` from `deriveRendererContextOptions(quality)` (DPR-aware ultra map size; shadows off on low).
- **`LODManager.QUALITY_SETTINGS`** medium/high `shadowMapSize` aligned to the contract matrix (`1024` / `2048`).
- **`LOGARITHMIC_DEPTH_BUFFER_ENABLED = false`** with documented evaluation: treadmill Z + custom ShaderMaterials make log-depth a poor tradeoff.
- Tests: LOD ↔ derive shadow alignment, log-depth guard, `createGameRenderer` asserts log depth stays off.
- **`docs/reference/RENDERER.md`** updated (SceneLighting wiring + log-depth decision).

## Already on main (#344)

Quality → DPR / AA / shadow mode / tone mapping / color space; Canvas remount on quality change; context-loss toast; `preserveDrawingBuffer` only for `?screenshot=1` / `?capture=1`; WebGL-only invariant.

## Checks

- `pnpm test` — 501 passed, 2 skipped
- `pnpm typecheck` — exit 0

## Acceptance (#337)

- [x] Quality preset changes DPR and/or shadow configuration in a testable way
- [x] Tone mapping + color space set once at renderer setup
- [x] Screenshot/visual-smoke `preserveDrawingBuffer` path
- [x] Context-loss recovery path
- [x] Unit tests for `deriveRendererContextOptions`
- [x] RENDERER.md updated; no WebGPU flip

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e08fe14a-a8d0-42cb-a638-a34e67e0dd26?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e08fe14a-a8d0-42cb-a638-a34e67e0dd26&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Shadow quality now adapts consistently to selected quality settings and device capabilities.
  * Medium- and high-quality shadow-map sizing has been aligned for more predictable rendering.
  * Logarithmic depth buffering remains disabled across quality presets for consistent renderer behavior.

* **Documentation**
  * Updated renderer documentation with shadow-setting behavior, depth-buffer decisions, and related configuration details.

* **Tests**
  * Added coverage for shadow sizing and logarithmic depth behavior across quality levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->