### PR TITLE
Improve boot loader readiness and start menu feedback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Canvas } from '@react-three/fiber';
 import Experience from './Experience';
 import { Loader } from './components/Loader';
+import { useProgress } from '@react-three/drei';
 import { StartMenu } from './components/StartMenu';
 import { PauseMenu } from './components/PauseMenu';
 import DebugPanel from './components/DebugPanel';
@@ -93,7 +94,10 @@ function App() {
     parseRendererPreference()
   );
   const qualityPreset = useQualityPreset();
+  const { active: assetsLoading } = useProgress();
   const [canvasEpoch, setCanvasEpoch] = useState(0);
+  const [canvasReady, setCanvasReady] = useState(false);
+  const bootReady = canvasReady && !assetsLoading;
   const [webglRecovering, setWebglRecovering] = useState(false);
   const rendererContextOptions = deriveRendererContextOptions(qualityPreset, {
     devicePixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio : 1,
@@ -116,6 +120,10 @@ function App() {
         .catch((err) => console.error('[App] Failed to load LevelEditor:', err));
     }
   }, []);
+
+  useEffect(() => {
+    setCanvasReady(false);
+  }, [canvasEpoch]);
 
   useEffect(() => {
     initPersistence(getActiveRunKey(selectedMapId));
@@ -316,13 +324,14 @@ function App() {
     const onKeyDown = (e: KeyboardEvent) => {
       if (isTypingTarget(e.target)) return;
       if (e.key === 'Enter') {
+        if (!bootReady) return;
         e.preventDefault();
         handleStart(selectedMapId, { launchHour: undefined, placedCacheIds: [] });
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [handleStart, phase, selectedMapId]);
+  }, [bootReady, handleStart, phase, selectedMapId]);
 
   return (
     <ErrorBoundary>
@@ -364,6 +373,7 @@ function App() {
             frameloop="always"
             onCreated={({ gl }) => {
               debug.runStage('visualization', () => undefined);
+              setCanvasReady(true);
               const canvas = gl.domElement;
               const onContextLost = (event: Event) => {
                 event.preventDefault();
@@ -426,7 +436,9 @@ function App() {
           )}
 
           {/* Asset loading overlay */}
-          {debug.isStageEnabled('uiOverlay') && !skipLoader && <Loader />}
+          {debug.isStageEnabled('uiOverlay') && !skipLoader && (
+            <Loader gamePhase={phase} canvasReady={canvasReady} worldEnabled={worldEnabled} />
+          )}
 
           {/* Goal 4: Start Menu — shown before first run */}
           {debug.isStageEnabled('uiOverlay') && phase === 'menu' && !settingsOpen && (
@@ -435,6 +447,7 @@ function App() {
               selectedMapId={selectedMapId}
               onSelectMap={handleSelectMap}
               onOpenOptions={() => setSettingsOpen(true)}
+              bootReady={bootReady}
             />
           )}
           {/* Goal 4: Pause Menu — shown when pointer lock is lost during play */}

--- a/src/Experience.tsx
+++ b/src/Experience.tsx
@@ -5,6 +5,7 @@ import { LODProvider, PerformanceMonitor } from './systems/LODManager';
 import { SunPositionProvider } from './systems/SunPositionSystem';
 import PerfCheckpointMonitor from './debug/PerfCheckpointMonitor';
 import RendererDiagnosticsMonitor from './rendering/RendererDiagnosticsMonitor';
+import BootAssetPreloader from './components/BootAssetPreloader';
 import InnerExperience from './experience/InnerExperience';
 import { NOOP_DEBUG } from './experience/constants';
 import { initShelfLaunchScoringListener } from './systems/LaunchScoringSession';
@@ -47,6 +48,7 @@ export default function Experience({
   return (
     <>
       {isDebug && <Stats />}
+      <BootAssetPreloader />
       <KeyboardControls map={keyboardMap}>
         <LODProvider initialQuality="high" enableAdaptive targetFPS={60}>
           <BiomeProvider initialBiome="canyonSummer" enableTimeOfDay={false}>

--- a/src/components/BootAssetPreloader.tsx
+++ b/src/components/BootAssetPreloader.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useTexture } from '@react-three/drei';
+import { TRACK_ROCK_TEXTURE_PATHS } from '../constants/trackTextures';
+
+/**
+ * Warms the drei/THREE texture cache during the boot loader so the first START
+ * click does not re-trigger a full-screen asset overlay.
+ */
+export default function BootAssetPreloader() {
+  useEffect(() => {
+    useTexture.preload([...TRACK_ROCK_TEXTURE_PATHS]);
+  }, []);
+
+  return null;
+}

--- a/src/components/Loader.test.tsx
+++ b/src/components/Loader.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Loader } from './Loader';
+
+const defaultProps = {
+  gamePhase: 'menu' as const,
+  canvasReady: false,
+  worldEnabled: false,
+};
 
 // Mock useProgress to simulate loading state
 vi.mock('@react-three/drei', () => ({
@@ -8,19 +14,34 @@ vi.mock('@react-three/drei', () => ({
     active: true,
     progress: 50,
     item: 'test-asset.jpg',
+    errors: [],
   }),
 }));
 
-test('renders loader when active', () => {
-  const { getByText, getByRole } = render(<Loader />);
-  expect(getByText(/SYSTEM INITIALIZATION/i)).toBeInTheDocument();
-  expect(getByText(/LOADING ASSETS... 50%/i)).toBeInTheDocument();
-  expect(getByText(/PROCESSING: test-asset.jpg/i)).toBeInTheDocument();
+test('renders boot loader while canvas is initializing', () => {
+  render(<Loader {...defaultProps} />);
+  expect(screen.getByText(/STARTING UP/i)).toBeInTheDocument();
+  expect(screen.getByText(/Initializing graphics engine/i)).toBeInTheDocument();
+});
 
-  const progressbar = getByRole('progressbar');
-  expect(progressbar).toBeInTheDocument();
+test('renders asset progress while booting', () => {
+  render(<Loader {...defaultProps} canvasReady />);
+  expect(screen.getByText(/SYSTEM INITIALIZATION/i)).toBeInTheDocument();
+  expect(screen.getByText(/Loading assets… 50%/i)).toBeInTheDocument();
+  expect(screen.getByText(/PROCESSING: test-asset.jpg/i)).toBeInTheDocument();
+
+  const progressbar = screen.getByRole('progressbar');
   expect(progressbar).toHaveAttribute('aria-valuenow', '50');
-  expect(progressbar).toHaveAttribute('aria-valuemin', '0');
-  expect(progressbar).toHaveAttribute('aria-valuemax', '100');
-  expect(progressbar).toHaveAttribute('aria-label', 'Asset loading progress');
+});
+
+test('renders world loader when entering play mode', () => {
+  render(
+    <Loader
+      gamePhase="playing"
+      canvasReady
+      worldEnabled
+    />,
+  );
+  expect(screen.getByText(/ENTERING CANYON/i)).toBeInTheDocument();
+  expect(screen.getByText(/Loading world… 50%/i)).toBeInTheDocument();
 });

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,44 +1,99 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useProgress } from '@react-three/drei';
 
-export const Loader = () => {
-  const { progress, active, item, total } = useProgress();
-  const [finished, setFinished] = useState(false);
+export type GamePhase = 'menu' | 'playing' | 'paused';
+
+export interface LoaderProps {
+  gamePhase: GamePhase;
+  canvasReady: boolean;
+  worldEnabled: boolean;
+}
+
+const STUCK_TIMEOUT_MS = 20_000;
+const READY_FLASH_MS = 900;
+
+export const Loader = ({ gamePhase, canvasReady, worldEnabled }: LoaderProps) => {
+  const { progress, active, item, errors } = useProgress();
+  const [stuck, setStuck] = useState(false);
+  const [readyFlash, setReadyFlash] = useState(false);
+  const [bootDismissed, setBootDismissed] = useState(false);
+
+  const bootReady = canvasReady && !active;
+  const loadingWorld = worldEnabled && active && gamePhase !== 'menu';
+  const booting = gamePhase === 'menu' && !bootReady && !bootDismissed;
+  const visible = booting || loadingWorld || readyFlash;
 
   useEffect(() => {
     if (!active) {
-      const timer = setTimeout(() => setFinished(true), 200);
-      return () => clearTimeout(timer);
+      setStuck(false);
+      return;
     }
-
-    setFinished(false);
+    const timer = window.setTimeout(() => setStuck(true), STUCK_TIMEOUT_MS);
+    return () => window.clearTimeout(timer);
   }, [active]);
 
-  if (finished) return null;
+  useEffect(() => {
+    if (!bootReady || gamePhase !== 'menu' || bootDismissed || readyFlash) return;
+    setReadyFlash(true);
+    const timer = window.setTimeout(() => {
+      setReadyFlash(false);
+      setBootDismissed(true);
+    }, READY_FLASH_MS);
+    return () => window.clearTimeout(timer);
+  }, [bootDismissed, bootReady, gamePhase, readyFlash]);
 
-  // Fade out if finished loading
-  // Match the logic above: if !active, start fading
-  const isFading = !active;
+  useEffect(() => {
+    if (gamePhase === 'menu') return;
+    setBootDismissed(false);
+  }, [gamePhase]);
 
-  // Show 0% until progress reports; avoid a stuck "1%" idle flash
+  if (!visible) return null;
+
   const displayProgress = Math.round(progress);
+  const isFading = readyFlash || (!active && !booting && !loadingWorld);
+
+  let header = 'SYSTEM INITIALIZATION';
+  let message = `Loading assets… ${displayProgress}%`;
+
+  if (readyFlash) {
+    header = 'READY TO PLAY';
+    message = 'Choose your map and press START RUN';
+  } else if (!canvasReady) {
+    header = 'STARTING UP';
+    message = 'Initializing graphics engine…';
+  } else if (loadingWorld) {
+    header = 'ENTERING CANYON';
+    message = `Loading world… ${displayProgress}%`;
+  } else if (stuck) {
+    header = 'STILL LOADING';
+    message = `This is taking longer than expected (${displayProgress}%)`;
+  }
 
   return (
-    <div className={`loader-overlay ${isFading ? 'fade-out' : ''}`}>
+    <div className={`loader-overlay ${isFading ? 'fade-out' : ''}`} data-testid="boot-loader">
       <div className="loader-content">
-        <div className="loader-header">SYSTEM INITIALIZATION</div>
-        <div className="loader-text" aria-live="polite">LOADING ASSETS... {displayProgress}%</div>
-        <div
-          className="loader-bar"
-          role="progressbar"
-          aria-label="Asset loading progress"
-          aria-valuenow={displayProgress}
-          aria-valuemin={0}
-          aria-valuemax={100}
-        >
-          <div className="loader-bar-fill" style={{ width: `${displayProgress}%` }} />
+        <div className="loader-header">{header}</div>
+        <div className="loader-text" aria-live="polite">
+          {message}
         </div>
-        {item && <div className="loader-item">PROCESSING: {item}</div>}
+        {!readyFlash && (
+          <div
+            className="loader-bar"
+            role="progressbar"
+            aria-label="Asset loading progress"
+            aria-valuenow={displayProgress}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <div className="loader-bar-fill" style={{ width: `${displayProgress}%` }} />
+          </div>
+        )}
+        {item && !readyFlash && <div className="loader-item">PROCESSING: {item}</div>}
+        {stuck && errors.length > 0 && (
+          <div className="loader-item loader-item--warning">
+            Some assets failed to load. You can still try starting the run.
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/StartMenu.tsx
+++ b/src/components/StartMenu.tsx
@@ -41,6 +41,8 @@ interface StartMenuProps {
   onSelectMap: (mapId: MapRegistryId) => void;
   /** Open the full Options panel (audio, controls/rebinding, graphics). */
   onOpenOptions: () => void;
+  /** False while the boot loader is still warming WebGL / preloading assets. */
+  bootReady?: boolean;
 }
 
 const DIFFICULTY_LABELS: Record<MapMenuEntry['difficulty'], string> = {
@@ -65,6 +67,7 @@ export const StartMenu: React.FC<StartMenuProps> = ({
   selectedMapId,
   onSelectMap,
   onOpenOptions,
+  bootReady = true,
 }) => {
   const completedMaps = useMemo(() => getCompletedMaps(), []);
   const lastMapId = useMemo(() => getLastMapId(), []);
@@ -118,6 +121,16 @@ export const StartMenu: React.FC<StartMenuProps> = ({
           <p className="start-menu-tagline">
             From alpine source to valley delta — shed the water.
           </p>
+          {!bootReady && (
+            <p className="start-menu-boot-status" role="status" aria-live="polite">
+              Preparing game assets…
+            </p>
+          )}
+          {bootReady && (
+            <p className="start-menu-boot-status start-menu-boot-status--ready" role="status">
+              Ready — press START RUN or Enter
+            </p>
+          )}
         </div>
 
         {(
@@ -229,11 +242,16 @@ export const StartMenu: React.FC<StartMenuProps> = ({
             <button
               className="start-menu-start-btn"
               onClick={() => onStart(effectiveMapId, startOptions)}
-              aria-label="Start Game - Click or Press Enter"
+              aria-label={bootReady ? 'Start Game - Click or Press Enter' : 'Preparing game assets'}
               autoFocus
+              disabled={!bootReady}
             >
-              {playMode === 'journey' ? 'START JOURNEY' : 'START RUN'}
-              <span className="start-menu-keyhint">ENTER</span>
+              {bootReady
+                ? playMode === 'journey'
+                  ? 'START JOURNEY'
+                  : 'START RUN'
+                : 'PREPARING…'}
+              {bootReady && <span className="start-menu-keyhint">ENTER</span>}
             </button>
 
             <button

--- a/src/components/TrackManager.tsx
+++ b/src/components/TrackManager.tsx
@@ -9,6 +9,7 @@ import React, {
 import * as THREE from 'three';
 import { useFrame, useThree } from '@react-three/fiber';
 import { useTexture } from '@react-three/drei';
+import { TRACK_ROCK_TEXTURE_PATHS } from '../constants/trackTextures';
 import TrackSegment from './TrackSegment';
 import WaterFlowForces from './WaterFlowForces';
 import VehicleTuner from './VehicleTuner';
@@ -234,11 +235,7 @@ const TrackManager = forwardRef<TrackManagerRef, TrackManagerProps>(function Tra
 
   // PBR texture loading
   const [colorMap, normalMap, roughnessMap, aoMap, displacementMap] = useTexture([
-    './Rock031_1K-JPG_Color.jpg',
-    './Rock031_1K-JPG_NormalGL.jpg',
-    './Rock031_1K-JPG_Roughness.jpg',
-    './Rock031_1K-JPG_AmbientOcclusion.jpg',
-    './Rock031_1K-JPG_Displacement.jpg',
+    ...TRACK_ROCK_TEXTURE_PATHS,
   ]);
 
   // Fallback texture generator

--- a/src/constants/trackTextures.ts
+++ b/src/constants/trackTextures.ts
@@ -1,0 +1,8 @@
+/** Canonical PBR texture paths for canyon rock walls (shared by boot preload + TrackManager). */
+export const TRACK_ROCK_TEXTURE_PATHS = [
+  './Rock031_1K-JPG_Color.jpg',
+  './Rock031_1K-JPG_NormalGL.jpg',
+  './Rock031_1K-JPG_Roughness.jpg',
+  './Rock031_1K-JPG_AmbientOcclusion.jpg',
+  './Rock031_1K-JPG_Displacement.jpg',
+] as const;

--- a/src/styles/loader.css
+++ b/src/styles/loader.css
@@ -60,3 +60,13 @@
   font-size: 14px;
   opacity: 0.7;
 }
+
+.loader-item--warning {
+  margin-top: 12px;
+  color: #fbbf24;
+  opacity: 0.95;
+}
+
+.loader-overlay.ready-state .loader-text {
+  color: #4fd1c7;
+}

--- a/src/styles/start-menu.css
+++ b/src/styles/start-menu.css
@@ -351,6 +351,28 @@
   letter-spacing: 0.05em;
 }
 
+.start-menu-boot-status {
+  margin: 12px 0 0;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 200, 120, 0.85);
+}
+
+.start-menu-boot-status--ready {
+  color: rgba(79, 209, 199, 0.95);
+}
+
+.start-menu-start-btn:disabled {
+  opacity: 0.55;
+  cursor: wait;
+  filter: grayscale(0.2);
+}
+
+.start-menu-start-btn:disabled .start-menu-keyhint {
+  display: none;
+}
+
 .start-menu-buttons {
   display: flex;
   flex-direction: column;

--- a/src/systems/AudioSystem.ts
+++ b/src/systems/AudioSystem.ts
@@ -108,6 +108,8 @@ const FALLBACK_URLS: Record<string, string> = {};
 export class AudioManager {
   private listener: THREE.AudioListener;
   private loader: THREE.AudioLoader;
+  /** Isolated from THREE.DefaultLoadingManager so boot SFX preload does not block the UI loader. */
+  private readonly audioLoadingManager = new THREE.LoadingManager();
   private audioContext: AudioContext | null = null;
   private sounds: Map<string, AudioBuffer> = new Map();
   private activeSounds: Map<string, ActiveSound[]> = new Map();
@@ -148,8 +150,8 @@ export class AudioManager {
     this.listener = new THREE.AudioListener();
     camera.add(this.listener);
     
-    // Create audio loader
-    this.loader = new THREE.AudioLoader();
+    // Create audio loader (private manager — avoid polluting drei's useProgress overlay)
+    this.loader = new THREE.AudioLoader(this.audioLoadingManager);
     
     // Cache the underlying Web Audio context for introspection
     this.audioContext = this.listener.context as AudioContext;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The boot overlay showed only "LOADING ASSETS…" with no clear signal when the game was ready to start. The loader also sat above the start menu (z-index 10000 vs 200), so if asset loading stayed active the menu was unreachable.

Audio preloads via `THREE.AudioLoader` were hooked into `DefaultLoadingManager`, which could keep the global loader active during menu boot even when graphics were ready.

## Solution

- **Phased boot loader** with distinct messages:
  - `STARTING UP` — waiting for WebGL canvas
  - `SYSTEM INITIALIZATION` — boot asset preload progress
  - `READY TO PLAY` — brief flash before dismissing
  - `ENTERING CANYON` — world load after pressing START (if any assets remain)
  - `STILL LOADING` — 20s timeout with warning text
- **Start menu readiness**
  - START RUN disabled until `canvasReady && !assetsLoading`
  - Status line: "Preparing game assets…" / "Ready — press START RUN or Enter"
  - Enter key blocked until boot is ready
- **Boot texture preload** via `BootAssetPreloader` so canyon PBR textures warm during boot instead of on first START click
- **Audio isolation** — `AudioLoader` uses a private `LoadingManager` so SFX preload no longer blocks the UI loader

## Testing

- `pnpm test` — 533 passed
- `pnpm typecheck` — clean
- Loader unit tests updated for new phases
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9906cd05-57b5-4a8d-8f6f-496ba5279abf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9906cd05-57b5-4a8d-8f6f-496ba5279abf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a coordinated startup loading experience for the game.
  * The start button and Enter shortcut remain disabled until the canvas and required assets are ready.
  * Added clearer loading, ready, progress, and asset-error status messages.
  * Preloads track visuals before gameplay begins.

* **Bug Fixes**
  * Improved loading behavior when entering gameplay, including handling delayed or stuck loading states.
  * Isolated audio loading so it does not interfere with other loading indicators.

* **Style**
  * Added visual states for waiting, ready, and loading warnings in the start menu and loader.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->