### PR TITLE
feat(journey): multi-Reach seamless handoff + continuous Journey mode (#339)

### DIFF
--- a/SYSTEMS.md
+++ b/SYSTEMS.md
@@ -17,9 +17,10 @@ GameState (Zustand) ── shared state ─────────────�
 LODProvider ──quality/config──> BiomeProvider ──biome palette──> scene
                                       │
 ReachStreamer ──ReachManifest──> ReachNormalizer ──NormalizedSegment[]──> ReachManager ──wraps──> TrackManager ──> TrackSegment
-  (fetch /api/reaches)                                                         │
-                                                                               ├──> ReactiveAudio
-                                                                               └──> WeatherSystem
+  (fetch /api/reaches)                     │                                    │
+                                           │                                    ├──> ReactiveAudio
+journeyContinuity / journeyHandoff ────────┴── seamless append / map handoff    └──> WeatherSystem
+runSession (journeyMode + mapStack + survival carry)
 
 Player velocity/contacts ──> SplashSystem ──> ParticlePool ──> splash/foam/mist InstancedMesh + raft bow-wave
                                          └──> injectSWEDisturbance ──> WaterForceSystem / SWEHeightField
@@ -124,7 +125,10 @@ into TrackManager-compatible segments, and watches player position for transitio
 
 **Produces:**
 - Renders `<TrackManager reachSegments={...} />` (plus `ReactiveAudio`, `WeatherSystem`).
-- Logs transition entry/exit to console when player crosses `manifest.transition.segmentIndex`.
+- On transition entry: prefetches `transition.nextReachId` (when authored), joins
+  waypoints with control-point continuity, appends normalized segments, cross-fades
+  biome via `BiomeProvider.setBiome`, and emits `reach-exit` / `reach-enter` /
+  `journey-handoff` CustomEvents. Autosaves a journey checkpoint.
 - On load error: renders `TrackManager` without segments so procedural generation takes over.
 
 **Boundaries (Do NOT):**
@@ -132,10 +136,16 @@ into TrackManager-compatible segments, and watches player position for transitio
   wraps the treadmill; bypassing it breaks segment lifecycle and biome callbacks.
 - Do NOT add loading-spinner or error UI inside this component — overlays are lifted
   to `ExperienceUI` / `InnerExperience`.
+- Do NOT call `ReachStreamer.preloadReach` inside `useFrame` — handoff schedules it
+  from the transition act path (async), never as a blocking frame body.
 
-**Known Pain:**
-- Transition detection uses Z-coordinate bounds only; there is no multi-Reach handoff yet
-  (transition entry is logged, not acted upon).
+**Residual limits:**
+- Transition Z-bounds remain a coarse trigger (not a full multi-axis portal volume).
+- Reach HTTP 404 still falls back to procedural; handoff then checkpoints without
+  appending remote segments.
+- Map-campaign seamless handoff (Journey mode / Continue) is owned by
+  `TrackManager.handoffToMap` + `useExperienceWorld.performSeamlessMapHandoff`,
+  not by ReachManager alone.
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -259,7 +259,12 @@ function App() {
   const handleStart = useCallback(
     (
       mapId: MapRegistryId = selectedMapId,
-      options?: { launchHour?: number; placedCacheIds?: string[]; loadoutId?: string },
+      options?: {
+        launchHour?: number;
+        placedCacheIds?: string[];
+        loadoutId?: string;
+        journeyMode?: 'single' | 'journey';
+      },
     ) => {
       handleSelectMap(mapId);
       initRunSession({
@@ -267,6 +272,7 @@ function App() {
         launchHour: options?.launchHour,
         placedCacheIds: options?.placedCacheIds,
         loadoutId: options?.loadoutId,
+        journeyMode: options?.journeyMode ?? 'single',
       });
       setActiveLaunchHour(options?.launchHour ?? getLaunchHour());
       setPhase('playing');

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -4,11 +4,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   formatDuration,
+  getDefaultJourneyStack,
   isMapUnlocked,
   listMapsForMenu,
   type MapMenuEntry,
 } from '../maps/campaign';
 import type { MapRegistryId } from '../maps/registry';
+import { MAP_REGISTRY } from '../maps/registry';
 import { getMapSurvivalMetadata, mapHasSurvivalFeatures } from '../maps/survivalMetadata';
 import {
   getBestScoreForMap,
@@ -23,11 +25,17 @@ import CachePlacementPanel from './CachePlacementPanel';
 import LoadoutPicker from './LoadoutPicker';
 import { DEFAULT_MAX_CACHE_PLACEMENTS } from '../systems/portageCache';
 import { DEFAULT_LOADOUT_ID, type LoadoutId } from '../systems/survival';
+import type { JourneyMode } from '../systems/runSession';
 
 interface StartMenuProps {
   onStart: (
     mapId: MapRegistryId,
-    options: { launchHour: number; placedCacheIds: string[]; loadoutId: LoadoutId },
+    options: {
+      launchHour: number;
+      placedCacheIds: string[];
+      loadoutId: LoadoutId;
+      journeyMode: 'single' | 'journey';
+    },
   ) => void;
   selectedMapId: MapRegistryId;
   onSelectMap: (mapId: MapRegistryId) => void;
@@ -61,16 +69,20 @@ export const StartMenu: React.FC<StartMenuProps> = ({
   const completedMaps = useMemo(() => getCompletedMaps(), []);
   const lastMapId = useMemo(() => getLastMapId(), []);
   const maps = useMemo(() => listMapsForMenu(), []);
+  const journeyStack = useMemo(() => getDefaultJourneyStack(), []);
+  const [playMode, setPlayMode] = useState<JourneyMode>('single');
   const [launchHour, setLaunchHourLocal] = useState(() => getLaunchHour());
   const [placedCacheIds, setPlacedCacheIds] = useState<string[]>([]);
   const [loadoutId, setLoadoutId] = useState<LoadoutId>(DEFAULT_LOADOUT_ID);
 
+  const effectiveMapId = playMode === 'journey' ? journeyStack[0] ?? 'glacial' : selectedMapId;
+
   const survivalMeta = useMemo(
-    () => getMapSurvivalMetadata(selectedMapId),
-    [selectedMapId],
+    () => getMapSurvivalMetadata(effectiveMapId),
+    [effectiveMapId],
   );
   const maxCachePlacements = survivalMeta.maxCachePlacements ?? DEFAULT_MAX_CACHE_PLACEMENTS;
-  const showSurvival = mapHasSurvivalFeatures(selectedMapId);
+  const showSurvival = mapHasSurvivalFeatures(effectiveMapId);
 
   const handleLaunchHourChange = (hour: number) => {
     setLaunchHourLocal(hour);
@@ -89,7 +101,14 @@ export const StartMenu: React.FC<StartMenuProps> = ({
 
   useEffect(() => {
     setPlacedCacheIds([]);
-  }, [selectedMapId]);
+  }, [effectiveMapId]);
+
+  const startOptions = {
+    launchHour,
+    placedCacheIds,
+    loadoutId,
+    journeyMode: playMode,
+  };
 
   return (
     <div className="start-menu-overlay">
@@ -103,47 +122,92 @@ export const StartMenu: React.FC<StartMenuProps> = ({
 
         {(
           <div className="start-menu-buttons">
-            <div className="start-menu-map-select" role="listbox" aria-label="Select map">
-              <div className="start-menu-map-select-label">Choose Map</div>
-              {maps.map((map) => {
-                const unlocked = isMapUnlocked(map.id, completedMaps);
-                const best = getBestScoreForMap(map.id);
-                const isSelected = selectedMapId === map.id;
-                const isLast = lastMapId === map.id;
-
-                return (
-                  <button
-                    key={map.id}
-                    type="button"
-                    role="option"
-                    aria-selected={isSelected}
-                    className={`start-menu-map-option ${isSelected ? 'active' : ''} ${
-                      unlocked ? '' : 'soft-locked'
-                    }`}
-                    onClick={() => onSelectMap(map.id)}
-                  >
-                    <div className="start-menu-map-option-main">
-                      <span className="start-menu-map-option-title">{map.label}</span>
-                      <span className="start-menu-map-option-meta">
-                        {DIFFICULTY_LABELS[map.difficulty]} · {formatDuration(map.estimatedDurationSec)}
-                      </span>
-                    </div>
-                    <div className="start-menu-map-option-side">
-                      {isLast && <span className="start-menu-map-badge">Last</span>}
-                      {!unlocked && <span className="start-menu-map-badge muted">Locked</span>}
-                      {best > 0 && (
-                        <span className="start-menu-map-best">
-                          Best {Math.floor(best).toLocaleString()}
-                        </span>
-                      )}
-                    </div>
-                  </button>
-                );
-              })}
+            <div className="start-menu-mode-select" role="radiogroup" aria-label="Play mode">
+              <div className="start-menu-map-select-label">Play Mode</div>
+              <div className="start-menu-mode-row">
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={playMode === 'single'}
+                  className={`start-menu-mode-option ${playMode === 'single' ? 'active' : ''}`}
+                  onClick={() => setPlayMode('single')}
+                >
+                  Single Map
+                </button>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={playMode === 'journey'}
+                  className={`start-menu-mode-option ${playMode === 'journey' ? 'active' : ''}`}
+                  onClick={() => setPlayMode('journey')}
+                >
+                  Journey
+                </button>
+              </div>
               <p className="start-menu-map-hint">
-                Soft-lock marks campaign order — every map stays playable.
+                {playMode === 'journey'
+                  ? 'Seamless descent across the unlock graph — survival and score carry at each reach boundary.'
+                  : 'Play one authored map. Continue still hands off without remounting the world.'}
               </p>
             </div>
+
+            {playMode === 'journey' ? (
+              <div className="start-menu-map-select" aria-label="Journey route">
+                <div className="start-menu-map-select-label">Descent Route</div>
+                <ol className="start-menu-journey-stack">
+                  {journeyStack.map((id, i) => (
+                    <li key={id} className="start-menu-journey-step">
+                      <span className="start-menu-journey-index">{i + 1}</span>
+                      <span className="start-menu-journey-label">
+                        {MAP_REGISTRY[id].label}
+                      </span>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            ) : (
+              <div className="start-menu-map-select" role="listbox" aria-label="Select map">
+                <div className="start-menu-map-select-label">Choose Map</div>
+                {maps.map((map) => {
+                  const unlocked = isMapUnlocked(map.id, completedMaps);
+                  const best = getBestScoreForMap(map.id);
+                  const isSelected = selectedMapId === map.id;
+                  const isLast = lastMapId === map.id;
+
+                  return (
+                    <button
+                      key={map.id}
+                      type="button"
+                      role="option"
+                      aria-selected={isSelected}
+                      className={`start-menu-map-option ${isSelected ? 'active' : ''} ${
+                        unlocked ? '' : 'soft-locked'
+                      }`}
+                      onClick={() => onSelectMap(map.id)}
+                    >
+                      <div className="start-menu-map-option-main">
+                        <span className="start-menu-map-option-title">{map.label}</span>
+                        <span className="start-menu-map-option-meta">
+                          {DIFFICULTY_LABELS[map.difficulty]} · {formatDuration(map.estimatedDurationSec)}
+                        </span>
+                      </div>
+                      <div className="start-menu-map-option-side">
+                        {isLast && <span className="start-menu-map-badge">Last</span>}
+                        {!unlocked && <span className="start-menu-map-badge muted">Locked</span>}
+                        {best > 0 && (
+                          <span className="start-menu-map-best">
+                            Best {Math.floor(best).toLocaleString()}
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })}
+                <p className="start-menu-map-hint">
+                  Soft-lock marks campaign order — every map stays playable.
+                </p>
+              </div>
+            )}
 
             <LaunchHourPicker
               value={launchHour}
@@ -164,11 +228,11 @@ export const StartMenu: React.FC<StartMenuProps> = ({
 
             <button
               className="start-menu-start-btn"
-              onClick={() => onStart(selectedMapId, { launchHour, placedCacheIds, loadoutId })}
+              onClick={() => onStart(effectiveMapId, startOptions)}
               aria-label="Start Game - Click or Press Enter"
               autoFocus
             >
-              START RUN
+              {playMode === 'journey' ? 'START JOURNEY' : 'START RUN'}
               <span className="start-menu-keyhint">ENTER</span>
             </button>
 

--- a/src/components/TrackManager.tsx
+++ b/src/components/TrackManager.tsx
@@ -37,6 +37,14 @@ export interface TrackManagerRef {
   synthesizeSegmentEnter: (index: number) => void;
   isInitialized: () => boolean;
   getLastEnteredSegment: () => number;
+  /**
+   * Seamless map handoff: attach next map configs without remounting the
+   * TrackManager React tree or wiping the live segment pool.
+   */
+  handoffToMap: (options: {
+    nextMapId: MapRegistryId;
+    plan: import('../systems/journeyContinuity').HandoffPlan;
+  }) => boolean;
 }
 
 export interface TrackManagerProps {
@@ -51,6 +59,16 @@ export interface TrackManagerProps {
   startIndex?: number;
   /** @deprecated Use mapId / mapDefinition instead */
   mapProgression?: SegmentRange[];
+  /**
+   * When true, journeyComplete segments trigger seamless handoff via
+   * `onSeamlessHandoff` instead of pausing the run.
+   */
+  seamlessJourney?: boolean;
+  /** Called when a journeyComplete segment is entered in seamless mode. */
+  onSeamlessHandoff?: (info: {
+    segmentIndex: number;
+    fromMapId: MapRegistryId;
+  }) => void;
 }
 
 interface RenderSlot {
@@ -87,6 +105,8 @@ const TrackManager = forwardRef<TrackManagerRef, TrackManagerProps>(function Tra
     mapDefinition,
     startIndex,
     mapProgression,
+    seamlessJourney = false,
+    onSeamlessHandoff,
   },
   ref
 ) {
@@ -103,6 +123,15 @@ const TrackManager = forwardRef<TrackManagerRef, TrackManagerProps>(function Tra
 
   const chunkManagerRef = useRef<ChunkManager | null>(null);
   const pendingSynthesizesRef = useRef<number[]>([]);
+  const seamlessJourneyRef = useRef(seamlessJourney);
+  seamlessJourneyRef.current = seamlessJourney;
+  const onSeamlessHandoffRef = useRef(onSeamlessHandoff);
+  onSeamlessHandoffRef.current = onSeamlessHandoff;
+  const activeMapIdRef = useRef<MapRegistryId>(resolvedMap.id as MapRegistryId);
+  activeMapIdRef.current = (mapId ?? resolvedMap.id) as MapRegistryId;
+  const handoffInFlightRef = useRef(false);
+  /** Set by handoffToMap so the mapId prop sync does not wipe the live pool. */
+  const skipNextMapEffectResetRef = useRef(false);
 
   useImperativeHandle(ref, () => ({
     synthesizeSegmentEnter: (index: number) => {
@@ -114,6 +143,38 @@ const TrackManager = forwardRef<TrackManagerRef, TrackManagerProps>(function Tra
     },
     isInitialized: () => chunkManagerRef.current?.isInitialized() ?? false,
     getLastEnteredSegment: () => chunkManagerRef.current?.getLastEnteredSegment?.() ?? -1,
+    handoffToMap: ({ nextMapId, plan }) => {
+      const cm = chunkManagerRef.current;
+      if (!cm?.isInitialized()) return false;
+
+      const nextDef = getMapDefinition(nextMapId);
+      let manager = mapManagerRef.current;
+      if (!(manager instanceof ProceduralMapManager)) {
+        manager = new ProceduralMapManager(
+          effectiveLevelData,
+          effectiveFallback,
+          {},
+          null,
+        );
+        mapManagerRef.current = manager;
+        cm.setMapManager(manager);
+      }
+
+      (manager as ProceduralMapManager).attachContinuation(
+        {
+          levelData: nextDef.levelData,
+          startIndex: plan.toMapLocalStartIndex,
+        },
+        {
+          globalStartIndex: plan.nextMapStartIndex,
+          widthBlend: plan.widthBlend,
+        },
+      );
+      activeMapIdRef.current = nextMapId;
+      handoffInFlightRef.current = false;
+      skipNextMapEffectResetRef.current = true;
+      return true;
+    },
   }));
 
   const forecastByIndexRef = useRef<Map<number, string>>(new Map());
@@ -134,14 +195,31 @@ const TrackManager = forwardRef<TrackManagerRef, TrackManagerProps>(function Tra
   const reachSegmentsRef = useRef(reachSegments);
   const obstaclePoolRef = useRef(createObstaclePool(16));
 
-  // Keep reachSegments ref in sync
+  // Keep reachSegments ref in sync — soft update on append (seamless handoff),
+  // hard reset only when the array identity is a full reload (null → data or shrink).
   useEffect(() => {
+    const prev = reachSegmentsRef.current;
     reachSegmentsRef.current = reachSegments;
-    if (chunkManagerRef.current && chunkManagerRef.current.isInitialized()) {
-      chunkManagerRef.current.reset(reachSegments);
-      chunkManagerRef.current.initializePool();
-      setPoolVersion((v) => v + 1);
+
+    const cm = chunkManagerRef.current;
+    if (!cm?.isInitialized()) return;
+
+    const prevLen = prev?.length ?? 0;
+    const nextLen = reachSegments?.length ?? 0;
+    const isAppend =
+      prev &&
+      reachSegments &&
+      nextLen > prevLen &&
+      prev[0]?.id === reachSegments[0]?.id;
+
+    if (isAppend) {
+      cm.setReachSegments(reachSegments);
+      return;
     }
+
+    cm.reset(reachSegments);
+    cm.initializePool();
+    setPoolVersion((v) => v + 1);
   }, [reachSegments]);
 
   // Weather listener
@@ -269,6 +347,16 @@ const TrackManager = forwardRef<TrackManagerRef, TrackManagerProps>(function Tra
   }, [forecastSamples]);
 
   useEffect(() => {
+    if (skipNextMapEffectResetRef.current) {
+      skipNextMapEffectResetRef.current = false;
+      // Keep the live ProceduralMapManager that already has continuation attached.
+      // Still point ChunkManager at it in case React remounted nothing.
+      if (chunkManagerRef.current && mapManagerRef.current) {
+        chunkManagerRef.current.setMapManager(mapManagerRef.current);
+      }
+      return;
+    }
+
     mapManagerRef.current = new ProceduralMapManager(
       effectiveLevelData,
       effectiveFallback,
@@ -318,7 +406,15 @@ const TrackManager = forwardRef<TrackManagerRef, TrackManagerProps>(function Tra
 
         const segmentConfig = mapManagerRef.current?.getChunkConfig?.(index);
         if (segmentConfig?.journeyComplete && !useGameStore.getState().isJourneyComplete) {
-          useGameStore.getState().setJourneyComplete();
+          if (seamlessJourneyRef.current && !handoffInFlightRef.current) {
+            handoffInFlightRef.current = true;
+            onSeamlessHandoffRef.current?.({
+              segmentIndex: index,
+              fromMapId: activeMapIdRef.current,
+            });
+          } else if (!seamlessJourneyRef.current) {
+            useGameStore.getState().setJourneyComplete();
+          }
         }
       },
     };

--- a/src/experience/InnerExperience.tsx
+++ b/src/experience/InnerExperience.tsx
@@ -138,6 +138,8 @@ export default function InnerExperience({
                   forecastSamples={state.forecastSamples}
                   startIndex={state.activeDefaultMap.startIndex}
                   mapId={state.activeDefaultMapId}
+                  seamlessJourney={state.seamlessJourney}
+                  onSeamlessHandoff={state.handleSeamlessHandoffFromTrack}
                 />
                 {/* Speed wind for default (non-Reach) maps — Reach path gets it via ReactiveAudio. */}
                 <SpeedWindAudio targetRef={state.vehicleRef} />

--- a/src/experience/hooks/useExperienceWorld.ts
+++ b/src/experience/hooks/useExperienceWorld.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
 import type { FlowForecastSample } from '../../components/FlowForecast';
 import { PLAYER_SPAWN } from '../../constants/game';
 import { useBiome } from '../../systems/BiomeSystem';
@@ -27,8 +27,17 @@ import { hydrateStoreForRun } from '../../systems/persistenceBootstrap';
 import { getActiveRunKey } from '../../utils/runContext';
 import { ACTIVE_MAP_ID } from '../../maps/registry';
 import { buildForecastSamples } from '../../systems/flowForecast';
-import { initRunSession, getActiveLaunchHour, getRunSession } from '../../systems/runSession';
+import {
+  initRunSession,
+  getActiveLaunchHour,
+  getRunSession,
+  isJourneyMode,
+  advanceRunSessionMap,
+  saveJourneyCheckpoint,
+} from '../../systems/runSession';
 import { getLaunchHour } from '../../systems/PersistenceSystem';
+import { kickoffMapHandoff } from '../../systems/journeyHandoff';
+import { planMapHandoff } from '../../systems/journeyContinuity';
 
 const DEFAULT_FORECAST_OPTIONS = {
   temperature: 8,
@@ -116,8 +125,11 @@ export function useExperienceWorld({
   const [activeDefaultMapId, setActiveDefaultMapId] = useState<MapRegistryId>(() =>
     resolveInitialMapId(controlledMapId),
   );
+  /** Suppress remount / snap when App mapId updates from a seamless handoff. */
+  const seamlessHandoffRef = useRef(false);
 
   const activeDefaultMap = DEFAULT_MAPS[activeDefaultMapId] ?? DEFAULT_MAPS.meander;
+  const journeyModeActive = isJourneyMode();
   const journeyDecision = useMemo(
     () => getJourneyCompletionDecision(activeDefaultMapId),
     [activeDefaultMapId],
@@ -141,6 +153,13 @@ export function useExperienceWorld({
   useEffect(() => {
     if (!controlledMapId || controlledMapId === activeDefaultMapId) return;
 
+    if (seamlessHandoffRef.current) {
+      // App URL sync after seamless handoff — adopt id without remount/snap.
+      setActiveDefaultMapId(controlledMapId);
+      seamlessHandoffRef.current = false;
+      return;
+    }
+
     const targetMap = DEFAULT_MAPS[controlledMapId] ?? DEFAULT_MAPS.meander;
     setActiveDefaultMapId(controlledMapId);
     setCurrentSegmentIndex(targetMap.startIndex);
@@ -162,6 +181,10 @@ export function useExperienceWorld({
 
   useEffect(() => {
     if (levelUrl || reachId) return;
+    if (seamlessHandoffRef.current) return;
+
+    // Only snap spawn/biome on hard map loads (TrackManager remount key), not
+    // seamless handoffs that update activeDefaultMapId in place.
     const syncMapStartState = () => {
       setCurrentSegmentIndex(activeDefaultMap.startIndex);
       setRespawnSegmentIndex(activeDefaultMap.startIndex);
@@ -173,13 +196,15 @@ export function useExperienceWorld({
     const timeout = window.setTimeout(syncMapStartState, 0);
     return () => window.clearTimeout(timeout);
   }, [
-    activeDefaultMap.initialBiome,
-    activeDefaultMap.startIndex,
+    defaultMapRunKey,
     levelUrl,
     reachId,
     snapBiomeContext,
     setCurrentSegmentIndex,
     setRespawnSegmentIndex,
+    // intentional: read latest map from closure when remount key changes
+    activeDefaultMap.initialBiome,
+    activeDefaultMap.startIndex,
   ]);
 
   useEffect(() => {
@@ -379,6 +404,7 @@ export function useExperienceWorld({
           launchHour: getActiveLaunchHour(),
           placedCacheIds: getRunSession()?.placedCacheIds ?? [],
           loadoutId: getRunSession()?.loadoutId,
+          journeyMode: getRunSession()?.journeyMode,
         });
         useGameStore.getState().resetGameState();
         setIsWipeout(false);
@@ -421,6 +447,88 @@ export function useExperienceWorld({
     ],
   );
 
+  /**
+   * Seamless campaign handoff: no TrackManager remount, preserve vehicle
+   * velocity + survival wetness/exposure, cross-fade biome, emit boundary events.
+   */
+  const performSeamlessMapHandoff = useCallback(
+    (fromMapId: MapRegistryId, segmentIndex: number) => {
+      const decision = getJourneyCompletionDecision(fromMapId);
+      if (decision.kind !== 'continue') {
+        // Final map — fall through to classic journey-complete overlay.
+        if (!useGameStore.getState().isJourneyComplete) {
+          useGameStore.getState().setJourneyComplete();
+        }
+        return false;
+      }
+
+      const nextMapId = decision.nextMapId;
+      const plan =
+        planMapHandoff({
+          fromMapId,
+          toMapId: nextMapId,
+          lastSegmentIndex: segmentIndex,
+        }) ?? null;
+
+      if (!plan) return false;
+
+      const kickoff = kickoffMapHandoff({
+        fromMapId,
+        toMapId: nextMapId,
+        segmentIndex,
+      });
+      if (!kickoff) return false;
+
+      const attached = trackManagerRef.current?.handoffToMap?.({
+        nextMapId,
+        plan: kickoff.plan,
+      });
+      if (!attached) {
+        console.warn(
+          `[useExperienceWorld] Seamless handoff attach failed for ${fromMapId} → ${nextMapId}; falling back to remount`,
+        );
+        resetDefaultMapRun(nextMapId);
+        return false;
+      }
+
+      seamlessHandoffRef.current = true;
+
+      const score = useGameStore.getState().score;
+      advanceRunSessionMap(nextMapId, { score, segmentIndex: plan.nextMapStartIndex });
+      saveJourneyCheckpoint({
+        mapId: nextMapId,
+        segmentIndex: plan.nextMapStartIndex,
+        score,
+      });
+
+      // Cross-fade biome (no snap); keep Canvas + vehicle motion.
+      setBiomeContext(kickoff.biomeKickoff.biomeId, kickoff.biomeKickoff.durationSeconds);
+      useGameStore.getState().clearJourneyComplete();
+      useGameStore.setState({
+        currentBiome: kickoff.biomeKickoff.biomeId,
+        isPaused: false,
+      });
+
+      setActiveDefaultMapId(nextMapId);
+      syncMapUrl(nextMapId);
+      onMapChange?.(nextMapId);
+
+      // Do NOT teleport, reset score, or remount TrackManager.
+      console.log(
+        `[useExperienceWorld] Seamless map handoff ${fromMapId} → ${nextMapId} (segment ${segmentIndex})`,
+      );
+      return true;
+    },
+    [onMapChange, resetDefaultMapRun, setBiomeContext, trackManagerRef],
+  );
+
+  const handleSeamlessHandoffFromTrack = useCallback(
+    (info: { segmentIndex: number; fromMapId: MapRegistryId }) => {
+      performSeamlessMapHandoff(info.fromMapId, info.segmentIndex);
+    },
+    [performSeamlessMapHandoff],
+  );
+
   const handleLoopCurrentMap = useCallback(() => {
     resetDefaultMapRun(activeDefaultMapId);
   }, [activeDefaultMapId, resetDefaultMapRun]);
@@ -428,17 +536,26 @@ export function useExperienceWorld({
   const handleContinueJourney = useCallback(() => {
     const decision = getJourneyCompletionDecision(activeDefaultMapId);
     if (decision.kind !== 'continue') return;
-    resetDefaultMapRun(decision.nextMapId);
-  }, [activeDefaultMapId, resetDefaultMapRun]);
+
+    // Prefer seamless handoff (no Canvas / TrackManager remount).
+    const segmentIndex =
+      useGameStore.getState().currentSegmentIndex ??
+      DEFAULT_MAPS[activeDefaultMapId]?.startIndex ??
+      0;
+    const ok = performSeamlessMapHandoff(activeDefaultMapId, segmentIndex);
+    if (!ok) {
+      resetDefaultMapRun(decision.nextMapId);
+    }
+  }, [activeDefaultMapId, performSeamlessMapHandoff, resetDefaultMapRun]);
 
   const handleDefaultJourneyAction = useCallback(() => {
     const decision = getJourneyCompletionDecision(activeDefaultMapId);
     if (decision.kind === 'continue') {
-      resetDefaultMapRun(decision.nextMapId);
+      handleContinueJourney();
       return;
     }
     resetDefaultMapRun(activeDefaultMapId);
-  }, [activeDefaultMapId, resetDefaultMapRun]);
+  }, [activeDefaultMapId, handleContinueJourney, resetDefaultMapRun]);
 
   const handleReturnToMenu = useCallback(() => {
     setLastMapId(activeDefaultMapId);
@@ -476,6 +593,9 @@ export function useExperienceWorld({
     continueLabel,
     isFinalMap,
     ghostBestScore,
+    /** Journey mode auto-handoffs at boundaries; single-map still seamless on Continue. */
+    seamlessJourney: journeyModeActive,
+    handleSeamlessHandoffFromTrack,
     handleLevelLoad,
     handleBiomeChange,
     handleLevelError,

--- a/src/maps/campaign.test.ts
+++ b/src/maps/campaign.test.ts
@@ -4,8 +4,10 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  buildCampaignStack,
   formatDuration,
   getContinuationTarget,
+  getDefaultJourneyStack,
   getJourneyCompletionDecision,
   isMapRegistryId,
   isMapUnlocked,
@@ -87,6 +89,14 @@ describe('getJourneyCompletionDecision', () => {
   it('shows summary for the final map', () => {
     expect(getJourneyCompletionDecision('delta')).toEqual({ kind: 'summary' });
     expect(getContinuationTarget('delta')).toBeNull();
+  });
+});
+
+describe('buildCampaignStack', () => {
+  it('chains glacial → meander → hydro → delta', () => {
+    expect(buildCampaignStack('glacial')).toEqual(['glacial', 'meander', 'hydro', 'delta']);
+    expect(buildCampaignStack('hydro')).toEqual(['hydro', 'delta']);
+    expect(getDefaultJourneyStack()[0]).toBe('glacial');
   });
 });
 

--- a/src/maps/campaign.ts
+++ b/src/maps/campaign.ts
@@ -141,3 +141,25 @@ export function formatDuration(seconds: number): string {
   const mins = Math.max(1, Math.round(seconds / 60));
   return `~${mins} min`;
 }
+
+/**
+ * Campaign descent stack for Journey mode.
+ * Starts at `fromMapId` (default glacial) and follows nextMapId / continuation
+ * until the final map. Lumber stays out of the default chain (menuHidden).
+ */
+export function buildCampaignStack(fromMapId: MapRegistryId = 'glacial'): MapRegistryId[] {
+  const stack: MapRegistryId[] = [];
+  let cursor: MapRegistryId | null = fromMapId;
+  const guard = new Set<MapRegistryId>();
+  while (cursor && !guard.has(cursor)) {
+    stack.push(cursor);
+    guard.add(cursor);
+    cursor = getContinuationTarget(cursor);
+  }
+  return stack;
+}
+
+/** Canonical full descent used by Journey mode StartMenu. */
+export function getDefaultJourneyStack(): MapRegistryId[] {
+  return buildCampaignStack('glacial');
+}

--- a/src/styles/start-menu.css
+++ b/src/styles/start-menu.css
@@ -50,6 +50,76 @@
   margin-bottom: 4px;
 }
 
+.start-menu-mode-select {
+  margin-bottom: 12px;
+  text-align: left;
+}
+
+.start-menu-mode-row {
+  display: flex;
+  gap: 8px;
+}
+
+.start-menu-mode-option {
+  flex: 1;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.03);
+  color: rgba(255, 255, 255, 0.85);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.start-menu-mode-option:hover {
+  border-color: rgba(79, 209, 199, 0.4);
+}
+
+.start-menu-mode-option.active {
+  border-color: rgba(79, 209, 199, 0.85);
+  background: rgba(59, 130, 246, 0.16);
+  color: #fff;
+}
+
+.start-menu-journey-stack {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.start-menu-journey-step {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.start-menu-journey-index {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  background: rgba(79, 209, 199, 0.2);
+  color: #9fe8e0;
+}
+
+.start-menu-journey-label {
+  font-size: 14px;
+  color: #fff;
+}
+
 .start-menu-map-option {
   display: flex;
   align-items: center;

--- a/src/systems/ChunkManager.ts
+++ b/src/systems/ChunkManager.ts
@@ -683,6 +683,23 @@ export class ChunkManager {
     this.reachSegments = reachSegments ?? null;
   }
 
+  /**
+   * Hot-swap the config source without wiping the live pool / vehicle continuity.
+   * Used by seamless map handoff so the treadmill keeps generating from the
+   * current nextSegmentId.
+   */
+  setMapManager(mapManager: MapManager): void {
+    this.mapManager = mapManager;
+  }
+
+  getMapManager(): MapManager {
+    return this.mapManager;
+  }
+
+  getNextSegmentId(): number {
+    return this.nextSegmentId;
+  }
+
   private clearBiomeDebounce(): void {
     if (this.biomeDebounceTimer) {
       clearTimeout(this.biomeDebounceTimer);

--- a/src/systems/GameState.ts
+++ b/src/systems/GameState.ts
@@ -91,6 +91,8 @@ export interface GameActions {
   setCurrentSegmentIndex: (index: number) => void;
   setIsWipeout: (wipeout: boolean) => void;
   setJourneyComplete: () => void;
+  /** Clear journey-complete overlay without a full run reset (seamless handoff). */
+  clearJourneyComplete: () => void;
   setIsDodging: (dodging: boolean) => void;
   setRespawnSegmentIndex: (index: number) => void;
   setWaterfallGravityMultiplier: (multiplier: number) => void;
@@ -188,6 +190,12 @@ export const useGameStore = create<GameStore>((set) => ({
         isPaused: true,
         highScore: newHighScore,
       };
+    }),
+
+  clearJourneyComplete: () =>
+    set({
+      isJourneyComplete: false,
+      isPaused: false,
     }),
 
   setIsDodging: (dodging) => set({ isDodging: dodging }),

--- a/src/systems/MapSystem.ts
+++ b/src/systems/MapSystem.ts
@@ -471,6 +471,16 @@ export class ProceduralMapManager implements MapManager {
   private continuationManager: JSONMapManager | null;
   private continuationStartIndex: number;
   private fallbackManager: DefaultMapManager;
+  /** Global treadmill index where continuation levelData begins (primary totalSegments by default). */
+  private continuationGlobalStart: number | null = null;
+  /** Optional width/water overrides at the handoff seam (segmentOffset → blend). */
+  private handoffWidthBlend: Map<number, { width: number; waterWidth: number }> = new Map();
+  /**
+   * When true, primary journeyComplete is suppressed so the treadmill can keep
+   * generating into an attached handoff continuation. Initial registry
+   * continuation must NOT set this — single-map hydro still needs its overlay.
+   */
+  private suppressTerminalComplete = false;
 
   constructor(
     levelData?: LevelData | null,
@@ -488,16 +498,65 @@ export class ProceduralMapManager implements MapManager {
     this.fallbackManager = new DefaultMapManager(config, fallbackProgression);
   }
 
+  /** Authored segment count of the primary map (0 when procedural-only). */
+  getPrimarySegmentCount(): number {
+    return this.levelData?.world.track.totalSegments ?? 0;
+  }
+
+  /**
+   * Attach or replace the continuation map used when the primary authored range
+   * is exhausted. Does not reset the treadmill — call from seamless handoff.
+   */
+  attachContinuation(
+    continuation: { levelData: LevelData; startIndex?: number },
+    options?: {
+      globalStartIndex?: number;
+      widthBlend?: Array<{ segmentOffset: number; width: number; waterWidth: number }>;
+    },
+  ): void {
+    this.continuationManager = new JSONMapManager(continuation.levelData);
+    this.continuationStartIndex = continuation.startIndex ?? 0;
+    this.continuationGlobalStart =
+      options?.globalStartIndex ?? this.getPrimarySegmentCount();
+    this.suppressTerminalComplete = true;
+    this.handoffWidthBlend.clear();
+    for (const step of options?.widthBlend ?? []) {
+      this.handoffWidthBlend.set(step.segmentOffset, {
+        width: step.width,
+        waterWidth: step.waterWidth,
+      });
+    }
+  }
+
   getChunkConfig(index: number): SegmentProgressionConfig {
     if (this.jsonManager && this.levelData) {
       const totalSegments = this.levelData.world.track.totalSegments;
       const hasExplicit = this.levelData.segments.some((segment) => segment.index === index);
       if (hasExplicit || index < totalSegments) {
-        return this.jsonManager.getChunkConfig(index);
+        const cfg = this.jsonManager.getChunkConfig(index);
+        if (this.suppressTerminalComplete && cfg.journeyComplete) {
+          return { ...cfg, journeyComplete: false };
+        }
+        return cfg;
       }
       if (this.continuationManager) {
-        const continuationIndex = this.continuationStartIndex + (index - totalSegments);
-        return this.continuationManager.getChunkConfig(continuationIndex);
+        const globalStart = this.continuationGlobalStart ?? totalSegments;
+        const continuationIndex =
+          this.continuationStartIndex + (index - globalStart);
+        const cfg = this.continuationManager.getChunkConfig(continuationIndex);
+        const blend = this.handoffWidthBlend.get(index - globalStart);
+        if (blend) {
+          return {
+            ...cfg,
+            width: blend.width,
+            waterWidth: blend.waterWidth,
+            journeyComplete: false,
+          };
+        }
+        return {
+          ...cfg,
+          journeyComplete: index - globalStart === 0 ? false : cfg.journeyComplete,
+        };
       }
     }
     return this.fallbackManager.getChunkConfig(index);

--- a/src/systems/ReachManager.tsx
+++ b/src/systems/ReachManager.tsx
@@ -1,13 +1,14 @@
 /**
  * ReachManager.tsx
  *
- * Orchestrates a single Reach lifecycle.
+ * Orchestrates Reach lifecycle + multi-Reach seamless handoff.
  * - Loads Reach manifest and assets in the background.
  * - Normalizes manifest data into TrackManager-compatible segments.
- * - Watches player progress and logs transition entry for future multi-Reach handoff.
+ * - On transition entry: prefetch next reach, append continuous segments,
+ *   cross-fade biome, emit reach-exit / reach-enter (no Canvas remount).
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
 import TrackManager from '../components/TrackManager';
 import ReactiveAudio from '../components/ReactiveAudio';
@@ -17,7 +18,17 @@ import { normalizeReachManifest, NormalizedSegment } from './ReachNormalizer';
 import { type BiomeId, normalizeBiomeId } from '../configs/biomes';
 import { samplesToForecastByIndex } from './flowForecast';
 import { FLOW_FORECAST_STATES } from '../constants/game';
-// Removed DOM UI imports — overlays are lifted to Experience.jsx
+import { joinWaypoints } from './journeyContinuity';
+import {
+  emitReachEnter,
+  emitReachExit,
+  emitJourneyHandoff,
+  prefetchNextReach,
+  resolveNextReachId,
+} from './journeyHandoff';
+import { saveJourneyCheckpoint } from './runSession';
+import { useGameStore } from './GameState';
+import { useBiome } from './BiomeSystem';
 
 interface ReachManagerProps {
   /** Player / vehicle rigid body ref */
@@ -28,6 +39,8 @@ interface ReachManagerProps {
   forecastSamples?: Array<{ state: string; [key: string]: unknown }>;
   /** Reach identifier to load */
   reachId?: string;
+  /** Optional next reach override when manifest omits transition.nextReachId */
+  nextReachId?: string;
   /** Called when loading state changes */
   onLoadingChange?: (loading: boolean) => void;
   /** Called when an error occurs or is cleared */
@@ -41,6 +54,7 @@ export default function ReachManager({
   onBiomeChange,
   forecastSamples = [],
   reachId = undefined,
+  nextReachId: nextReachIdProp,
   onLoadingChange,
   onError,
   retryKey = 0,
@@ -49,7 +63,10 @@ export default function ReachManager({
   const [manifest, setManifest] = useState<ReachManifest | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const transitionLoggedRef = useRef(false);
+  const [activeReachId, setActiveReachId] = useState<string | undefined>(reachId);
+  const transitionHandledRef = useRef(false);
+  const handoffInProgressRef = useRef(false);
+  const { setBiome } = useBiome();
 
   // Notify parent of loading / error state changes
   useEffect(() => {
@@ -60,14 +77,14 @@ export default function ReachManager({
     onError?.(error);
   }, [error, onError]);
 
-  // Load the Reach on mount / reachId change
+  // Load the Reach on mount / reachId change (initial load only — handoffs append)
   useEffect(() => {
-    // Skip loading if no reachId provided
     if (!reachId) {
       setLoading(false);
       setError(null);
       setReachSegments(null);
       setManifest(null);
+      setActiveReachId(undefined);
       return;
     }
 
@@ -78,7 +95,8 @@ export default function ReachManager({
       setError(null);
       setReachSegments(null);
       setManifest(null);
-      transitionLoggedRef.current = false;
+      transitionHandledRef.current = false;
+      handoffInProgressRef.current = false;
 
       try {
         const result = await ReachStreamer.preloadReach(reachId);
@@ -95,9 +113,16 @@ export default function ReachManager({
 
         setManifest(result.manifest);
         setReachSegments(segments);
+        setActiveReachId(reachId);
         console.log(`[ReachManager] Reach ${reachId} loaded with ${segments.length} segments.`);
 
-        // Trigger initial biome callback if provided
+        emitReachEnter({
+          reachId,
+          nextReachId: resolveNextReachId(result.manifest.transition, nextReachIdProp),
+          segmentIndex: 0,
+          transitionType: result.manifest.transition?.type,
+        });
+
         if (onBiomeChange && result.manifest.world?.biome?.baseType) {
           onBiomeChange(normalizeBiomeId(result.manifest.world.biome.baseType));
         }
@@ -121,10 +146,126 @@ export default function ReachManager({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reachId, onBiomeChange, retryKey]);
 
-  // Watch player position for transition entry
+  const performReachHandoff = useCallback(
+    async (fromReachId: string, currentManifest: ReachManifest, currentSegments: NormalizedSegment[]) => {
+      if (handoffInProgressRef.current) return;
+      handoffInProgressRef.current = true;
+
+      const nextId = resolveNextReachId(currentManifest.transition, nextReachIdProp);
+      const transitionIndex = currentManifest.transition.segmentIndex;
+
+      emitReachExit({
+        reachId: fromReachId,
+        nextReachId: nextId,
+        segmentIndex: transitionIndex,
+        transitionType: currentManifest.transition.type,
+      });
+
+      saveJourneyCheckpoint({
+        segmentIndex: transitionIndex,
+        score: useGameStore.getState().score,
+      });
+
+      if (!nextId) {
+        console.log(
+          `[ReachManager] Transition acted (no nextReachId) — boundary checkpoint saved for ${fromReachId}`,
+        );
+        handoffInProgressRef.current = false;
+        return;
+      }
+
+      // Prefetch (404 → procedural remains OK)
+      const prefetch = await prefetchNextReach(nextId);
+      if (!prefetch?.ok) {
+        console.warn(
+          `[ReachManager] Next reach ${nextId} unavailable; staying on current treadmill after transition act.`,
+        );
+        handoffInProgressRef.current = false;
+        return;
+      }
+
+      try {
+        const nextManifest = structuredClone(ReachStreamer.getCachedReach(nextId));
+        const prevSeg = currentSegments[currentSegments.length - 1];
+        const forecastByIndex = samplesToForecastByIndex(forecastSamples);
+
+        // Continuity: join next waypoints onto previous end before normalize.
+        const nextWaypoints = (nextManifest.world?.track?.waypoints ?? []) as number[][];
+        if (prevSeg?.points?.length && nextWaypoints.length > 0) {
+          const joined = joinWaypoints(
+            prevSeg.points,
+            nextWaypoints.map((p) => ({ x: p[0], y: p[1], z: p[2] })),
+          );
+          nextManifest.world.track.waypoints = joined.joinedWaypoints.map((v) => [
+            v.x,
+            v.y,
+            v.z,
+          ]);
+        }
+
+        const nextSegments = normalizeReachManifest(nextManifest, prevSeg, {
+          forecastByIndex,
+          forecastState:
+            forecastSamples.length > 0
+              ? forecastSamples[0].state
+              : FLOW_FORECAST_STATES.NORMAL,
+        });
+
+        // Re-index appended segments so TrackManager IDs stay monotonic.
+        const idOffset = currentSegments.length;
+        const appended = nextSegments.map((seg) => ({
+          ...seg,
+          id: seg.id + idOffset,
+        }));
+
+        const merged = [...currentSegments, ...appended];
+        setReachSegments(merged);
+        setManifest(nextManifest);
+        setActiveReachId(nextId);
+        transitionHandledRef.current = false;
+
+        const nextBiome = normalizeBiomeId(
+          nextManifest.world?.biome?.baseType || 'canyonSummer',
+        );
+        // Cross-fade — no hard snap / Canvas remount
+        setBiome(nextBiome, currentManifest.transition.durationSeconds || 2);
+        onBiomeChange?.(nextBiome);
+
+        emitJourneyHandoff({
+          kind: 'reach',
+          fromId: fromReachId,
+          toId: nextId,
+          segmentIndex: transitionIndex,
+          seamless: true,
+          biomeKickoff: {
+            biomeId: nextBiome,
+            durationSeconds: currentManifest.transition.durationSeconds || 2,
+            mode: 'crossfade',
+          },
+        });
+        emitReachEnter({
+          reachId: nextId,
+          nextReachId: resolveNextReachId(nextManifest.transition),
+          segmentIndex: idOffset,
+          transitionType: nextManifest.transition?.type,
+        });
+
+        console.log(
+          `[ReachManager] Seamless handoff ${fromReachId} → ${nextId} (+${appended.length} segments)`,
+        );
+      } catch (err) {
+        console.error(`[ReachManager] Handoff to ${nextId} failed:`, err);
+      } finally {
+        handoffInProgressRef.current = false;
+      }
+    },
+    [forecastSamples, nextReachIdProp, onBiomeChange, setBiome],
+  );
+
+  // Watch player position for transition entry — ACT, do not only log.
   useFrame(() => {
     if (!manifest || !reachSegments || reachSegments.length === 0) return;
-    if (!playerRef.current) return;
+    if (!playerRef.current || handoffInProgressRef.current) return;
 
     const playerPos = playerRef.current.translation
       ? playerRef.current.translation()
@@ -135,23 +276,22 @@ export default function ReachManager({
     const transitionSegment = reachSegments[transitionIndex];
     if (!transitionSegment) return;
 
-    // Determine if player is inside the transition segment by checking Z bounds
     const segPoints = transitionSegment.points;
     const zMin = Math.min(...segPoints.map((p) => p.z));
     const zMax = Math.max(...segPoints.map((p) => p.z));
 
     const inTransition = playerPos.z <= zMax && playerPos.z >= zMin;
 
-    if (inTransition && !transitionLoggedRef.current) {
-      transitionLoggedRef.current = true;
+    if (inTransition && !transitionHandledRef.current) {
+      transitionHandledRef.current = true;
+      const currentId = activeReachId ?? reachId ?? manifest.reachId;
       console.log(
-        `[ReachManager] Player entered transition segment ${transitionIndex} (${manifest.transition.type}) of Reach ${reachId}`
+        `[ReachManager] Transition entry acted for Reach ${currentId} (segment ${transitionIndex}, ${manifest.transition.type})`,
       );
-    } else if (!inTransition && transitionLoggedRef.current) {
-      transitionLoggedRef.current = false;
-      console.log(
-        `[ReachManager] Player exited transition segment ${transitionIndex} of Reach ${reachId}`
-      );
+      void performReachHandoff(currentId, manifest, reachSegments);
+    } else if (!inTransition && transitionHandledRef.current && !handoffInProgressRef.current) {
+      // Allow re-entry detection only before handoff completes; after append the
+      // transition index still points at the old seam which the player has left.
     }
   });
 
@@ -173,13 +313,13 @@ export default function ReachManager({
         onBiomeChange={onBiomeChange}
         raftRef={playerRef}
         forecastSamples={forecastSamples}
-        reachId={reachId}
+        reachId={activeReachId ?? reachId}
       />
       {!error && (
         <>
           <ReactiveAudio
             targetRef={playerRef}
-            reachId={reachId}
+            reachId={activeReachId ?? reachId}
             manifest={manifest ?? undefined}
             reachSegments={reachSegments ?? []}
           />

--- a/src/systems/ReachStreamer.ts
+++ b/src/systems/ReachStreamer.ts
@@ -37,6 +37,8 @@ export interface ReachTransition {
   segmentIndex: number;
   type: 'waterfall' | 'slotCanyon' | 'splash';
   durationSeconds: number;
+  /** Optional next reach for multi-Reach seamless handoff. */
+  nextReachId?: string;
 }
 
 export interface ReachManifest {

--- a/src/systems/__tests__/journeyContinuity.test.ts
+++ b/src/systems/__tests__/journeyContinuity.test.ts
@@ -1,0 +1,137 @@
+/**
+ * journeyContinuity.test.ts — Pure handoff join + biome kickoff helpers.
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import {
+  blendWaterLevel,
+  blendWidthsOverSegments,
+  joinWaypoints,
+  planBiomeTransitionKickoff,
+  planMapHandoff,
+  HANDOFF_BLEND_SEGMENTS,
+} from '../journeyContinuity';
+
+describe('joinWaypoints', () => {
+  it('translates next waypoints so the first point meets the previous end', () => {
+    const prev = [
+      { x: 0, y: -2, z: 10 },
+      { x: 0, y: -2, z: 0 },
+    ];
+    const next = [
+      { x: 100, y: 5, z: 50 },
+      { x: 100, y: 5, z: 40 },
+      { x: 102, y: 4, z: 30 },
+    ];
+
+    const { joinedWaypoints, offset } = joinWaypoints(prev, next);
+
+    expect(offset.x).toBeCloseTo(-100);
+    expect(offset.y).toBeCloseTo(-7);
+    expect(offset.z).toBeCloseTo(-50);
+
+    // After offset + tangent nudge, first point stays near the previous end.
+    expect(joinedWaypoints[0].x).toBeCloseTo(0, 1);
+    expect(joinedWaypoints[0].y).toBeCloseTo(-2, 1);
+    expect(joinedWaypoints[0].z).toBeCloseTo(0, 1);
+  });
+
+  it('preserves relative spacing of the next path', () => {
+    const prev = [
+      new THREE.Vector3(0, 0, 10),
+      new THREE.Vector3(0, 0, 0),
+    ];
+    const next = [
+      new THREE.Vector3(5, 0, 5),
+      new THREE.Vector3(5, 0, -5),
+    ];
+    const { joinedWaypoints } = joinWaypoints(prev, next);
+    const dx = joinedWaypoints[1].x - joinedWaypoints[0].x;
+    const dz = joinedWaypoints[1].z - joinedWaypoints[0].z;
+    expect(dx).toBeCloseTo(0);
+    // ensureTangentContinuity nudges the joint by ~0.01 along the prev tangent
+    expect(dz).toBeCloseTo(-10, 1);
+  });
+
+  it('returns empty join for empty next waypoints', () => {
+    const result = joinWaypoints([{ x: 0, y: 0, z: 0 }], []);
+    expect(result.joinedWaypoints).toEqual([]);
+  });
+});
+
+describe('blendWidthsOverSegments', () => {
+  it('blends width and waterWidth over the default segment count', () => {
+    const steps = blendWidthsOverSegments(40, 12, 80, 24);
+    expect(steps).toHaveLength(HANDOFF_BLEND_SEGMENTS);
+    expect(steps[0].width).toBeCloseTo(40);
+    expect(steps[0].waterWidth).toBeCloseTo(12);
+    expect(steps[steps.length - 1].width).toBeCloseTo(80);
+    expect(steps[steps.length - 1].waterWidth).toBeCloseTo(24);
+  });
+
+  it('uses a single step when blendCount is 1', () => {
+    const steps = blendWidthsOverSegments(10, 5, 20, 8, 1);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].width).toBeCloseTo(20);
+    expect(steps[0].waterWidth).toBeCloseTo(8);
+  });
+});
+
+describe('blendWaterLevel', () => {
+  it('lerps water Y across the seam', () => {
+    expect(blendWaterLevel(0.5, 1.5, 0)).toBeCloseTo(0.5);
+    expect(blendWaterLevel(0.5, 1.5, 0.5)).toBeCloseTo(1.0);
+    expect(blendWaterLevel(0.5, 1.5, 1)).toBeCloseTo(1.5);
+  });
+});
+
+describe('planMapHandoff', () => {
+  it('plans hydro → delta with continuity fields', () => {
+    const plan = planMapHandoff({
+      fromMapId: 'hydro',
+      toMapId: 'delta',
+      lastSegmentIndex: 15,
+      lastWidth: 40,
+      lastWaterWidth: 14,
+    });
+    expect(plan).not.toBeNull();
+    expect(plan!.fromMapId).toBe('hydro');
+    expect(plan!.toMapId).toBe('delta');
+    expect(plan!.initialBiome).toBe('delta');
+    expect(plan!.preserveSurvival).toBe(true);
+    expect(plan!.preserveScore).toBe(true);
+    expect(plan!.preserveVehicleMotion).toBe(true);
+    expect(plan!.widthBlend.length).toBeGreaterThanOrEqual(1);
+    expect(plan!.biomeTransitionSeconds).toBeGreaterThan(0);
+    // Hydro wires continuation.levelData → next starts at hydro totalSegments.
+    expect(plan!.nextMapStartIndex).toBe(16);
+  });
+
+  it('plans meander → hydro via nextMapId', () => {
+    const plan = planMapHandoff({
+      fromMapId: 'meander',
+      lastSegmentIndex: 38,
+    });
+    expect(plan).not.toBeNull();
+    expect(plan!.toMapId).toBe('hydro');
+    expect(plan!.nextMapStartIndex).toBe(39);
+  });
+
+  it('returns null for the final campaign map', () => {
+    expect(
+      planMapHandoff({ fromMapId: 'delta', lastSegmentIndex: 8 }),
+    ).toBeNull();
+  });
+});
+
+describe('planBiomeTransitionKickoff', () => {
+  it('requests a crossfade (not a hard snap)', () => {
+    const kickoff = planBiomeTransitionKickoff('delta', 2.5);
+    expect(kickoff).toEqual({
+      biomeId: 'delta',
+      durationSeconds: 2.5,
+      mode: 'crossfade',
+    });
+  });
+});

--- a/src/systems/__tests__/journeyHandoff.test.ts
+++ b/src/systems/__tests__/journeyHandoff.test.ts
@@ -1,0 +1,74 @@
+/**
+ * journeyHandoff.test.ts — Event emission + map handoff kickoff.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  JOURNEY_HANDOFF_EVENT,
+  MAP_ENTER_EVENT,
+  MAP_EXIT_EVENT,
+  kickoffMapHandoff,
+  resolveNextReachId,
+} from '../journeyHandoff';
+
+describe('resolveNextReachId', () => {
+  it('prefers transition.nextReachId over fallback', () => {
+    expect(resolveNextReachId({ nextReachId: 'delta-reach' }, 'other')).toBe('delta-reach');
+  });
+
+  it('falls back when transition omits nextReachId', () => {
+    expect(resolveNextReachId({ type: 'waterfall' }, 'meander-reach')).toBe('meander-reach');
+    expect(resolveNextReachId(null, null)).toBeNull();
+  });
+});
+
+describe('kickoffMapHandoff', () => {
+  const events: Array<{ type: string; detail: unknown }> = [];
+
+  beforeEach(() => {
+    events.length = 0;
+    vi.stubGlobal(
+      'window',
+      Object.assign(window, {
+        dispatchEvent: (ev: Event) => {
+          const ce = ev as CustomEvent;
+          events.push({ type: ce.type, detail: ce.detail });
+          return true;
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('emits exit / handoff / enter for hydro → delta', () => {
+    const result = kickoffMapHandoff({
+      fromMapId: 'hydro',
+      toMapId: 'delta',
+      segmentIndex: 15,
+      lastWidth: 40,
+      lastWaterWidth: 12,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.plan.toMapId).toBe('delta');
+    expect(result!.biomeKickoff.mode).toBe('crossfade');
+    expect(result!.biomeKickoff.biomeId).toBe('delta');
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain(MAP_EXIT_EVENT);
+    expect(types).toContain(JOURNEY_HANDOFF_EVENT);
+    expect(types).toContain(MAP_ENTER_EVENT);
+
+    const handoff = events.find((e) => e.type === JOURNEY_HANDOFF_EVENT)?.detail as {
+      seamless: boolean;
+      fromId: string;
+      toId: string;
+    };
+    expect(handoff.seamless).toBe(true);
+    expect(handoff.fromId).toBe('hydro');
+    expect(handoff.toId).toBe('delta');
+  });
+});

--- a/src/systems/__tests__/runSession.journey.test.ts
+++ b/src/systems/__tests__/runSession.journey.test.ts
@@ -1,0 +1,57 @@
+/**
+ * runSession.journey.test.ts — Journey mode map stack + survival continuity.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  advanceRunSessionMap,
+  getRunSession,
+  initRunSession,
+  resetRunSessionForTests,
+  saveJourneyCheckpoint,
+  tickRunSurvival,
+} from '../runSession';
+
+describe('runSession journey mode', () => {
+  beforeEach(() => {
+    resetRunSessionForTests();
+  });
+
+  it('builds a campaign stack when journeyMode is journey', () => {
+    const session = initRunSession({ mapId: 'glacial', journeyMode: 'journey' });
+    expect(session.journeyMode).toBe('journey');
+    expect(session.mapStack[0]).toBe('glacial');
+    expect(session.mapStack).toContain('meander');
+    expect(session.mapStack).toContain('hydro');
+    expect(session.mapStack[session.mapStack.length - 1]).toBe('delta');
+    expect(session.mapId).toBe('glacial');
+  });
+
+  it('preserves survival wetness/exposure across advanceRunSessionMap', () => {
+    initRunSession({ mapId: 'hydro', journeyMode: 'journey', launchHour: 10 });
+    tickRunSurvival({
+      dt: 2,
+      biomeId: 'hydroDam',
+      inWater: true,
+      windSpeed: 1,
+    });
+    const before = getRunSession()!.survival;
+    expect(before.wetness).toBeGreaterThan(0);
+
+    advanceRunSessionMap('delta', { score: 1200, segmentIndex: 16 });
+    const after = getRunSession()!;
+    expect(after.mapId).toBe('delta');
+    expect(after.survival.wetness).toBeCloseTo(before.wetness);
+    expect(after.survival.coreTemp).toBeCloseTo(before.coreTemp);
+    expect(after.cumulativeScore).toBe(1200);
+    expect(after.lastCheckpoint?.mapId).toBe('delta');
+  });
+
+  it('autosaves a boundary checkpoint without changing map', () => {
+    initRunSession({ mapId: 'meander', journeyMode: 'single' });
+    const cp = saveJourneyCheckpoint({ segmentIndex: 38, score: 500 });
+    expect(cp).not.toBeNull();
+    expect(getRunSession()!.lastCheckpoint?.score).toBe(500);
+    expect(getRunSession()!.mapId).toBe('meander');
+  });
+});

--- a/src/systems/journeyContinuity.ts
+++ b/src/systems/journeyContinuity.ts
@@ -1,0 +1,227 @@
+/**
+ * journeyContinuity.ts — Pure helpers for seamless map/reach handoffs.
+ *
+ * Joins the end of reach/map N to the start of N+1 (waypoints, water level,
+ * width blend) without allocating scene graph objects. Unit-tested; safe to
+ * call from handoff planning outside React.
+ */
+
+import * as THREE from 'three';
+import { ensureTangentContinuity } from './MapSystem.generation';
+import type { MapRegistryId } from '../maps/registry';
+import { getMapDefinition } from '../maps/registry';
+import { getContinuationTarget } from '../maps/campaign';
+import type { BiomeId } from '../configs/biomes';
+
+/** Default number of segments over which width/water blend at a seam. */
+export const HANDOFF_BLEND_SEGMENTS = 2;
+
+export interface Vec3Like {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface JoinWaypointsResult {
+  /** Next-reach waypoints translated so index 0 meets the previous end. */
+  joinedWaypoints: THREE.Vector3[];
+  /** World-space offset applied to every next waypoint. */
+  offset: THREE.Vector3;
+  /** Tangent of the previous path end (unit length, or zero if unavailable). */
+  prevTangent: THREE.Vector3;
+}
+
+export interface WidthBlendStep {
+  segmentOffset: number;
+  width: number;
+  waterWidth: number;
+}
+
+export interface HandoffPlan {
+  fromMapId: MapRegistryId;
+  toMapId: MapRegistryId;
+  /** Global treadmill index where the next map's segment 0 begins. */
+  nextMapStartIndex: number;
+  /** Authored start index inside the next map's level data. */
+  toMapLocalStartIndex: number;
+  initialBiome: BiomeId;
+  widthBlend: WidthBlendStep[];
+  waterLevelFrom: number;
+  waterLevelTo: number;
+  /** Recommended biome crossfade duration (seconds). */
+  biomeTransitionSeconds: number;
+  preserveSurvival: true;
+  preserveScore: true;
+  preserveVehicleMotion: true;
+}
+
+/**
+ * Translate `nextWaypoints` so their first point coincides with `prevEnd`,
+ * then nudge the joint for Catmull-Rom tangent continuity.
+ */
+export function joinWaypoints(
+  prevPoints: ReadonlyArray<Vec3Like>,
+  nextWaypoints: ReadonlyArray<Vec3Like>,
+): JoinWaypointsResult {
+  if (nextWaypoints.length === 0) {
+    return {
+      joinedWaypoints: [],
+      offset: new THREE.Vector3(0, 0, 0),
+      prevTangent: new THREE.Vector3(0, 0, -1),
+    };
+  }
+
+  const prevEnd =
+    prevPoints.length > 0
+      ? toVector3(prevPoints[prevPoints.length - 1])
+      : toVector3(nextWaypoints[0]);
+
+  const nextStart = toVector3(nextWaypoints[0]);
+  const offset = new THREE.Vector3().subVectors(prevEnd, nextStart);
+
+  const joined = nextWaypoints.map((p) => toVector3(p).add(offset));
+
+  const prevTangent = computeEndTangent(prevPoints);
+  if (prevPoints.length >= 2 && joined.length >= 2) {
+    ensureTangentContinuity(
+      prevPoints.map(toVector3),
+      joined,
+    );
+  }
+
+  return { joinedWaypoints: joined, offset, prevTangent };
+}
+
+/**
+ * Linear blend schedule from outgoing widths to incoming over `blendCount`
+ * segments (inclusive of segmentOffset 0 = first next-map segment).
+ */
+export function blendWidthsOverSegments(
+  fromWidth: number,
+  fromWaterWidth: number,
+  toWidth: number,
+  toWaterWidth: number,
+  blendCount: number = HANDOFF_BLEND_SEGMENTS,
+): WidthBlendStep[] {
+  const steps = Math.max(1, Math.floor(blendCount));
+  const result: WidthBlendStep[] = [];
+  for (let i = 0; i < steps; i += 1) {
+    const t = steps === 1 ? 1 : i / (steps - 1);
+    result.push({
+      segmentOffset: i,
+      width: lerp(fromWidth, toWidth, t),
+      waterWidth: lerp(fromWaterWidth, toWaterWidth, t),
+    });
+  }
+  return result;
+}
+
+/** Interpolate water surface Y across a handoff seam. */
+export function blendWaterLevel(fromY: number, toY: number, t: number): number {
+  return lerp(fromY, toY, clamp01(t));
+}
+
+/**
+ * Build a handoff plan for an authored campaign pair (e.g. hydro → delta).
+ * Pure: does not mutate scene state.
+ */
+export function planMapHandoff(options: {
+  fromMapId: MapRegistryId;
+  toMapId?: MapRegistryId | null;
+  /** Last treadmill segment index that belongs to the outgoing map. */
+  lastSegmentIndex: number;
+  lastWidth?: number;
+  lastWaterWidth?: number;
+  lastWaterLevelY?: number;
+  blendSegments?: number;
+}): HandoffPlan | null {
+  const toMapId = options.toMapId ?? getContinuationTarget(options.fromMapId);
+  if (!toMapId) return null;
+
+  const fromDef = getMapDefinition(options.fromMapId);
+  const toDef = getMapDefinition(toMapId);
+
+  const toLocalStart =
+    fromDef.continuation?.mapId === toMapId
+      ? (fromDef.continuation.startIndex ?? toDef.startIndex)
+      : toDef.startIndex;
+
+  const fromTotal = fromDef.levelData.world.track.totalSegments;
+  // Next map starts immediately after the last authored outgoing segment when
+  // the outgoing map already wired continuation levelData; otherwise after
+  // lastSegmentIndex (journeyComplete fire point).
+  const nextMapStartIndex =
+    fromDef.continuation?.levelData && fromDef.continuation?.mapId === toMapId
+      ? fromTotal
+      : options.lastSegmentIndex + 1;
+
+  const lastWidth = options.lastWidth ?? 35;
+  const lastWaterWidth = options.lastWaterWidth ?? 10;
+  const toCfg = toDef.levelData.segments?.[0];
+  const toWidth = typeof toCfg?.width === 'number' ? toCfg.width : lastWidth;
+  const toWaterWidth =
+    typeof toCfg?.waterWidth === 'number' ? toCfg.waterWidth : lastWaterWidth;
+
+  const waterFrom = options.lastWaterLevelY ?? 0.5;
+  // Level JSON has no absolute water Y; preserve outgoing level across the seam
+  // unless the caller supplied an explicit target.
+  const waterTo = waterFrom;
+
+  return {
+    fromMapId: options.fromMapId,
+    toMapId,
+    nextMapStartIndex,
+    toMapLocalStartIndex: toLocalStart,
+    initialBiome: toDef.initialBiome,
+    widthBlend: blendWidthsOverSegments(
+      lastWidth,
+      lastWaterWidth,
+      toWidth,
+      toWaterWidth,
+      options.blendSegments ?? HANDOFF_BLEND_SEGMENTS,
+    ),
+    waterLevelFrom: waterFrom,
+    waterLevelTo: waterTo,
+    biomeTransitionSeconds: 2,
+    preserveSurvival: true,
+    preserveScore: true,
+    preserveVehicleMotion: true,
+  };
+}
+
+/**
+ * Kickoff payload for biome crossfade at a handoff seam — used by tests and
+ * ReachManager / TrackManager to start `BiomeProvider.setBiome` without a snap.
+ */
+export function planBiomeTransitionKickoff(
+  toBiome: BiomeId,
+  durationSeconds: number = 2,
+): { biomeId: BiomeId; durationSeconds: number; mode: 'crossfade' } {
+  return {
+    biomeId: toBiome,
+    durationSeconds,
+    mode: 'crossfade',
+  };
+}
+
+function toVector3(p: Vec3Like): THREE.Vector3 {
+  return p instanceof THREE.Vector3 ? p.clone() : new THREE.Vector3(p.x, p.y, p.z);
+}
+
+function computeEndTangent(points: ReadonlyArray<Vec3Like>): THREE.Vector3 {
+  if (points.length < 2) return new THREE.Vector3(0, 0, -1);
+  const a = toVector3(points[points.length - 2]);
+  const b = toVector3(points[points.length - 1]);
+  const t = new THREE.Vector3().subVectors(b, a);
+  if (!t.lengthSq() || !Number.isFinite(t.x)) return new THREE.Vector3(0, 0, -1);
+  return t.normalize();
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * clamp01(t);
+}
+
+function clamp01(t: number): number {
+  if (!Number.isFinite(t)) return 0;
+  return Math.min(1, Math.max(0, t));
+}

--- a/src/systems/journeyHandoff.ts
+++ b/src/systems/journeyHandoff.ts
@@ -1,0 +1,164 @@
+/**
+ * journeyHandoff.ts — Runtime handoff protocol for multi-map / multi-reach journeys.
+ *
+ * Emits window CustomEvents consumed by audio, scoring, and persistence.
+ * Coordinates prefetch + continuity planning; scene mutation stays in
+ * ReachManager / TrackManager / useExperienceWorld.
+ */
+
+import type { MapRegistryId } from '../maps/registry';
+import { getMapDefinition } from '../maps/registry';
+import {
+  planBiomeTransitionKickoff,
+  planMapHandoff,
+  type HandoffPlan,
+} from './journeyContinuity';
+import { ReachStreamer } from './ReachStreamer';
+
+export const REACH_ENTER_EVENT = 'reach-enter';
+export const REACH_EXIT_EVENT = 'reach-exit';
+export const MAP_ENTER_EVENT = 'map-enter';
+export const MAP_EXIT_EVENT = 'map-exit';
+export const JOURNEY_HANDOFF_EVENT = 'journey-handoff';
+
+export interface ReachBoundaryDetail {
+  reachId: string;
+  nextReachId?: string | null;
+  segmentIndex: number;
+  transitionType?: string;
+}
+
+export interface MapBoundaryDetail {
+  mapId: MapRegistryId;
+  nextMapId?: MapRegistryId | null;
+  segmentIndex: number;
+  plan?: HandoffPlan | null;
+}
+
+export interface JourneyHandoffDetail {
+  kind: 'map' | 'reach';
+  fromId: string;
+  toId: string;
+  segmentIndex: number;
+  plan?: HandoffPlan | null;
+  biomeKickoff?: ReturnType<typeof planBiomeTransitionKickoff>;
+  /** True when Canvas / TrackManager React tree must stay mounted. */
+  seamless: true;
+}
+
+export function emitReachExit(detail: ReachBoundaryDetail): void {
+  dispatch(REACH_EXIT_EVENT, detail);
+}
+
+export function emitReachEnter(detail: ReachBoundaryDetail): void {
+  dispatch(REACH_ENTER_EVENT, detail);
+}
+
+export function emitMapExit(detail: MapBoundaryDetail): void {
+  dispatch(MAP_EXIT_EVENT, detail);
+}
+
+export function emitMapEnter(detail: MapBoundaryDetail): void {
+  dispatch(MAP_ENTER_EVENT, detail);
+}
+
+export function emitJourneyHandoff(detail: JourneyHandoffDetail): void {
+  dispatch(JOURNEY_HANDOFF_EVENT, detail);
+}
+
+/**
+ * Prefetch next reach assets (no-op when already cached). Safe outside useFrame.
+ * Returns null when the Reach API is unavailable (404 → procedural is OK).
+ */
+export async function prefetchNextReach(
+  nextReachId: string | null | undefined,
+): Promise<{ reachId: string; ok: boolean; error?: string } | null> {
+  if (!nextReachId) return null;
+  if (ReachStreamer.isReachCached(nextReachId)) {
+    return { reachId: nextReachId, ok: true };
+  }
+  try {
+    await ReachStreamer.preloadReach(nextReachId);
+    return { reachId: nextReachId, ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[journeyHandoff] Prefetch of reach ${nextReachId} failed (procedural OK):`, message);
+    return { reachId: nextReachId, ok: false, error: message };
+  }
+}
+
+/**
+ * Build the full handoff kickoff for an authored map pair and emit boundary events.
+ * Callers still apply biome crossfade + map manager swap.
+ */
+export function kickoffMapHandoff(options: {
+  fromMapId: MapRegistryId;
+  toMapId: MapRegistryId;
+  segmentIndex: number;
+  lastWidth?: number;
+  lastWaterWidth?: number;
+}): {
+  plan: HandoffPlan;
+  biomeKickoff: ReturnType<typeof planBiomeTransitionKickoff>;
+} | null {
+  const plan = planMapHandoff({
+    fromMapId: options.fromMapId,
+    toMapId: options.toMapId,
+    lastSegmentIndex: options.segmentIndex,
+    lastWidth: options.lastWidth,
+    lastWaterWidth: options.lastWaterWidth,
+  });
+  if (!plan) return null;
+
+  const biomeKickoff = planBiomeTransitionKickoff(
+    plan.initialBiome,
+    plan.biomeTransitionSeconds,
+  );
+
+  emitMapExit({
+    mapId: options.fromMapId,
+    nextMapId: options.toMapId,
+    segmentIndex: options.segmentIndex,
+    plan,
+  });
+  emitJourneyHandoff({
+    kind: 'map',
+    fromId: options.fromMapId,
+    toId: options.toMapId,
+    segmentIndex: options.segmentIndex,
+    plan,
+    biomeKickoff,
+    seamless: true,
+  });
+  emitMapEnter({
+    mapId: options.toMapId,
+    nextMapId: getContinuationTargetSafe(options.toMapId),
+    segmentIndex: plan.nextMapStartIndex,
+    plan,
+  });
+
+  return { plan, biomeKickoff };
+}
+
+/**
+ * Resolve next reach id from a manifest transition (optional authored field).
+ * Falls back to `transition.nextReachId` when present on the typed extension.
+ */
+export function resolveNextReachId(
+  transition: { nextReachId?: string; type?: string } | null | undefined,
+  fallback?: string | null,
+): string | null {
+  if (transition?.nextReachId) return transition.nextReachId;
+  return fallback ?? null;
+}
+
+function getContinuationTargetSafe(mapId: MapRegistryId): MapRegistryId | null {
+  const def = getMapDefinition(mapId);
+  if (def.nextMapId) return def.nextMapId;
+  return def.continuation?.mapId ?? null;
+}
+
+function dispatch(name: string, detail: unknown): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(name, { detail }));
+}

--- a/src/systems/runSession.ts
+++ b/src/systems/runSession.ts
@@ -7,6 +7,7 @@
 
 import type { MapRegistryId } from '../maps/registry';
 import { getMapSurvivalMetadata } from '../maps/survivalMetadata';
+import { buildCampaignStack } from '../maps/campaign';
 import {
   createPortageCacheRunState,
   placeCache,
@@ -15,7 +16,7 @@ import {
   type PortageCacheRunState,
   DEFAULT_MAX_CACHE_PLACEMENTS,
 } from './portageCache';
-import { getLaunchHour } from './PersistenceSystem';
+import { getLaunchHour, setLastMapId, markMapCompleted } from './PersistenceSystem';
 import {
   createSurvivalState,
   getLoadoutDefinition,
@@ -28,6 +29,16 @@ import {
   type SurvivalTickInput,
 } from './survival';
 
+export type JourneyMode = 'single' | 'journey';
+
+export interface JourneyCheckpoint {
+  mapId: MapRegistryId;
+  segmentIndex: number;
+  score: number;
+  survival: SurvivalState;
+  savedAtMs: number;
+}
+
 export interface RunSessionSnapshot {
   mapId: MapRegistryId;
   launchHour: number;
@@ -35,6 +46,17 @@ export interface RunSessionSnapshot {
   loadoutId: LoadoutId;
   portageCache: PortageCacheRunState;
   survival: SurvivalState;
+  /** single = one map; journey = campaign chain with seamless handoffs. */
+  journeyMode: JourneyMode;
+  /** Ordered campaign stack when journeyMode === 'journey'. */
+  mapStack: MapRegistryId[];
+  currentMapIndex: number;
+  /** Cumulative score across map boundaries (mirrors Zustand score in journey). */
+  cumulativeScore: number;
+  peakAirTime: number;
+  peakExposureStress: number;
+  /** Last autosave at a reach/map boundary. */
+  lastCheckpoint: JourneyCheckpoint | null;
 }
 
 let activeSession: RunSessionSnapshot | null = null;
@@ -45,8 +67,14 @@ export function initRunSession(options: {
   launchHour?: number;
   placedCacheIds?: string[];
   loadoutId?: LoadoutId | string;
+  journeyMode?: JourneyMode;
 }): RunSessionSnapshot {
-  const survival = getMapSurvivalMetadata(options.mapId);
+  const journeyMode = options.journeyMode ?? 'single';
+  const mapStack =
+    journeyMode === 'journey' ? buildCampaignStack(options.mapId) : [options.mapId];
+  const startMapId = mapStack[0] ?? options.mapId;
+
+  const survival = getMapSurvivalMetadata(startMapId);
   const launchHour = normalizeHour(options.launchHour ?? getLaunchHour());
   const maxPlacements = survival.maxCachePlacements ?? DEFAULT_MAX_CACHE_PLACEMENTS;
   const loadoutId = resolveLoadoutId(options.loadoutId);
@@ -67,12 +95,19 @@ export function initRunSession(options: {
   }
 
   activeSession = {
-    mapId: options.mapId,
+    mapId: startMapId,
     launchHour,
     placedCacheIds,
     loadoutId,
     portageCache,
     survival: createSurvivalState(),
+    journeyMode,
+    mapStack,
+    currentMapIndex: 0,
+    cumulativeScore: 0,
+    peakAirTime: 0,
+    peakExposureStress: 0,
+    lastCheckpoint: null,
   };
   awardedCacheSegments = new Set();
   return activeSession;
@@ -80,6 +115,10 @@ export function initRunSession(options: {
 
 export function getRunSession(): RunSessionSnapshot | null {
   return activeSession;
+}
+
+export function isJourneyMode(): boolean {
+  return activeSession?.journeyMode === 'journey';
 }
 
 export function getActiveLaunchHour(): number {
@@ -114,7 +153,14 @@ export function tickRunSurvival(input: Omit<SurvivalTickInput, 'launchHour'>): S
       loadout,
     ),
   };
-  return getSurvivalModifiers(activeSession.survival, input.biomeId, loadout);
+  const mods = getSurvivalModifiers(activeSession.survival, input.biomeId, loadout);
+  if (mods.exposureStress > activeSession.peakExposureStress) {
+    activeSession = {
+      ...activeSession,
+      peakExposureStress: mods.exposureStress,
+    };
+  }
+  return mods;
 }
 
 export function dispatchPortageCacheEvent(event: PortageCacheEvent): PortageCacheRunState | null {
@@ -130,6 +176,101 @@ export function markCacheBonusAwarded(segmentIndex: number): boolean {
   if (awardedCacheSegments.has(segmentIndex)) return false;
   awardedCacheSegments.add(segmentIndex);
   return true;
+}
+
+/**
+ * Advance to the next campaign map without resetting survival wetness/exposure.
+ * Remaps portage caches for the new map metadata; preserves loadout + launch hour.
+ */
+export function advanceRunSessionMap(
+  nextMapId: MapRegistryId,
+  options?: { score?: number; segmentIndex?: number; airTime?: number },
+): RunSessionSnapshot | null {
+  if (!activeSession) return null;
+
+  const previousSurvival = activeSession.survival;
+  const survivalMeta = getMapSurvivalMetadata(nextMapId);
+  const maxPlacements = survivalMeta.maxCachePlacements ?? DEFAULT_MAX_CACHE_PLACEMENTS;
+
+  let portageCache = createPortageCacheRunState({
+    cacheSlots: survivalMeta.cacheSlots,
+    portageRoutes: survivalMeta.portageRoutes,
+  });
+
+  // Re-apply placements that still exist on the next map.
+  const placedCacheIds: string[] = [];
+  for (const slotId of activeSession.placedCacheIds) {
+    if (portageCache.cacheSlots.some((slot) => slot.id === slotId && slot.status === 'unplaced')) {
+      portageCache = placeCache(portageCache, slotId, maxPlacements);
+      if (portageCache.cacheSlots.find((slot) => slot.id === slotId)?.status === 'placed') {
+        placedCacheIds.push(slotId);
+      }
+    }
+  }
+
+  const stackIndex = activeSession.mapStack.indexOf(nextMapId);
+  const currentMapIndex =
+    stackIndex >= 0 ? stackIndex : Math.min(activeSession.currentMapIndex + 1, activeSession.mapStack.length - 1);
+
+  const score = options?.score ?? activeSession.cumulativeScore;
+  const segmentIndex = options?.segmentIndex ?? 0;
+  const airTime = options?.airTime ?? activeSession.peakAirTime;
+
+  markMapCompleted(activeSession.mapId);
+  setLastMapId(nextMapId);
+
+  const checkpoint: JourneyCheckpoint = {
+    mapId: nextMapId,
+    segmentIndex,
+    score,
+    survival: { ...previousSurvival },
+    savedAtMs: Date.now(),
+  };
+
+  activeSession = {
+    ...activeSession,
+    mapId: nextMapId,
+    placedCacheIds,
+    portageCache,
+    // Preserve wetness / coreTemp across the boundary (AC).
+    survival: previousSurvival,
+    currentMapIndex,
+    cumulativeScore: score,
+    peakAirTime: Math.max(activeSession.peakAirTime, airTime),
+    lastCheckpoint: checkpoint,
+  };
+  awardedCacheSegments = new Set();
+  return activeSession;
+}
+
+/** Autosave checkpoint at a reach/map boundary without changing the active map. */
+export function saveJourneyCheckpoint(options: {
+  mapId?: MapRegistryId;
+  segmentIndex: number;
+  score: number;
+}): JourneyCheckpoint | null {
+  if (!activeSession) return null;
+  const checkpoint: JourneyCheckpoint = {
+    mapId: options.mapId ?? activeSession.mapId,
+    segmentIndex: options.segmentIndex,
+    score: options.score,
+    survival: { ...activeSession.survival },
+    savedAtMs: Date.now(),
+  };
+  activeSession = {
+    ...activeSession,
+    cumulativeScore: options.score,
+    lastCheckpoint: checkpoint,
+  };
+  setLastMapId(checkpoint.mapId);
+  return checkpoint;
+}
+
+export function notePeakAirTime(seconds: number): void {
+  if (!activeSession || !Number.isFinite(seconds)) return;
+  if (seconds > activeSession.peakAirTime) {
+    activeSession = { ...activeSession, peakAirTime: seconds };
+  }
 }
 
 export function resetRunSessionForTests(): void {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **#339** — multi-Reach / campaign map seamless handoff so source→delta runs stay continuous without Canvas remount.

### Handoff protocol
- **ReachManager** transition entry now **acts**: prefetch via `ReachStreamer.preloadReach`, join waypoints (`journeyContinuity`), append normalized segments, biome crossfade (`setBiome`), emit `reach-exit` / `reach-enter` / `journey-handoff`, autosave checkpoint
- **Map campaign**: `TrackManager.handoffToMap` + `ProceduralMapManager.attachContinuation` stitch the next authored map (e.g. hydro→delta, meander→hydro) without remounting TrackManager/Canvas; vehicle velocity retained
- **Continue** (single-map) and **Journey mode** auto-boundary use the same seamless path; survival wetness/exposure preserved via `advanceRunSessionMap`

### Journey UX
- StartMenu: **Single Map** vs **Journey** (campaign stack glacial→meander→hydro→delta)
- `runSession` carries `journeyMode`, `mapStack`, cumulative score, peak exposure, boundary checkpoints

### Continuity contract + tests
- Pure helpers in `journeyContinuity.ts` / events in `journeyHandoff.ts`
- Unit tests: join waypoints, width/water blend, biome kickoff, hydro→delta plan, survival carry, campaign stack

### Docs
- `SYSTEMS.md` ReachManager Known Pain removed; residual limits documented (Z-bounds trigger, 404→procedural OK)

### Non-goals (unchanged)
- No Reach HTTP backend
- No multiplayer

### Manual checklist
- [ ] Journey mode: pointer lock held across handoff; no fall-through
- [ ] Audio crossfade acceptable at biome seam
- [ ] Survival wetness persists hydro→delta (or meander→hydro Continue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9371db0f-3d19-4e27-a9c4-5e9ac69a04f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9371db0f-3d19-4e27-a9c4-5e9ac69a04f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

