### PR TITLE
Productize WASM water physics: default-on worker, quality-gated SWE, split C++

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ src/
 │   ├── ReachManager.tsx         # Reach streaming wrapper
 │   ├── BiomeSystem.tsx / LODManager.tsx / GameState.ts
 │   ├── SplashSystem.tsx / AudioSystem.ts / WatershedWasm.ts
+│   ├── sweQuality.ts            # SWE grid/step/displacement budget per quality preset
 │   └── …
 │
 ├── maps/                        # Authored map JSON + registry.ts

--- a/SYSTEMS.md
+++ b/SYSTEMS.md
@@ -448,9 +448,12 @@ resolution; unmounted for `low` / `medium` (no extra scene render).
 ### `src/physics/rapier.worker.ts` + `RapierWorkerProxy`
 
 **Purpose:** Co-locate Rapier rigid-body stepping with C++ `watershed_native` batch water
-forces in a single worker tick. Enabled via `?physicsWorker=1` (legacy alias:
-`?raftWorker=1`). Default off — main-thread `@react-three/rapier` remains the stable path
-for visual-smoke and CI.
+forces in a single worker tick. **Default on** wherever the browser exposes `Worker` +
+`WebAssembly`. Kill switches, in precedence order: `?physicsWorker=0` (legacy alias
+`?raftWorker=0`) > capability detection > `?physicsWorker=1` > Settings → Physics >
+default on. The decision is made once per vehicle mount by `resolvePhysicsWorker`
+(`src/utils/physicsWorkerFlag.ts`); switching mid-session would strand the Rapier body
+between two authorities.
 
 **Tick order (worker path, per `docs/reference/ADR_WASM_RAPIER_WATER_FORCES.md`):**
 
@@ -471,20 +474,48 @@ for visual-smoke and CI.
 into the worker when the flag is on).
 
 **Fallback:** Missing `watershed_native.wasm` → worker uses `calculateWaterForceFallback`
-inside the same tick (no extra frame of lag). Flag off → existing main-thread
-`WaterForceSystem` + Rapier path.
+inside the same tick (no extra frame of lag); parity with the C++ path is pinned by
+`src/physics/__tests__/waterForceParity.test.ts`. Worker init failure or an explicit off →
+existing main-thread `WaterForceSystem` + Rapier path.
 
 **Phase 2 protocol (collider registration):** `ADD_STATIC_COLLIDER`, `REMOVE_STATIC_COLLIDER`,
 `CLEAR_STATIC_COLLIDERS` — segment treadmill meshes can be streamed without a second worker.
 
-**Debug:** `window.__watershedPhysicsWorker` (dev) exposes `waterForce` diagnostics and tick
-order when the worker path is active.
+**Debug:** DebugPanel (`?debug=1`) has a *Physics worker* section: worker state + the reason
+it resolved that way, active force path (`wasm` / `fallback`), last force-batch cost in µs,
+and the live SWE grid. `window.__watershedPhysicsWorker` (dev) still exposes raw `waterForce`
+diagnostics and tick order.
+
+### SWE quality budgets — `src/systems/sweQuality.ts`
+
+The SWE height field is a visual system and is budgeted by the live quality preset
+(`useQualityPreset`, which LODManager may downgrade adaptively):
+
+| Preset | Grid | Cell | Step rate | Displacement |
+|--------|------|------|-----------|--------------|
+| low | — | — | off | 0 |
+| medium | 32×24 | 0.75 m | 30 Hz | 0.14 |
+| high | 48×32 | 0.5 m | 60 Hz | 0.22 |
+| ultra | 64×40 | 0.5 m | 60 Hz | 0.26 |
+
+`WaterForceSystem` reallocates the grid + upload texture when the budget changes, steps at
+most `stepHz` times per second, and publishes `displacementScale` through the height-field
+snapshot to `FlowingWater`. `injectSWEDisturbance` no-ops while the budget is disabled, and
+the pending queue is capped, so splashes can't accumulate work nobody drains.
+
+**Constraint:** do NOT quality-gate the force math. Buoyancy / drag / flow are
+gameplay-affecting and must run identically at every preset.
 
 ---
 
 ## WASM Module
 
 ### `src/systems/WatershedWasm.ts` + `emscripten/`
+
+**Layout:** `emscripten/watershed_native.h` (shared declarations) + `forces.cpp` (water force
+math) + `swe.cpp` (solver + heap grids) + `bindings.cpp` (Embind surface, `getVersion()` — 3).
+All compile/link flags live in `CMakeLists.txt`; `build.sh` and the `SOURCES` list are the only
+places a new translation unit must be registered.
 
 **Purpose:** Optional C++/WASM acceleration layer for computationally intensive physics:
 Archimedes buoyancy, drag force, river-current flow force, and a linearised

--- a/WASM.md
+++ b/WASM.md
@@ -28,9 +28,12 @@ TypeScript bindings are in `src/systems/WatershedWasm.ts`.
 
 ```
 emscripten/
-├── main.cpp          # C++ source — all exported functions
-├── build.sh          # Bash build script (wraps em++)
-└── CMakeLists.txt    # CMake build configuration (alternative to build.sh)
+├── watershed_native.h # Shared declarations, constants, value types
+├── forces.cpp        # Buoyancy / drag / flow / batched water forces
+├── swe.cpp           # Shallow-water solver + heap grid helpers
+├── bindings.cpp      # getVersion() + the Embind surface (the ABI)
+├── build.sh          # Bash build script (wraps CMake)
+└── CMakeLists.txt    # CMake build configuration — ALL compile/link flags live here
 
 src/systems/
 └── WatershedWasm.ts  # TypeScript bindings + SWEGrid helper
@@ -100,7 +103,20 @@ and callable after `await getWasm()`.
 
 ### `getVersion(): number`
 
-Returns the module version integer. Bump when the API changes.
+Returns the module ABI version integer. Bump in `bindings.cpp` whenever the
+exported surface or a batch stride changes.
+
+| Version | Change |
+|---------|--------|
+| 1 | Initial buoyancy / drag / flow surface |
+| 2 | Batched `computeWaterForcesBatch` + SWE grid helpers |
+| 3 | Split into `forces.cpp` / `swe.cpp` / `bindings.cpp` (no signature changes) |
+
+### Adding a translation unit
+
+Add the `.cpp` to `set(SOURCES …)` in `CMakeLists.txt` **and** to the `em++`
+invocation in `build_colab.sh`, declare its exports in `watershed_native.h`, and
+bind them in `bindings.cpp`. Never put compile or link flags in a shell script.
 
 ### `computeBuoyancy(submergedVolume, waterDensity, gravity): number`
 
@@ -213,9 +229,23 @@ const grid = createSWEGrid(wasm, 32, 32, 0.5);
 grid.dispose();
 ```
 
-Pure-TypeScript fallbacks (`buoyancyFallback`, `dragForceFallback`) are also
-exported and match the C++ implementations exactly — useful in unit tests where
-the WASM module is unavailable.
+Pure-TypeScript fallbacks (`buoyancyFallback`, `dragForceFallback`,
+`calculateWaterForceFallback`) are also exported and match the C++
+implementations — they are what runs when `watershed_native.wasm` fails to load,
+so the two must stay in lockstep.
+
+### Parity + integration tests
+
+```bash
+pnpm test                 # includes the TS-side fixture pins (no WASM needed)
+pnpm test:wasm            # WATERSHED_WASM_INTEGRATION=1 — loads the built module
+pnpm test:wasm:parity     # native vs TypeScript force math, per fixture
+```
+
+`pnpm test:wasm` and `pnpm test:wasm:parity` require `pnpm build:wasm` to have
+produced `public/watershed_native.{js,wasm}` first; without the env var the
+native blocks are skipped so CI stays green on a machine with no Emscripten.
+Fixtures live in `src/physics/__tests__/waterForceFixtures.ts`.
 
 ---
 

--- a/docs/reference/ADR_WASM_RAPIER_WATER_FORCES.md
+++ b/docs/reference/ADR_WASM_RAPIER_WATER_FORCES.md
@@ -1,6 +1,6 @@
 # ADR: Rapier and C++ WASM Water-Force Coupling
 
-Status: accepted for v1
+Status: accepted for v1; worker path default-on since the productization pass
 
 ## Context
 
@@ -172,14 +172,49 @@ The POC is intentionally isolated behind a URL flag and does not replace the nor
 
 ### Production worker rollout
 
-Run raft mode with co-located Rapier + C++ water forces:
+The co-located Rapier + C++ water-force worker is the **default** path. It runs on any
+browser that exposes `Worker` and `WebAssembly`; no query parameter is needed.
 
-```txt
-?physicsWorker=1&vehicle=raft
-```
+Resolution order (`src/utils/physicsWorkerFlag.ts`, `resolvePhysicsWorker`):
 
-(`?raftWorker=1` remains a legacy alias.) Default path is unchanged when the flag is absent.
-Worker diagnostics are exposed at `window.__watershedPhysicsWorker` in development builds.
+| Precedence | Input | Result |
+|-----------|-------|--------|
+| 1 | `?physicsWorker=0` (or legacy `?raftWorker=0`) | off — kill switch, wins over everything |
+| 2 | no `Worker` / no `WebAssembly` | off — `no-worker` / `no-wasm` |
+| 3 | `?physicsWorker=1` (or `?raftWorker=1`) | on — overrides the stored setting |
+| 4 | Settings → Physics → Physics worker (`auto`/`on`/`off`) | per preference |
+| 5 | nothing set | on — `default-on` |
+
+Two independent fallbacks sit under that decision, so no single failure strands the raft:
+
+1. **Worker init fails** → `RaftVehicle` disposes the proxy and keeps the main-thread
+   Rapier body authoritative.
+2. **`watershed_native.wasm` fails to load inside the worker** → `getWorkerWasm()` returns
+   null and the worker runs the TypeScript force math (`calculateWaterForceFallback`).
+   Parity between the two is pinned by `src/physics/__tests__/waterForceParity.test.ts`.
+
+No `SharedArrayBuffer` / COOP+COEP requirement is introduced for the default path — the
+single-threaded build stays the shipping artefact.
+
+Diagnostics: the DebugPanel (`?debug=1`) shows worker state and why, the active force path
+(`wasm` / `fallback`), the last force-batch cost in µs, and the active SWE grid. Development
+builds also expose `window.__watershedPhysicsWorker`.
+
+### SWE quality budgets
+
+The shallow-water height field is a *visual* system and is budgeted per quality preset in
+`src/systems/sweQuality.ts`:
+
+| Preset | Grid | Cell | Step rate | Displacement |
+|--------|------|------|-----------|--------------|
+| low | — | — | off | 0 |
+| medium | 32×24 | 0.75 m | 30 Hz | 0.14 |
+| high | 48×32 | 0.5 m | 60 Hz | 0.22 |
+| ultra | 64×40 | 0.5 m | 60 Hz | 0.26 |
+
+`injectSWEDisturbance` is gated by the same budget, so splash events don't queue work that
+nobody drains on `low`. Force math is **not** quality-gated — buoyancy, drag, and flow are
+gameplay-affecting and run at every preset.
 
 ## Biome Math V1
 
@@ -195,6 +230,20 @@ Glacial melt:
 - `flowSpeed`: 1.5 to 3.0 m/s
 - `turbulenceStrength`: 0.02 to 0.06
 - Lower base momentum, later augmented with sharper lateral fields around ice and rocks.
+
+## C++ Module Layout
+
+The native module is split by concern so hull sampling and multi-grid work don't land in
+one growing translation unit:
+
+| File | Owns |
+|------|------|
+| `emscripten/watershed_native.h` | Shared constants, `Vec3` / `WaterForceResult`, declarations |
+| `emscripten/forces.cpp` | Buoyancy, drag, flow, `calculateWaterForce`, `computeWaterForcesBatch` |
+| `emscripten/swe.cpp` | `stepShallowWater`, `allocateGrid` / `freeGrid` |
+| `emscripten/bindings.cpp` | `getVersion()` and the Embind surface — the ABI |
+
+`getVersion()` is 3 as of the split. All compile/link flags stay in `CMakeLists.txt`.
 
 ## Consequences
 

--- a/docs/reference/WASM_WATER_FORCES.md
+++ b/docs/reference/WASM_WATER_FORCES.md
@@ -2,7 +2,9 @@
 
 Architecture decision: see [ADR_WASM_RAPIER_WATER_FORCES.md](./ADR_WASM_RAPIER_WATER_FORCES.md).
 
-Watershed's first native module lives in `emscripten/main.cpp` and builds to:
+Watershed's native module lives in `emscripten/` — `forces.cpp` (water force math),
+`swe.cpp` (shallow-water solver + heap grids), `bindings.cpp` (the Embind ABI), with
+shared declarations in `watershed_native.h`. It builds to:
 
 - `public/watershed_native.js`
 - `public/watershed_native.wasm`

--- a/emscripten/CMakeLists.txt
+++ b/emscripten/CMakeLists.txt
@@ -4,7 +4,12 @@ project(WatershedNative CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(SOURCES main.cpp)
+# Translation units — keep this list in sync with WASM.md's directory layout.
+set(SOURCES
+    forces.cpp
+    swe.cpp
+    bindings.cpp
+)
 add_executable(watershed_native ${SOURCES})
 
 if(EMSCRIPTEN)

--- a/emscripten/bindings.cpp
+++ b/emscripten/bindings.cpp
@@ -1,0 +1,58 @@
+/**
+ * bindings.cpp — Embind surface for the Watershed WASM module.
+ *
+ * This is the ABI: anything reachable from TypeScript is listed here, and
+ * src/systems/WatershedWasm.ts declares the matching types. Adding, removing, or
+ * changing a signature (or a batch stride) means bumping getVersion() below and
+ * updating WASM.md.
+ *
+ * Build:
+ *   cd emscripten && ./build.sh
+ *   (or) npm run build:wasm
+ *
+ * Output (placed in public/ so Vite serves them):
+ *   public/watershed_native.js   — Emscripten glue + Embind
+ *   public/watershed_native.wasm — WASM binary
+ */
+
+#include "watershed_native.h"
+
+#include <emscripten/bind.h>
+
+// ---------------------------------------------------------------------------
+// Version history
+//   1 — initial buoyancy/drag/flow surface
+//   2 — batched computeWaterForcesBatch + SWE grid helpers
+//   3 — split into forces.cpp / swe.cpp / bindings.cpp (no signature changes)
+// ---------------------------------------------------------------------------
+int getVersion() noexcept {
+    return 3;
+}
+
+EMSCRIPTEN_BINDINGS(watershed_native) {
+    emscripten::function("getVersion",       &getVersion);
+    emscripten::function("calculateBuoyancyAndDrag", &calculateBuoyancyAndDrag);
+    emscripten::function("calculateWaterForce", &calculateWaterForce);
+    emscripten::function("computeWaterForcesBatch", &computeWaterForcesBatch);
+    emscripten::function("computeBuoyancy",  &computeBuoyancy);
+    emscripten::function("computeDragForce", &computeDragForce);
+    emscripten::function("computeFlowForce", &computeFlowForce);
+    emscripten::function("stepShallowWater", &stepShallowWater);
+    emscripten::function("allocateGrid",     &allocateGrid);
+    emscripten::function("freeGrid",         &freeGrid);
+
+    emscripten::value_object<Vec3>("Vec3")
+        .field("x", &Vec3::x)
+        .field("y", &Vec3::y)
+        .field("z", &Vec3::z);
+
+    emscripten::value_object<WaterForceResult>("WaterForceResult")
+        .field("forceX", &WaterForceResult::forceX)
+        .field("forceY", &WaterForceResult::forceY)
+        .field("forceZ", &WaterForceResult::forceZ)
+        .field("buoyancy", &WaterForceResult::buoyancy)
+        .field("drag", &WaterForceResult::drag)
+        .field("flow", &WaterForceResult::flow)
+        .field("turbulence", &WaterForceResult::turbulence)
+        .field("submergedRatio", &WaterForceResult::submergedRatio);
+}

--- a/emscripten/build_colab.sh
+++ b/emscripten/build_colab.sh
@@ -132,7 +132,9 @@ rm -f "$OUTPUT_JS" \
 # ---------------------------------------------------------------------------
 echo "Compiling & Linking..."
 # shellcheck disable=SC2086  # word-splitting on FLAGS is intentional
-em++ "$SCRIPT_DIR/main.cpp" \
+em++ "$SCRIPT_DIR/forces.cpp" \
+    "$SCRIPT_DIR/swe.cpp" \
+    "$SCRIPT_DIR/bindings.cpp" \
     -o "$OUTPUT_JS" \
     $COMPILE_FLAGS \
     $LINK_FLAGS

--- a/emscripten/forces.cpp
+++ b/emscripten/forces.cpp
@@ -1,76 +1,17 @@
 /**
- * emscripten/main.cpp — Watershed C++ WebAssembly Module
+ * forces.cpp — water-force math (buoyancy, drag, flow, turbulence).
  *
- * Implements performance-critical water simulation and physics calculations
- * for the Watershed game using Emscripten + Embind.
- *
- * Exposed functions (via Embind):
- *   getVersion()
- *   calculateBuoyancyAndDrag(...)
- *   calculateWaterForce(...)
- *   computeWaterForcesBatch(...)
- *   computeBuoyancy(submergedVolume, waterDensity, gravity)
- *   computeDragForce(vx, vy, vz, cd, area, density)
- *   computeFlowForce(vx,vy,vz, fx,fy,fz, flowSpeed, mass, submergedRatio, cd, area) → Vec3
- *   stepShallowWater(hPtr, uPtr, wPtr, width, height, dt, g, dx, H)
- *   allocateGrid(count) → ptr
- *   freeGrid(ptr)
- *
- * Build:
- *   cd emscripten && ./build.sh
- *   (or) npm run build:wasm
- *
- * Output (placed in public/ so Vite serves them):
- *   public/watershed_native.js   — Emscripten glue + Embind
- *   public/watershed_native.wasm — WASM binary
+ * Every function here is mirrored by a pure-TypeScript fallback in
+ * src/systems/WatershedWasm.ts (`*Fallback`), and the two are held to an
+ * epsilon by the parity tests in src/physics/__tests__/waterForceParity.test.ts.
+ * Change one, change the other.
  */
 
-#include <emscripten/bind.h>
+#include "watershed_native.h"
+
 #include <emscripten/emscripten.h>
 #include <cmath>
-#include <cstdint>
-#include <cstdlib>
 #include <algorithm>
-
-// ---------------------------------------------------------------------------
-// Compile-time constants
-// ---------------------------------------------------------------------------
-static constexpr float WATER_DENSITY_DEFAULT = 1000.0f;  // kg/m³  (fresh water)
-static constexpr float GRAVITY_DEFAULT       = 9.80665f; // m/s² (standard gravity)
-static constexpr float DAMPING_COEFF        = 0.1f;      // velocity damping per second
-
-// ---------------------------------------------------------------------------
-// Utility
-// ---------------------------------------------------------------------------
-static inline float clampf(float v, float lo, float hi) noexcept {
-    return v < lo ? lo : (v > hi ? hi : v);
-}
-
-// ---------------------------------------------------------------------------
-// 3-component float vector (returned by computeFlowForce via Embind)
-// ---------------------------------------------------------------------------
-struct Vec3 {
-    float x = 0.f, y = 0.f, z = 0.f;
-};
-
-struct WaterForceResult {
-    float forceX = 0.f;
-    float forceY = 0.f;
-    float forceZ = 0.f;
-    float buoyancy = 0.f;
-    float drag = 0.f;
-    float flow = 0.f;
-    float turbulence = 0.f;
-    float submergedRatio = 0.f;
-};
-
-// ---------------------------------------------------------------------------
-// Version / sanity check
-// ---------------------------------------------------------------------------
-/** Returns the module version integer (bump when ABI changes). */
-int getVersion() noexcept {
-    return 2;
-}
 
 // ---------------------------------------------------------------------------
 // 1. Buoyancy  —  Archimedes' principle
@@ -239,11 +180,7 @@ WaterForceResult calculateWaterForce(float posX, float posY, float posZ,
     return result;
 }
 
-// Batch ABI for workers:
-// input stride = 8 floats per raft/sample:
-//   [posX, posY, posZ, velX, velY, velZ, flowDirX, flowDirZ]
-// output stride = 8 floats per raft/sample:
-//   [forceX, forceY, forceZ, buoyancy, drag, flow, turbulence, submergedRatio]
+// Batch ABI for workers — strides documented in watershed_native.h.
 void computeWaterForcesBatch(uintptr_t inputPtr,
                              uintptr_t outputPtr,
                              int sampleCount,
@@ -261,11 +198,9 @@ void computeWaterForcesBatch(uintptr_t inputPtr,
 
     const float* input = reinterpret_cast<const float*>(inputPtr);
     float* output = reinterpret_cast<float*>(outputPtr);
-    constexpr int IN_STRIDE = 8;
-    constexpr int OUT_STRIDE = 8;
 
     for (int i = 0; i < sampleCount; ++i) {
-        const float* s = input + i * IN_STRIDE;
+        const float* s = input + i * WATER_FORCE_INPUT_STRIDE;
         const WaterForceResult r = calculateWaterForce(
             s[0], s[1], s[2],
             s[3], s[4], s[5],
@@ -282,7 +217,7 @@ void computeWaterForcesBatch(uintptr_t inputPtr,
             turbulenceFrequency
         );
 
-        float* o = output + i * OUT_STRIDE;
+        float* o = output + i * WATER_FORCE_OUTPUT_STRIDE;
         o[0] = r.forceX;
         o[1] = r.forceY;
         o[2] = r.forceZ;
@@ -292,129 +227,4 @@ void computeWaterForcesBatch(uintptr_t inputPtr,
         o[6] = r.turbulence;
         o[7] = r.submergedRatio;
     }
-}
-
-// ---------------------------------------------------------------------------
-// 4. Shallow Water Equations (SWE) — linearised, one time step
-//
-//    Solves on a staggered Cartesian grid using forward differences:
-//      ∂h/∂t = −H · (∂u/∂x + ∂w/∂z)
-//      ∂u/∂t = −g · ∂h/∂x
-//      ∂w/∂t = −g · ∂h/∂z
-//
-//    Grid layout: row-major, index = z * width + x
-//      h[i]  — water height perturbation (m)
-//      u[i]  — X-velocity component (m/s)
-//      w[i]  — Z-velocity component (m/s)
-//
-//    All three arrays live in WASM linear memory; JS passes byte-offset
-//    pointers obtained from allocateGrid().
-//
-//    @param hPtr   Heap pointer (byte offset) for height field
-//    @param uPtr   Heap pointer (byte offset) for X-velocity field
-//    @param wPtr   Heap pointer (byte offset) for Z-velocity field
-//    @param width  Grid columns
-//    @param height Grid rows
-//    @param dt     Time step (s)  — internally clamped to CFL limit
-//    @param g      Gravity (m/s²)
-//    @param dx     Cell size (m)
-//    @param H      Mean resting water depth (m) for linearisation
-// ---------------------------------------------------------------------------
-void stepShallowWater(uintptr_t hPtr, uintptr_t uPtr, uintptr_t wPtr,
-                      int width, int height,
-                      float dt, float g, float dx, float H) {
-    if (width <= 0 || height <= 0 || dx <= 0.f || H <= 0.f) return;
-
-    float* h = reinterpret_cast<float*>(hPtr);
-    float* u = reinterpret_cast<float*>(uPtr);
-    float* w = reinterpret_cast<float*>(wPtr);
-
-    // Enforce CFL stability: dt ≤ dx / (c · √2),  c = √(g·H)
-    const float waveSpeed = std::sqrt(g * H);
-    const float cflMax    = dx / (waveSpeed * 1.5f);
-    const float safeDt    = std::min(dt, cflMax);
-
-    // --- Step 1: update velocities from pressure gradients ---
-    for (int z = 0; z < height; ++z) {
-        for (int x = 0; x < width; ++x) {
-            const int idx = z * width + x;
-
-            const float dhdx = (x < width  - 1) ? (h[idx + 1]     - h[idx]) / dx : 0.f;
-            const float dhdz = (z < height - 1) ? (h[idx + width] - h[idx]) / dx : 0.f;
-
-            u[idx] -= g * safeDt * dhdx;
-            w[idx] -= g * safeDt * dhdz;
-        }
-    }
-
-    // --- Step 2: update heights from velocity divergence ---
-    for (int z = 0; z < height; ++z) {
-        for (int x = 0; x < width; ++x) {
-            const int idx = z * width + x;
-
-            const float dudx = (x > 0) ? (u[idx] - u[idx - 1])     / dx : 0.f;
-            const float dwdz = (z > 0) ? (w[idx] - w[idx - width])  / dx : 0.f;
-
-            h[idx] -= H * safeDt * (dudx + dwdz);
-        }
-    }
-
-    // --- Step 3: light velocity damping to prevent divergence ---
-    const float damp = 1.f - safeDt * DAMPING_COEFF;
-    const int N = width * height;
-    for (int i = 0; i < N; ++i) {
-        u[i] *= damp;
-        w[i] *= damp;
-    }
-}
-
-// ---------------------------------------------------------------------------
-// 5. Grid memory helpers
-//    Allocate / free Float32 arrays in WASM heap, addressable from JS via
-//    Float32Array(module.HEAPF32.buffer, ptr, count).
-// ---------------------------------------------------------------------------
-
-/** Allocate `count` floats (zero-initialised) in WASM heap.
- *  Returns a byte-offset pointer suitable for use with HEAPF32.
- */
-uintptr_t allocateGrid(int count) {
-    if (count <= 0) return 0;
-    void* ptr = std::calloc(static_cast<std::size_t>(count), sizeof(float));
-    return reinterpret_cast<uintptr_t>(ptr);
-}
-
-/** Free a grid previously returned by allocateGrid. */
-void freeGrid(uintptr_t ptr) {
-    std::free(reinterpret_cast<void*>(ptr));
-}
-
-// ---------------------------------------------------------------------------
-// Embind bindings
-// ---------------------------------------------------------------------------
-EMSCRIPTEN_BINDINGS(watershed_native) {
-    emscripten::function("getVersion",       &getVersion);
-    emscripten::function("calculateBuoyancyAndDrag", &calculateBuoyancyAndDrag);
-    emscripten::function("calculateWaterForce", &calculateWaterForce);
-    emscripten::function("computeWaterForcesBatch", &computeWaterForcesBatch);
-    emscripten::function("computeBuoyancy",  &computeBuoyancy);
-    emscripten::function("computeDragForce", &computeDragForce);
-    emscripten::function("computeFlowForce", &computeFlowForce);
-    emscripten::function("stepShallowWater", &stepShallowWater);
-    emscripten::function("allocateGrid",     &allocateGrid);
-    emscripten::function("freeGrid",         &freeGrid);
-
-    emscripten::value_object<Vec3>("Vec3")
-        .field("x", &Vec3::x)
-        .field("y", &Vec3::y)
-        .field("z", &Vec3::z);
-
-    emscripten::value_object<WaterForceResult>("WaterForceResult")
-        .field("forceX", &WaterForceResult::forceX)
-        .field("forceY", &WaterForceResult::forceY)
-        .field("forceZ", &WaterForceResult::forceZ)
-        .field("buoyancy", &WaterForceResult::buoyancy)
-        .field("drag", &WaterForceResult::drag)
-        .field("flow", &WaterForceResult::flow)
-        .field("turbulence", &WaterForceResult::turbulence)
-        .field("submergedRatio", &WaterForceResult::submergedRatio);
 }

--- a/emscripten/swe.cpp
+++ b/emscripten/swe.cpp
@@ -1,0 +1,105 @@
+/**
+ * swe.cpp — linearised shallow-water solver + WASM heap grid helpers.
+ *
+ * The grid is a *visual* system: WaterForceSystem steps a player-centred field
+ * and uploads it as a DataTexture that FlowingWater displaces by. Grid size and
+ * step rate are budgeted per quality preset in src/systems/sweQuality.ts, so this
+ * solver must stay size-agnostic — never assume the 48x32 baseline.
+ */
+
+#include "watershed_native.h"
+
+#include <cmath>
+#include <cstdlib>
+#include <algorithm>
+
+// ---------------------------------------------------------------------------
+// Shallow Water Equations (SWE) — one time step
+//
+//    Solves on a staggered Cartesian grid using forward differences:
+//      ∂h/∂t = −H · (∂u/∂x + ∂w/∂z)
+//      ∂u/∂t = −g · ∂h/∂x
+//      ∂w/∂t = −g · ∂h/∂z
+//
+//    Grid layout: row-major, index = z * width + x
+//      h[i]  — water height perturbation (m)
+//      u[i]  — X-velocity component (m/s)
+//      w[i]  — Z-velocity component (m/s)
+//
+//    All three arrays live in WASM linear memory; JS passes byte-offset
+//    pointers obtained from allocateGrid().
+//
+//    @param hPtr   Heap pointer (byte offset) for height field
+//    @param uPtr   Heap pointer (byte offset) for X-velocity field
+//    @param wPtr   Heap pointer (byte offset) for Z-velocity field
+//    @param width  Grid columns
+//    @param height Grid rows
+//    @param dt     Time step (s)  — internally clamped to CFL limit
+//    @param g      Gravity (m/s²)
+//    @param dx     Cell size (m)
+//    @param H      Mean resting water depth (m) for linearisation
+// ---------------------------------------------------------------------------
+void stepShallowWater(uintptr_t hPtr, uintptr_t uPtr, uintptr_t wPtr,
+                      int width, int height,
+                      float dt, float g, float dx, float H) {
+    if (width <= 0 || height <= 0 || dx <= 0.f || H <= 0.f) return;
+    if (hPtr == 0 || uPtr == 0 || wPtr == 0) return;
+
+    float* h = reinterpret_cast<float*>(hPtr);
+    float* u = reinterpret_cast<float*>(uPtr);
+    float* w = reinterpret_cast<float*>(wPtr);
+
+    // Enforce CFL stability: dt ≤ dx / (c · √2),  c = √(g·H)
+    const float waveSpeed = std::sqrt(g * H);
+    const float cflMax    = dx / (waveSpeed * 1.5f);
+    const float safeDt    = std::min(dt, cflMax);
+
+    // --- Step 1: update velocities from pressure gradients ---
+    for (int z = 0; z < height; ++z) {
+        for (int x = 0; x < width; ++x) {
+            const int idx = z * width + x;
+
+            const float dhdx = (x < width  - 1) ? (h[idx + 1]     - h[idx]) / dx : 0.f;
+            const float dhdz = (z < height - 1) ? (h[idx + width] - h[idx]) / dx : 0.f;
+
+            u[idx] -= g * safeDt * dhdx;
+            w[idx] -= g * safeDt * dhdz;
+        }
+    }
+
+    // --- Step 2: update heights from velocity divergence ---
+    for (int z = 0; z < height; ++z) {
+        for (int x = 0; x < width; ++x) {
+            const int idx = z * width + x;
+
+            const float dudx = (x > 0) ? (u[idx] - u[idx - 1])     / dx : 0.f;
+            const float dwdz = (z > 0) ? (w[idx] - w[idx - width])  / dx : 0.f;
+
+            h[idx] -= H * safeDt * (dudx + dwdz);
+        }
+    }
+
+    // --- Step 3: light velocity damping to prevent divergence ---
+    const float damp = 1.f - safeDt * DAMPING_COEFF;
+    const int N = width * height;
+    for (int i = 0; i < N; ++i) {
+        u[i] *= damp;
+        w[i] *= damp;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Grid memory helpers
+//    Allocate / free Float32 arrays in WASM heap, addressable from JS via
+//    Float32Array(module.HEAPF32.buffer, ptr, count).
+// ---------------------------------------------------------------------------
+
+uintptr_t allocateGrid(int count) {
+    if (count <= 0) return 0;
+    void* ptr = std::calloc(static_cast<std::size_t>(count), sizeof(float));
+    return reinterpret_cast<uintptr_t>(ptr);
+}
+
+void freeGrid(uintptr_t ptr) {
+    std::free(reinterpret_cast<void*>(ptr));
+}

--- a/emscripten/watershed_native.h
+++ b/emscripten/watershed_native.h
@@ -1,0 +1,141 @@
+/**
+ * watershed_native.h — shared declarations for the Watershed WASM module.
+ *
+ * Translation units:
+ *   forces.cpp    — buoyancy, drag, flow, per-body and batched water forces
+ *   swe.cpp       — shallow-water solver + WASM heap grid helpers
+ *   bindings.cpp  — getVersion() + the Embind surface
+ *
+ * All compile/link flags live in CMakeLists.txt — build.sh is a thin wrapper.
+ */
+
+#ifndef WATERSHED_NATIVE_H
+#define WATERSHED_NATIVE_H
+
+#include <cstdint>
+
+// ---------------------------------------------------------------------------
+// Compile-time constants
+// ---------------------------------------------------------------------------
+static constexpr float WATER_DENSITY_DEFAULT = 1000.0f;  // kg/m³  (fresh water)
+static constexpr float GRAVITY_DEFAULT       = 9.80665f; // m/s² (standard gravity)
+static constexpr float DAMPING_COEFF         = 0.1f;     // velocity damping per second
+
+/** Batch ABI stride, in floats. Mirrored by WATER_FORCE_*_STRIDE in WatershedWasm.ts. */
+static constexpr int WATER_FORCE_INPUT_STRIDE  = 8;
+static constexpr int WATER_FORCE_OUTPUT_STRIDE = 8;
+
+// ---------------------------------------------------------------------------
+// Value types crossing the Embind boundary
+// ---------------------------------------------------------------------------
+
+/** 3-component float vector (returned by computeFlowForce). */
+struct Vec3 {
+    float x = 0.f, y = 0.f, z = 0.f;
+};
+
+struct WaterForceResult {
+    float forceX = 0.f;
+    float forceY = 0.f;
+    float forceZ = 0.f;
+    float buoyancy = 0.f;
+    float drag = 0.f;
+    float flow = 0.f;
+    float turbulence = 0.f;
+    float submergedRatio = 0.f;
+};
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+inline float clampf(float v, float lo, float hi) noexcept {
+    return v < lo ? lo : (v > hi ? hi : v);
+}
+
+// ---------------------------------------------------------------------------
+// bindings.cpp
+// ---------------------------------------------------------------------------
+
+/**
+ * Module ABI version. Bump whenever the exported surface or a batch stride
+ * changes; WatershedWasm.ts documents what each version added.
+ */
+int getVersion() noexcept;
+
+// ---------------------------------------------------------------------------
+// forces.cpp
+// ---------------------------------------------------------------------------
+
+/** Archimedes buoyancy: F_b = ρ · V_displaced · g (N). */
+float computeBuoyancy(float submergedVolume,
+                      float waterDensity,
+                      float gravity) noexcept;
+
+/** Drag magnitude: F_d = ½ · ρ · |v|² · C_d · A (N). */
+float computeDragForce(float vx, float vy, float vz,
+                       float cd, float area, float density) noexcept;
+
+/** Browser smoke-test helper — combines upward buoyancy and current drag. */
+extern "C" float calculateBuoyancyAndDrag(float raftMass,
+                                          float submergedVolume,
+                                          float waterVelocityX,
+                                          float waterVelocityZ) noexcept;
+
+/** River-current force on a partially submerged object, along relative velocity. */
+Vec3 computeFlowForce(float vx, float vy, float vz,
+                      float fx, float fy, float fz,
+                      float flowSpeed,
+                      float mass,
+                      float submergedRatio,
+                      float cd, float area) noexcept;
+
+/** Full water-force solve for a single body (buoyancy + flow + drag + turbulence). */
+WaterForceResult calculateWaterForce(float posX, float posY, float posZ,
+                                     float velX, float velY, float velZ,
+                                     float flowDirX, float flowDirZ,
+                                     float flowSpeed,
+                                     float waterLevel,
+                                     float raftMass,
+                                     float raftVolume,
+                                     float dragCoefficient,
+                                     float frontalArea,
+                                     float sideArea,
+                                     float timeSeconds,
+                                     float turbulenceStrength,
+                                     float turbulenceFrequency) noexcept;
+
+/**
+ * Batch ABI for workers.
+ *   input  stride 8: [posX, posY, posZ, velX, velY, velZ, flowDirX, flowDirZ]
+ *   output stride 8: [forceX, forceY, forceZ, buoyancy, drag, flow, turbulence, submergedRatio]
+ */
+void computeWaterForcesBatch(uintptr_t inputPtr,
+                             uintptr_t outputPtr,
+                             int sampleCount,
+                             float flowSpeed,
+                             float waterLevel,
+                             float raftMass,
+                             float raftVolume,
+                             float dragCoefficient,
+                             float frontalArea,
+                             float sideArea,
+                             float timeSeconds,
+                             float turbulenceStrength,
+                             float turbulenceFrequency) noexcept;
+
+// ---------------------------------------------------------------------------
+// swe.cpp
+// ---------------------------------------------------------------------------
+
+/** Advance the linearised shallow-water grid one CFL-clamped time step. */
+void stepShallowWater(uintptr_t hPtr, uintptr_t uPtr, uintptr_t wPtr,
+                      int width, int height,
+                      float dt, float g, float dx, float H);
+
+/** Allocate `count` zero-initialised floats in the WASM heap; returns a byte offset. */
+uintptr_t allocateGrid(int count);
+
+/** Free a pointer previously returned by allocateGrid. */
+void freeGrid(uintptr_t ptr);
+
+#endif  // WATERSHED_NATIVE_H

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "build:wasm_colab": "cd emscripten && bash build_colab.sh",
     "build:wasm:threads": "cd emscripten && bash build.sh --threads",
     "build:wasm:threads_colab": "cd emscripten && bash build_colab.sh --threads",
-    "build:wasm:debug": "cd emscripten && bash build.sh --debug"
+    "build:wasm:debug": "cd emscripten && bash build.sh --debug",
+    "test:wasm:parity": "WATERSHED_WASM_INTEGRATION=1 vitest run src/physics/__tests__/waterForceParity.test.ts"
   },
   "browserslist": {
     "production": [

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -2,6 +2,11 @@ import React, { useState, useEffect, useSyncExternalStore } from 'react';
 import { DebugStageController, DebugStageId, DebugStageStatus } from '../debug/debugStages';
 import { getPerfMetrics, subscribePerfMetrics } from '../debug/perfMetrics';
 import { getRendererDiagnostics, subscribeRendererDiagnostics } from '../rendering/rendererState';
+import {
+  getPhysicsWorkerStatus,
+  subscribePhysicsWorkerStatus,
+} from '../physics/physicsWorkerRegistry';
+import { PHYSICS_WORKER_REASON_LABELS } from '../utils/physicsWorkerFlag';
 import type { RendererPreference } from '../rendering/types';
 
 // ─── Shared styles ────────────────────────────────────────────────────────────
@@ -125,6 +130,11 @@ export function DebugPanel({
   // Subscribe to live perf metrics from PerfCheckpointMonitor (inside Canvas)
   const metrics = useSyncExternalStore(subscribePerfMetrics, getPerfMetrics);
   const rendererDiagnostics = useSyncExternalStore(subscribeRendererDiagnostics, getRendererDiagnostics);
+  const physicsWorker = useSyncExternalStore(
+    subscribePhysicsWorkerStatus,
+    getPhysicsWorkerStatus,
+    getPhysicsWorkerStatus,
+  );
 
   if (!debug.debugEnabled) return null;
 
@@ -227,6 +237,51 @@ export function DebugPanel({
       <MetricRow
         label="Textures (GPU)"
         value={metrics.textures === 0 ? '—' : String(metrics.textures)}
+        t="ok"
+      />
+
+      <Divider />
+
+      {/* ── Physics worker / native water ───────────────────────────────── */}
+      <SectionTitle>Physics worker — Rapier + watershed_native</SectionTitle>
+      <MetricRow
+        label="Worker"
+        value={
+          physicsWorker.active
+            ? 'active'
+            : physicsWorker.enabled
+              ? 'starting'
+              : 'off'
+        }
+        t={physicsWorker.enabled ? (physicsWorker.active ? 'ok' : 'warn') : 'warn'}
+        hint={
+          physicsWorker.reason
+            ? PHYSICS_WORKER_REASON_LABELS[physicsWorker.reason]
+            : 'no vehicle mounted yet'
+        }
+      />
+      <MetricRow
+        label="Force path"
+        value={physicsWorker.path}
+        t={physicsWorker.path === 'fallback' ? 'warn' : 'ok'}
+        hint={
+          physicsWorker.path === 'fallback'
+            ? 'watershed_native.wasm did not load — TypeScript force math in use'
+            : undefined
+        }
+      />
+      <MetricRow
+        label="Last batch"
+        value={
+          physicsWorker.lastBatchMicros == null
+            ? '—'
+            : `${physicsWorker.lastBatchMicros} µs`
+        }
+        t="ok"
+      />
+      <MetricRow
+        label="SWE displacement"
+        value={physicsWorker.sweEnabled ? (physicsWorker.sweGrid ?? 'on') : 'off (quality)'}
         t="ok"
       />
 

--- a/src/components/FlowingWater.tsx
+++ b/src/components/FlowingWater.tsx
@@ -727,6 +727,10 @@ function isWaterShaderMaterial(
     if (mat.uniforms.sweEnabled) {
       mat.uniforms.sweEnabled.value = swe.enabled && swe.texture ? 1.0 : 0.0;
     }
+    if (mat.uniforms.sweDisplacementScale) {
+      // Quality-budgeted amplitude (sweQuality.ts) — 0 on the low preset.
+      mat.uniforms.sweDisplacementScale.value = swe.displacementScale;
+    }
 
     // Planar reflection texture published by WaterReflection (null when pass unmounted)
     if (mat.uniforms.reflectionTexture) {

--- a/src/physics/__tests__/waterForceFixtures.ts
+++ b/src/physics/__tests__/waterForceFixtures.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared water-force fixtures.
+ *
+ * These sample/config pairs are the contract between the C++ implementation
+ * (emscripten/forces.cpp) and its TypeScript mirror (`calculateWaterForceFallback`
+ * in WatershedWasm.ts). waterForceParity.test.ts pins the TS results to the
+ * committed expectations below, and — when run with WATERSHED_WASM_INTEGRATION=1
+ * — additionally asserts the native module agrees within a float epsilon.
+ *
+ * Cases deliberately cover: fully submerged, straddling the waterline, airborne
+ * (no submersion), diagonal flow, and a turbulence-active tick.
+ */
+
+import type {
+  NativeWaterForceConfig,
+  NativeWaterForceSample,
+} from '../../systems/WatershedWasm';
+
+export interface WaterForceFixture {
+  name: string;
+  sample: NativeWaterForceSample;
+  config: NativeWaterForceConfig;
+}
+
+const RAFT_CONFIG: NativeWaterForceConfig = {
+  flowSpeed: 4.5,
+  waterLevel: 0.5,
+  raftMass: 150,
+  raftVolume: 1.2,
+  dragCoefficient: 0.47,
+  frontalArea: 1.05,
+  sideArea: 0.7,
+  timeSeconds: 12.5,
+  turbulenceStrength: 0,
+  turbulenceFrequency: 2.4,
+};
+
+export const WATER_FORCE_FIXTURES: WaterForceFixture[] = [
+  {
+    name: 'raft fully submerged, straight downstream flow',
+    sample: {
+      position: { x: 0, y: 0.2, z: -10 },
+      velocity: { x: 0.2, y: 0, z: -1.4 },
+      flowDirection: { x: 0, z: -1 },
+    },
+    config: RAFT_CONFIG,
+  },
+  {
+    name: 'raft straddling the waterline',
+    sample: {
+      position: { x: 1.5, y: 0.55, z: -24 },
+      velocity: { x: -0.4, y: 0.6, z: -3.2 },
+      flowDirection: { x: 0, z: -1 },
+    },
+    config: RAFT_CONFIG,
+  },
+  {
+    name: 'raft airborne — no submersion, no force',
+    sample: {
+      position: { x: 0, y: 3.4, z: -40 },
+      velocity: { x: 0, y: -2.2, z: -6.0 },
+      flowDirection: { x: 0, z: -1 },
+    },
+    config: RAFT_CONFIG,
+  },
+  {
+    name: 'diagonal flow around a meander',
+    sample: {
+      position: { x: -2.1, y: 0.3, z: -55 },
+      velocity: { x: 1.1, y: -0.2, z: -5.4 },
+      flowDirection: { x: 0.6, z: -0.8 },
+    },
+    config: { ...RAFT_CONFIG, flowSpeed: 7.2 },
+  },
+  {
+    name: 'turbulence active (rapids tick)',
+    sample: {
+      position: { x: 0.8, y: 0.35, z: -88 },
+      velocity: { x: -0.9, y: 0.1, z: -7.8 },
+      flowDirection: { x: 0, z: -1 },
+    },
+    config: { ...RAFT_CONFIG, turbulenceStrength: 0.12, timeSeconds: 31.75 },
+  },
+  {
+    name: 'runner body (light, high drag) in slow water',
+    sample: {
+      position: { x: 0, y: 0.4, z: -120 },
+      velocity: { x: 0.05, y: -0.3, z: -2.1 },
+      flowDirection: { x: 0, z: -1 },
+    },
+    config: {
+      flowSpeed: 1.2,
+      waterLevel: 0.5,
+      raftMass: 82,
+      raftVolume: 0.08,
+      dragCoefficient: 1.0,
+      frontalArea: 0.45,
+      sideArea: 0.35,
+      timeSeconds: 4.25,
+      turbulenceStrength: 0.075,
+      turbulenceFrequency: 2.4,
+    },
+  },
+];

--- a/src/physics/__tests__/waterForceParity.test.ts
+++ b/src/physics/__tests__/waterForceParity.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Water-force parity — C++ (emscripten/forces.cpp) vs TypeScript fallback.
+ *
+ * The worker path runs native math by default and silently degrades to the TS
+ * fallback when watershed_native.wasm can't load, so the two implementations
+ * have to agree or the raft would feel different depending on asset delivery.
+ *
+ * Default run (`pnpm test`): pins the TS fallback to committed expectations, so
+ * an edit to either implementation that forgets the other shows up as a diff.
+ * Native run (`pnpm test:wasm:parity`, needs a built module): additionally loads
+ * watershed_native and asserts native ≈ TS within a float epsilon.
+ */
+
+import {
+  calculateWaterForceFallback,
+  createWaterForceBatch,
+  getWasm,
+  type NativeWaterForceResult,
+  type WatershedNativeModule,
+} from '../../systems/WatershedWasm';
+import { WATER_FORCE_FIXTURES } from './waterForceFixtures';
+
+/** Committed TS-fallback results, rounded to 4dp. Regenerate deliberately. */
+const EXPECTED: NativeWaterForceResult[] = [
+  {
+    forceX: -239.3792,
+    forceY: 11253.1309,
+    forceZ: -1773.6646,
+    buoyancy: 11767.98,
+    drag: 608.65,
+    flow: 2381.1375,
+    turbulence: 0,
+    submergedRatio: 1,
+  },
+  {
+    forceX: 190.5538,
+    forceY: 3645.2183,
+    forceZ: 985.047,
+    buoyancy: 4202.85,
+    drag: 1169.4775,
+    flow: 163.0312,
+    turbulence: 0,
+    submergedRatio: 0.3571,
+  },
+  {
+    forceX: 0,
+    forceY: 0,
+    forceZ: 0,
+    buoyancy: 0,
+    drag: 0,
+    flow: 0,
+    turbulence: 0,
+    submergedRatio: 0,
+  },
+  {
+    forceX: 1243.1819,
+    forceY: 11320.2592,
+    forceZ: 8716.9467,
+    buoyancy: 11767.98,
+    drag: 9254.5233,
+    flow: 3108.4578,
+    turbulence: 0,
+    submergedRatio: 1,
+  },
+  {
+    forceX: 2665.0421,
+    forceY: 10368.1811,
+    forceZ: 19993.3916,
+    buoyancy: 10927.41,
+    drag: 17424.3453,
+    flow: 2680.7625,
+    turbulence: 111.4286,
+    submergedRatio: 0.9286,
+  },
+  {
+    forceX: -52.4518,
+    forceY: 363.6016,
+    forceZ: 1186.8619,
+    buoyancy: 616.418,
+    drag: 1012.6605,
+    flow: 143.6384,
+    turbulence: 58.9286,
+    submergedRatio: 0.7857,
+  },
+];
+
+const RESULT_KEYS = Object.keys(EXPECTED[0]) as (keyof NativeWaterForceResult)[];
+
+/** Relative epsilon — float32 in C++ vs float64 in JS never matches bit-for-bit. */
+const REL_EPSILON = 1e-3;
+
+function expectClose(actual: number, expected: number, label: string): void {
+  const tolerance = Math.max(Math.abs(expected) * REL_EPSILON, 1e-4);
+  expect(
+    Math.abs(actual - expected),
+    `${label}: expected ${expected}, got ${actual}`,
+  ).toBeLessThanOrEqual(tolerance);
+}
+
+describe('water-force fixtures — TypeScript fallback', () => {
+  it('has one committed expectation per fixture', () => {
+    expect(EXPECTED).toHaveLength(WATER_FORCE_FIXTURES.length);
+  });
+
+  WATER_FORCE_FIXTURES.forEach((fixture, index) => {
+    it(`matches the committed result for: ${fixture.name}`, () => {
+      const actual = calculateWaterForceFallback(fixture.sample, fixture.config);
+      for (const key of RESULT_KEYS) {
+        expectClose(actual[key], EXPECTED[index][key], `${fixture.name}.${key}`);
+      }
+    });
+  });
+});
+
+// The native module is only present after `pnpm build:wasm`, so this block is
+// opt-in via WATERSHED_WASM_INTEGRATION=1 exactly like the other WASM tests.
+const runNative = process.env.WATERSHED_WASM_INTEGRATION === '1';
+const describeNative = runNative ? describe : describe.skip;
+
+describeNative('water-force parity — native C++ vs TypeScript', () => {
+  let wasm: WatershedNativeModule;
+
+  beforeAll(async () => {
+    wasm = await getWasm();
+  });
+
+  it('exposes the expected ABI version', () => {
+    expect(wasm.getVersion()).toBeGreaterThanOrEqual(3);
+  });
+
+  it('agrees with the TS fallback on every fixture (single-sample call)', () => {
+    for (const fixture of WATER_FORCE_FIXTURES) {
+      const { sample, config } = fixture;
+      const native = wasm.calculateWaterForce(
+        sample.position.x, sample.position.y, sample.position.z,
+        sample.velocity.x, sample.velocity.y, sample.velocity.z,
+        sample.flowDirection.x, sample.flowDirection.z,
+        config.flowSpeed,
+        config.waterLevel,
+        config.raftMass,
+        config.raftVolume,
+        config.dragCoefficient,
+        config.frontalArea,
+        config.sideArea,
+        config.timeSeconds,
+        config.turbulenceStrength,
+        config.turbulenceFrequency,
+      );
+      const fallback = calculateWaterForceFallback(sample, config);
+      for (const key of RESULT_KEYS) {
+        expectClose(native[key], fallback[key], `${fixture.name}.${key}`);
+      }
+    }
+  });
+
+  it('batched results match the single-sample path', () => {
+    // All fixtures sharing one config so a single batch call covers them.
+    const config = WATER_FORCE_FIXTURES[0].config;
+    const batch = createWaterForceBatch(wasm, WATER_FORCE_FIXTURES.length);
+    try {
+      WATER_FORCE_FIXTURES.forEach((fixture, i) => batch.setSample(i, fixture.sample));
+      batch.compute(config);
+
+      WATER_FORCE_FIXTURES.forEach((fixture, i) => {
+        const batched = batch.readResult(i);
+        const fallback = calculateWaterForceFallback(fixture.sample, config);
+        for (const key of RESULT_KEYS) {
+          expectClose(batched[key], fallback[key], `batch[${i}].${key}`);
+        }
+      });
+    } finally {
+      batch.dispose();
+    }
+  });
+});

--- a/src/physics/physicsWorkerRegistry.ts
+++ b/src/physics/physicsWorkerRegistry.ts
@@ -3,7 +3,13 @@
  *
  * WaterForceSystem publishes tick params; RaftVehicle reads them when stepping
  * the worker so native water forces stay co-located with Rapier.
+ *
+ * It also carries the debug-facing status bus (worker on/off + why, which force
+ * path ran, last batch cost, SWE budget) so DebugPanel can render live state
+ * without reaching into the worker.
  */
+
+import type { PhysicsWorkerReason } from '../utils/physicsWorkerFlag';
 
 export interface PhysicsWorkerTickParams {
   flowSpeed: number;
@@ -24,6 +30,26 @@ export interface WaterForceDiagnostics {
   flow: number;
   turbulence: number;
   submergedRatio: number;
+  /** Wall time of the force batch inside the worker, in microseconds. */
+  computeMicros?: number;
+}
+
+/** Snapshot rendered by DebugPanel. */
+export interface PhysicsWorkerStatus {
+  /** Worker path resolved as enabled for this session. */
+  enabled: boolean;
+  /** Why it resolved that way (query param, setting, capability, default). */
+  reason: PhysicsWorkerReason | null;
+  /** Worker is live and stepping (false while it boots or after a failure). */
+  active: boolean;
+  /** Which force math produced the last tick. */
+  path: 'wasm' | 'fallback' | 'off';
+  /** Last force-batch cost reported by the worker, in microseconds. */
+  lastBatchMicros: number | null;
+  /** SWE visual displacement currently running (quality-gated). */
+  sweEnabled: boolean;
+  /** Active SWE grid, e.g. '48x32' — null when SWE is off. */
+  sweGrid: string | null;
 }
 
 const DEFAULT_TICK_PARAMS: PhysicsWorkerTickParams = {
@@ -35,19 +61,77 @@ const DEFAULT_TICK_PARAMS: PhysicsWorkerTickParams = {
   flowDirZ: -1,
 };
 
+const DEFAULT_STATUS: PhysicsWorkerStatus = {
+  enabled: false,
+  reason: null,
+  active: false,
+  path: 'off',
+  lastBatchMicros: null,
+  sweEnabled: false,
+  sweGrid: null,
+};
+
 let workerActive = false;
 let tickParams: PhysicsWorkerTickParams = { ...DEFAULT_TICK_PARAMS };
 let latestDiagnostics: WaterForceDiagnostics | null = null;
+let status: PhysicsWorkerStatus = { ...DEFAULT_STATUS };
+
+const statusListeners = new Set<() => void>();
+
+function publishStatus(next: Partial<PhysicsWorkerStatus>): void {
+  const merged = { ...status, ...next };
+  // Reference equality drives useSyncExternalStore — skip no-op updates so a
+  // per-frame diagnostics push doesn't re-render the panel on unchanged data.
+  let changed = false;
+  for (const key of Object.keys(merged) as (keyof PhysicsWorkerStatus)[]) {
+    if (merged[key] !== status[key]) {
+      changed = true;
+      break;
+    }
+  }
+  if (!changed) return;
+  status = merged;
+  for (const listener of statusListeners) listener();
+}
 
 export function setPhysicsWorkerActive(active: boolean): void {
   workerActive = active;
   if (!active) {
     latestDiagnostics = null;
   }
+  publishStatus({
+    active,
+    path: active ? status.path : 'off',
+    lastBatchMicros: active ? status.lastBatchMicros : null,
+  });
 }
 
 export function isPhysicsWorkerActive(): boolean {
   return workerActive;
+}
+
+/** Record the resolved enable decision (called once when the vehicle mounts). */
+export function setPhysicsWorkerDecision(
+  enabled: boolean,
+  reason: PhysicsWorkerReason,
+): void {
+  publishStatus({ enabled, reason });
+}
+
+/** Publish the SWE visual budget currently in force (quality-gated). */
+export function setSWEStatus(enabled: boolean, grid: string | null): void {
+  publishStatus({ sweEnabled: enabled, sweGrid: enabled ? grid : null });
+}
+
+export function getPhysicsWorkerStatus(): PhysicsWorkerStatus {
+  return status;
+}
+
+export function subscribePhysicsWorkerStatus(listener: () => void): () => void {
+  statusListeners.add(listener);
+  return () => {
+    statusListeners.delete(listener);
+  };
 }
 
 export function setPhysicsWorkerTickParams(params: Partial<PhysicsWorkerTickParams>): void {
@@ -60,6 +144,14 @@ export function getPhysicsWorkerTickParams(): PhysicsWorkerTickParams {
 
 export function setPhysicsWorkerDiagnostics(diagnostics: WaterForceDiagnostics | null): void {
   latestDiagnostics = diagnostics;
+  if (!diagnostics) return;
+  publishStatus({
+    path: diagnostics.source === 'disabled' ? 'off' : diagnostics.source,
+    lastBatchMicros:
+      typeof diagnostics.computeMicros === 'number'
+        ? Math.round(diagnostics.computeMicros)
+        : status.lastBatchMicros,
+  });
 }
 
 export function getPhysicsWorkerDiagnostics(): WaterForceDiagnostics | null {
@@ -70,4 +162,6 @@ export function resetPhysicsWorkerRegistry(): void {
   workerActive = false;
   tickParams = { ...DEFAULT_TICK_PARAMS };
   latestDiagnostics = null;
+  status = { ...DEFAULT_STATUS };
+  for (const listener of statusListeners) listener();
 }

--- a/src/physics/physicsWorkerWaterForces.test.ts
+++ b/src/physics/physicsWorkerWaterForces.test.ts
@@ -6,7 +6,6 @@ import {
 } from './physicsWorkerWaterForces';
 import { calculateWaterForceFallback } from '../systems/WatershedWasm';
 import type { WorkerRaftState } from './rapierWorkerProtocol';
-import { isPhysicsWorkerEnabled } from '../utils/physicsWorkerFlag';
 
 const SAMPLE_STATE: WorkerRaftState = {
   position: [0, 0.45, -10],
@@ -84,7 +83,10 @@ describe('physicsWorkerWaterForces', () => {
     expect(diagnostics.forceX).toBeCloseTo(expected.forceX, 3);
     expect(diagnostics.forceZ).toBeCloseTo(expected.forceZ, 3);
     expect(diagnostics.submergedRatio).toBeCloseTo(expected.submergedRatio, 5);
-    expect(readWaterForceDiagnostics(output, 'fallback')).toEqual(diagnostics);
+    // Same force payload; `computeMicros` is wall-clock, so compare without it.
+    const { computeMicros, ...payload } = diagnostics;
+    expect(readWaterForceDiagnostics(output, 'fallback')).toEqual(payload);
+    expect(computeMicros).toBeGreaterThanOrEqual(0);
   });
 
   it('returns disabled diagnostics when worker water forces are turned off', () => {
@@ -116,14 +118,6 @@ describe('physicsWorkerWaterForces', () => {
 
     expect(diagnostics.source).toBe('disabled');
     expect(diagnostics.submergedRatio).toBe(0);
-  });
-});
-
-describe('physicsWorkerFlag', () => {
-  it('enables the worker path for physicsWorker=1 and legacy raftWorker=1', () => {
-    expect(isPhysicsWorkerEnabled('?physicsWorker=1')).toBe(true);
-    expect(isPhysicsWorkerEnabled('?raftWorker=1')).toBe(true);
-    expect(isPhysicsWorkerEnabled('')).toBe(false);
   });
 });
 

--- a/src/physics/physicsWorkerWaterForces.ts
+++ b/src/physics/physicsWorkerWaterForces.ts
@@ -21,6 +21,11 @@ import {
 import type { Vec3Tuple, WorkerRaftState } from './rapierWorkerProtocol';
 import type { WaterForceDiagnostics } from './physicsWorkerRegistry';
 
+/** High-resolution clock, degrading to Date.now where performance is absent. */
+function now(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
 /** Matches WaterForceSystem impulse scaling to Rapier game units. */
 export const PHYSICS_WORKER_IMPULSE_SCALE = 0.001;
 
@@ -109,9 +114,11 @@ export function toNativeWaterForceConfig(
 export function readWaterForceDiagnostics(
   output: Float32Array,
   source: WaterForceDiagnostics['source'],
+  computeMicros?: number,
 ): WaterForceDiagnostics {
   return {
     source,
+    ...(computeMicros === undefined ? {} : { computeMicros }),
     forceX: output[0],
     forceY: output[1],
     forceZ: output[2],
@@ -145,6 +152,7 @@ export function computePhysicsWorkerWaterForces(
 
   packRaftWaterSample(state, config.flowDirX, config.flowDirZ, batch.input);
   const nativeConfig = toNativeWaterForceConfig(config);
+  const startedAt = now();
 
   if (wasm) {
     wasm.computeWaterForcesBatch(
@@ -162,7 +170,7 @@ export function computePhysicsWorkerWaterForces(
       nativeConfig.turbulenceStrength,
       nativeConfig.turbulenceFrequency,
     );
-    return readWaterForceDiagnostics(batch.output, 'wasm');
+    return readWaterForceDiagnostics(batch.output, 'wasm', (now() - startedAt) * 1000);
   }
 
   const fallback = calculateWaterForceFallback(
@@ -183,7 +191,7 @@ export function computePhysicsWorkerWaterForces(
   batch.output[6] = fallback.turbulence;
   batch.output[7] = fallback.submergedRatio;
 
-  return readWaterForceDiagnostics(batch.output, 'fallback');
+  return readWaterForceDiagnostics(batch.output, 'fallback', (now() - startedAt) * 1000);
 }
 
 export function applyWaterForceImpulse(

--- a/src/physics/rapierWorkerProtocol.ts
+++ b/src/physics/rapierWorkerProtocol.ts
@@ -41,6 +41,8 @@ export interface WaterForceDiagnostics {
   flow: number;
   turbulence: number;
   submergedRatio: number;
+  /** Wall time of the force batch inside the worker, in microseconds. */
+  computeMicros?: number;
 }
 
 export interface RapierWorkerInitPayload {

--- a/src/systems/SWEHeightField.ts
+++ b/src/systems/SWEHeightField.ts
@@ -3,14 +3,23 @@
  *
  * WaterForceSystem owns the WASM grid and uploads a DataTexture each frame.
  * SplashSystem and other gameplay events enqueue disturbances via injectSWEDisturbance.
+ *
+ * The grid is quality-budgeted (see sweQuality.ts): on the `low` preset the whole
+ * path is off, and `setSWEActiveBudget` makes disturbance injection a no-op so
+ * splash events don't grow an unbounded queue nobody drains.
  */
 
 import * as THREE from 'three';
+import { sweBudgetForQuality, type SWEBudget } from './sweQuality';
 
+/** Baseline (high-preset) grid — kept as the historical default for consumers. */
 export const SWE_GRID_WIDTH = 48;
 export const SWE_GRID_HEIGHT = 32;
 export const SWE_CELL_SIZE = 0.5;
 export const SWE_MEAN_DEPTH = 1.0;
+
+/** Cap on queued disturbances, so a stalled consumer can't grow the queue forever. */
+const MAX_PENDING_DISTURBANCES = 64;
 
 export interface SWEDisturbance {
   worldX: number;
@@ -27,19 +36,42 @@ export interface SWEHeightFieldSnapshot {
   width: number;
   height: number;
   enabled: boolean;
+  /** Vertex displacement scale for the water shader (quality-budgeted). */
+  displacementScale: number;
 }
 
 const pendingDisturbances: SWEDisturbance[] = [];
 
-let snapshot: SWEHeightFieldSnapshot = {
+/** The budget WaterForceSystem is currently running. */
+let activeBudget: SWEBudget = sweBudgetForQuality('high');
+
+const emptySnapshot = (): SWEHeightFieldSnapshot => ({
   texture: null,
   originX: 0,
   originZ: 0,
-  cellSize: SWE_CELL_SIZE,
-  width: SWE_GRID_WIDTH,
-  height: SWE_GRID_HEIGHT,
+  cellSize: activeBudget.cellSize || SWE_CELL_SIZE,
+  width: activeBudget.width || SWE_GRID_WIDTH,
+  height: activeBudget.height || SWE_GRID_HEIGHT,
   enabled: false,
-};
+  displacementScale: activeBudget.displacementScale,
+});
+
+let snapshot: SWEHeightFieldSnapshot = emptySnapshot();
+
+/**
+ * Publish the budget WaterForceSystem is running. When the budget is disabled,
+ * queued disturbances are dropped and new ones are ignored.
+ */
+export function setSWEActiveBudget(budget: SWEBudget): void {
+  activeBudget = budget;
+  if (!budget.enabled) {
+    pendingDisturbances.length = 0;
+  }
+}
+
+export function getSWEActiveBudget(): SWEBudget {
+  return activeBudget;
+}
 
 /** Queue a Gaussian bump at world XZ (consumed on the next SWE step). */
 export function injectSWEDisturbance(
@@ -48,6 +80,8 @@ export function injectSWEDisturbance(
   radius = 1.5,
   amplitude = 0.35,
 ): void {
+  if (!activeBudget.enabled) return;
+  if (pendingDisturbances.length >= MAX_PENDING_DISTURBANCES) return;
   pendingDisturbances.push({ worldX, worldZ, radius, amplitude });
 }
 
@@ -70,14 +104,6 @@ export function clearSWEHeightField(): void {
   if (snapshot.texture) {
     snapshot.texture.dispose();
   }
-  snapshot = {
-    texture: null,
-    originX: 0,
-    originZ: 0,
-    cellSize: SWE_CELL_SIZE,
-    width: SWE_GRID_WIDTH,
-    height: SWE_GRID_HEIGHT,
-    enabled: false,
-  };
+  snapshot = emptySnapshot();
   pendingDisturbances.length = 0;
 }

--- a/src/systems/WaterForceSystem.tsx
+++ b/src/systems/WaterForceSystem.tsx
@@ -6,7 +6,7 @@
  * - Falls back to pure TypeScript force math when WASM is unavailable.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { WATER_LEVEL } from '../constants/game';
@@ -21,14 +21,14 @@ import {
   type WatershedNativeModule,
 } from './WatershedWasm';
 import {
-  SWE_CELL_SIZE,
-  SWE_GRID_HEIGHT,
-  SWE_GRID_WIDTH,
   SWE_MEAN_DEPTH,
   consumeSWEDisturbances,
+  setSWEActiveBudget,
   updateSWEHeightFieldSnapshot,
   clearSWEHeightField,
 } from './SWEHeightField';
+import { sweBudgetForQuality, sweStepInterval, type SWEBudget } from './sweQuality';
+import { useQualityPreset } from './GameState';
 import {
   collectWaterForceBodies,
   registerVehicleWaterBody,
@@ -38,6 +38,7 @@ import {
 import {
   isPhysicsWorkerActive,
   setPhysicsWorkerTickParams,
+  setSWEStatus,
 } from '../physics/physicsWorkerRegistry';
 import type { VehicleRigidBodyRef, VehicleType } from '../experience/types';
 
@@ -116,10 +117,11 @@ function worldToGridIndex(
   worldZ: number,
   originX: number,
   originZ: number,
+  budget: SWEBudget,
 ): { gx: number; gz: number } | null {
-  const gx = Math.round((worldX - originX) / SWE_CELL_SIZE);
-  const gz = Math.round((worldZ - originZ) / SWE_CELL_SIZE);
-  if (gx < 0 || gx >= SWE_GRID_WIDTH || gz < 0 || gz >= SWE_GRID_HEIGHT) return null;
+  const gx = Math.round((worldX - originX) / budget.cellSize);
+  const gz = Math.round((worldZ - originZ) / budget.cellSize);
+  if (gx < 0 || gx >= budget.width || gz < 0 || gz >= budget.height) return null;
   return { gx, gz };
 }
 
@@ -128,18 +130,19 @@ function applyDisturbances(
   originX: number,
   originZ: number,
   disturbances: ReturnType<typeof consumeSWEDisturbances>,
+  budget: SWEBudget,
 ): void {
   for (const d of disturbances) {
-    const center = worldToGridIndex(d.worldX, d.worldZ, originX, originZ);
+    const center = worldToGridIndex(d.worldX, d.worldZ, originX, originZ, budget);
     if (!center) continue;
 
-    const radiusCells = Math.max(1, Math.ceil(d.radius / SWE_CELL_SIZE));
+    const radiusCells = Math.max(1, Math.ceil(d.radius / budget.cellSize));
     for (let dz = -radiusCells; dz <= radiusCells; dz += 1) {
       for (let dx = -radiusCells; dx <= radiusCells; dx += 1) {
         const gx = center.gx + dx;
         const gz = center.gz + dz;
         if (gx < 0 || gx >= grid.width || gz < 0 || gz >= grid.height) continue;
-        const dist = Math.hypot(dx, dz) * SWE_CELL_SIZE;
+        const dist = Math.hypot(dx, dz) * budget.cellSize;
         if (dist > d.radius) continue;
         const falloff = Math.exp(-(dist * dist) / Math.max(d.radius * d.radius, 0.01));
         const idx = gz * grid.width + gx;
@@ -154,16 +157,18 @@ function uploadHeightTexture(
   texture: THREE.DataTexture,
   originX: number,
   originZ: number,
+  budget: SWEBudget,
 ): void {
-  texture.image.data.set(grid.h);
+  (texture.image.data as unknown as Float32Array).set(grid.h);
   texture.needsUpdate = true;
   updateSWEHeightFieldSnapshot({
     texture,
     originX,
     originZ,
-    cellSize: SWE_CELL_SIZE,
-    width: SWE_GRID_WIDTH,
-    height: SWE_GRID_HEIGHT,
+    cellSize: budget.cellSize,
+    width: budget.width,
+    height: budget.height,
+    displacementScale: budget.displacementScale,
     enabled: true,
   });
 }
@@ -181,7 +186,13 @@ export function WaterForceSystem({
   const textureRef = useRef<THREE.DataTexture | null>(null);
   const originRef = useRef({ x: 0, z: 0 });
   const statusRef = useRef<'loading' | 'ready' | 'fallback'>('loading');
-  const gridInitializedRef = useRef(false);
+  const stepAccumulatorRef = useRef(0);
+  const [wasmReady, setWasmReady] = useState(false);
+
+  // Visual SWE budget follows the live quality preset (LODManager may downgrade
+  // it adaptively). Force math below is NOT gated — it is gameplay-affecting.
+  const quality = useQualityPreset();
+  const budget = useMemo(() => sweBudgetForQuality(quality), [quality]);
 
   useEffect(() => {
     setWaterForceSystemActive(true);
@@ -192,20 +203,45 @@ export function WaterForceSystem({
         if (cancelled) return;
         wasmRef.current = wasm;
         statusRef.current = 'ready';
-        gridRef.current = createSWEGrid(wasm, SWE_GRID_WIDTH, SWE_GRID_HEIGHT, SWE_CELL_SIZE);
-        gridRef.current.h.fill(SWE_MEAN_DEPTH);
+        setWasmReady(true);
       })
       .catch((error) => {
         if (cancelled) return;
         statusRef.current = 'fallback';
         console.warn('[WaterForceSystem] WASM unavailable; using TypeScript fallbacks', error);
         updateSWEHeightFieldSnapshot({ enabled: false, texture: null });
+        setSWEStatus(false, null);
       });
 
+    return () => {
+      cancelled = true;
+      setWaterForceSystemActive(false);
+      registerVehicleWaterBody(null);
+      clearSWEHeightField();
+      setSWEStatus(false, null);
+    };
+  }, []);
+
+  // Grid + upload texture are sized by the budget, so a quality change
+  // reallocates both. `low` allocates nothing at all.
+  useEffect(() => {
+    setSWEActiveBudget(budget);
+
+    const wasm = wasmRef.current;
+    if (!budget.enabled || !wasm) {
+      updateSWEHeightFieldSnapshot({ enabled: false, texture: null });
+      setSWEStatus(false, null);
+      return;
+    }
+
+    const grid = createSWEGrid(wasm, budget.width, budget.height, budget.cellSize);
+    grid.h.fill(SWE_MEAN_DEPTH);
+    gridRef.current = grid;
+
     const texture = new THREE.DataTexture(
-      new Float32Array(SWE_GRID_WIDTH * SWE_GRID_HEIGHT),
-      SWE_GRID_WIDTH,
-      SWE_GRID_HEIGHT,
+      new Float32Array(budget.width * budget.height),
+      budget.width,
+      budget.height,
       THREE.RedFormat,
       THREE.FloatType,
     );
@@ -214,18 +250,18 @@ export function WaterForceSystem({
     texture.wrapS = THREE.ClampToEdgeWrapping;
     texture.wrapT = THREE.ClampToEdgeWrapping;
     textureRef.current = texture;
+    stepAccumulatorRef.current = 0;
+    setSWEStatus(true, `${budget.width}x${budget.height}`);
 
     return () => {
-      cancelled = true;
-      setWaterForceSystemActive(false);
-      registerVehicleWaterBody(null);
-      gridRef.current?.dispose();
+      grid.dispose();
       gridRef.current = null;
       texture.dispose();
       textureRef.current = null;
-      clearSWEHeightField();
+      updateSWEHeightFieldSnapshot({ enabled: false, texture: null });
+      setSWEStatus(false, null);
     };
-  }, []);
+  }, [budget, wasmReady]);
 
   useFrame((state, delta) => {
     const vehicleBody = vehicleRef.current;
@@ -252,33 +288,41 @@ export function WaterForceSystem({
       flowDirZ: -1,
     });
     const anchor = vehicleBody?.translation?.() ?? bodies[0].translation();
-    const originX = anchor.x - (SWE_GRID_WIDTH * SWE_CELL_SIZE) * 0.5;
-    const originZ = anchor.z - (SWE_GRID_HEIGHT * SWE_CELL_SIZE) * 0.5;
+    const originX = anchor.x - (budget.width * budget.cellSize) * 0.5;
+    const originZ = anchor.z - (budget.height * budget.cellSize) * 0.5;
     originRef.current = { x: originX, z: originZ };
 
     const grid = gridRef.current;
     const texture = textureRef.current;
-    if (grid && texture && wasmRef.current) {
-      if (!gridInitializedRef.current) {
-        grid.h.fill(SWE_MEAN_DEPTH);
-        gridInitializedRef.current = true;
+    if (budget.enabled && grid && texture && wasmRef.current) {
+      // Step-rate budget: accumulate render deltas and take one SWE step per
+      // budgeted interval, so a 30Hz preset costs half a 60Hz preset's steps.
+      const interval = sweStepInterval(budget);
+      stepAccumulatorRef.current += dt;
+      if (stepAccumulatorRef.current >= interval) {
+        const stepDt = Math.min(stepAccumulatorRef.current, 0.05);
+        stepAccumulatorRef.current = 0;
+
+        applyDisturbances(grid, originX, originZ, consumeSWEDisturbances(), budget);
+
+        wasmRef.current.stepShallowWater(
+          grid.hPtr,
+          grid.uPtr,
+          grid.wPtr,
+          grid.width,
+          grid.height,
+          stepDt,
+          9.80665,
+          grid.dx,
+          SWE_MEAN_DEPTH,
+        );
+
+        uploadHeightTexture(grid, texture, originX, originZ, budget);
+      } else {
+        // Grid didn't step, but the player moved — keep the sampling window
+        // anchored so the displacement doesn't lag behind the camera.
+        updateSWEHeightFieldSnapshot({ originX, originZ });
       }
-
-      applyDisturbances(grid, originX, originZ, consumeSWEDisturbances());
-
-      wasmRef.current.stepShallowWater(
-        grid.hPtr,
-        grid.uPtr,
-        grid.wPtr,
-        grid.width,
-        grid.height,
-        dt,
-        9.80665,
-        grid.dx,
-        SWE_MEAN_DEPTH,
-      );
-
-      uploadHeightTexture(grid, texture, originX, originZ);
     }
 
     const vehicleConfig = vehicleForceConfig(
@@ -392,6 +436,7 @@ export function WaterForceSystem({
         status: statusRef.current,
         origin: originRef.current,
         sampleCount: bodies.length,
+        sweBudget: budget,
         workerOwnsVehicleForces,
         workerDiagnostics: workerOwnsVehicleForces
           ? (window as any).__watershedPhysicsWorker?.waterForce

--- a/src/systems/WatershedWasm.ts
+++ b/src/systems/WatershedWasm.ts
@@ -2,7 +2,8 @@
  * WatershedWasm.ts — TypeScript bindings for the Watershed C++ WASM module
  *
  * Provides a typed, lazy-loaded interface to `public/watershed_native.js`,
- * which is compiled from `emscripten/main.cpp` via `npm run build:wasm`.
+ * which is compiled from `emscripten/{forces,swe,bindings}.cpp` via
+ * `npm run build:wasm`. `getVersion()` returns the ABI version (currently 3).
  *
  * Quick start
  * -----------
@@ -81,7 +82,12 @@ export interface WatershedNativeModule {
   HEAPU8:  Uint8Array;
 
   // ---- Module version ----
-  /** Returns the integer module version (bump on ABI changes). */
+  /**
+   * Returns the integer module ABI version (bump on ABI changes).
+   *   1 — initial buoyancy/drag/flow surface
+   *   2 — batched computeWaterForcesBatch + SWE grid helpers
+   *   3 — C++ split into forces.cpp / swe.cpp / bindings.cpp
+   */
   getVersion(): number;
 
   calculateBuoyancyAndDrag(

--- a/src/systems/sweQuality.test.ts
+++ b/src/systems/sweQuality.test.ts
@@ -1,0 +1,101 @@
+import {
+  SWE_BUDGETS,
+  sweBudgetForQuality,
+  sweCellCount,
+  sweStepInterval,
+} from './sweQuality';
+import {
+  injectSWEDisturbance,
+  consumeSWEDisturbances,
+  setSWEActiveBudget,
+} from './SWEHeightField';
+import type { QualityPreset } from './GameState';
+
+const PRESETS: QualityPreset[] = ['low', 'medium', 'high', 'ultra'];
+
+describe('sweBudgetForQuality', () => {
+  it('turns the SWE visual path off entirely on the low preset', () => {
+    const budget = sweBudgetForQuality('low');
+    expect(budget.enabled).toBe(false);
+    expect(sweCellCount(budget)).toBe(0);
+    expect(budget.displacementScale).toBe(0);
+  });
+
+  it('keeps the high preset on the historical 48x32 / 0.5m grid', () => {
+    expect(sweBudgetForQuality('high')).toMatchObject({
+      enabled: true,
+      width: 48,
+      height: 32,
+      cellSize: 0.5,
+      stepHz: 60,
+    });
+  });
+
+  it('scales cost monotonically with the preset', () => {
+    const cost = (q: QualityPreset) => {
+      const b = sweBudgetForQuality(q);
+      return sweCellCount(b) * b.stepHz;
+    };
+    expect(cost('low')).toBe(0);
+    expect(cost('medium')).toBeLessThan(cost('high'));
+    expect(cost('high')).toBeLessThanOrEqual(cost('ultra'));
+  });
+
+  it('covers a comparable slice of river at every enabled preset', () => {
+    for (const q of PRESETS) {
+      const b = sweBudgetForQuality(q);
+      if (!b.enabled) continue;
+      expect(b.width * b.cellSize).toBeGreaterThanOrEqual(20);
+      expect(b.height * b.cellSize).toBeGreaterThanOrEqual(15);
+    }
+  });
+
+  it('defines a budget for every quality preset', () => {
+    for (const q of PRESETS) {
+      expect(SWE_BUDGETS[q]).toBeDefined();
+    }
+  });
+});
+
+describe('sweStepInterval', () => {
+  it('is the reciprocal of the step rate, and 0 when disabled', () => {
+    expect(sweStepInterval(sweBudgetForQuality('medium'))).toBeCloseTo(1 / 30, 6);
+    expect(sweStepInterval(sweBudgetForQuality('high'))).toBeCloseTo(1 / 60, 6);
+    expect(sweStepInterval(sweBudgetForQuality('low'))).toBe(0);
+  });
+});
+
+describe('disturbance gating', () => {
+  afterEach(() => {
+    setSWEActiveBudget(sweBudgetForQuality('high'));
+    consumeSWEDisturbances();
+  });
+
+  it('drops splash disturbances while the budget is disabled', () => {
+    setSWEActiveBudget(sweBudgetForQuality('low'));
+    injectSWEDisturbance(1, 2);
+    injectSWEDisturbance(3, 4);
+    expect(consumeSWEDisturbances()).toHaveLength(0);
+  });
+
+  it('queues them again once an enabled budget is active', () => {
+    setSWEActiveBudget(sweBudgetForQuality('high'));
+    injectSWEDisturbance(1, 2, 1.5, 0.4);
+    const batch = consumeSWEDisturbances();
+    expect(batch).toHaveLength(1);
+    expect(batch[0]).toMatchObject({ worldX: 1, worldZ: 2, radius: 1.5, amplitude: 0.4 });
+  });
+
+  it('clears the queue when the budget is switched off mid-session', () => {
+    setSWEActiveBudget(sweBudgetForQuality('high'));
+    injectSWEDisturbance(0, 0);
+    setSWEActiveBudget(sweBudgetForQuality('low'));
+    expect(consumeSWEDisturbances()).toHaveLength(0);
+  });
+
+  it('caps the queue so a stalled consumer cannot grow it forever', () => {
+    setSWEActiveBudget(sweBudgetForQuality('high'));
+    for (let i = 0; i < 500; i += 1) injectSWEDisturbance(i, i);
+    expect(consumeSWEDisturbances().length).toBeLessThanOrEqual(64);
+  });
+});

--- a/src/systems/sweQuality.ts
+++ b/src/systems/sweQuality.ts
@@ -1,0 +1,88 @@
+/**
+ * sweQuality.ts — Quality budgets for the shallow-water (SWE) visual path.
+ *
+ * The SWE grid is a *visual* system: it steps a player-centred height field in
+ * C++/WASM and uploads it as a DataTexture that FlowingWater displaces by. It is
+ * therefore budgeted like any other renderer feature — the `low` preset turns it
+ * off entirely so the frame budget holds on weak hardware, and the higher presets
+ * scale grid resolution, step rate, and displacement amplitude.
+ *
+ * Force math is NOT gated here. Buoyancy/drag/flow are gameplay-affecting and run
+ * at every quality level (see WaterForceSystem).
+ *
+ * Pure module — no React, no THREE, no WASM. Unit-tested in sweQuality.test.ts.
+ */
+
+import type { QualityPreset } from './GameState';
+
+export interface SWEBudget {
+  /** Whether the SWE grid steps and displaces water at all. */
+  enabled: boolean;
+  /** Grid columns. */
+  width: number;
+  /** Grid rows. */
+  height: number;
+  /** Cell size in metres. Larger cells cover the same area with fewer cells. */
+  cellSize: number;
+  /** Maximum SWE steps per second (the render loop accumulates between steps). */
+  stepHz: number;
+  /** Vertex displacement scale applied by the water shader. */
+  displacementScale: number;
+}
+
+const DISABLED: SWEBudget = {
+  enabled: false,
+  width: 0,
+  height: 0,
+  cellSize: 0.5,
+  stepHz: 0,
+  displacementScale: 0,
+};
+
+/**
+ * Per-preset budgets. Areas are kept roughly comparable (~24m x 16m of river)
+ * so the displaced region doesn't visibly shrink when quality drops — the cell
+ * count falls instead.
+ */
+export const SWE_BUDGETS: Record<QualityPreset, SWEBudget> = {
+  low: DISABLED,
+  medium: {
+    enabled: true,
+    width: 32,
+    height: 24,
+    cellSize: 0.75,
+    stepHz: 30,
+    displacementScale: 0.14,
+  },
+  high: {
+    enabled: true,
+    width: 48,
+    height: 32,
+    cellSize: 0.5,
+    stepHz: 60,
+    displacementScale: 0.22,
+  },
+  ultra: {
+    enabled: true,
+    width: 64,
+    height: 40,
+    cellSize: 0.5,
+    stepHz: 60,
+    displacementScale: 0.26,
+  },
+};
+
+/** Budget for a quality preset. Unknown presets fall back to `high`. */
+export function sweBudgetForQuality(quality: QualityPreset): SWEBudget {
+  return SWE_BUDGETS[quality] ?? SWE_BUDGETS.high;
+}
+
+/** Cell count for a budget — what actually drives the per-step cost. */
+export function sweCellCount(budget: SWEBudget): number {
+  return budget.enabled ? budget.width * budget.height : 0;
+}
+
+/** Minimum seconds between SWE steps, or 0 when the budget is uncapped/off. */
+export function sweStepInterval(budget: SWEBudget): number {
+  return budget.enabled && budget.stepHz > 0 ? 1 / budget.stepHz : 0;
+}

--- a/src/systems/useSettingsStore.ts
+++ b/src/systems/useSettingsStore.ts
@@ -29,6 +29,7 @@ import {
   type SettingsQuality,
   type VolumeChannel,
 } from './settingsDerive';
+import type { PhysicsWorkerPreference } from '../utils/physicsWorkerFlag';
 
 // ---------------------------------------------------------------------------
 // State + actions
@@ -42,6 +43,12 @@ export interface SettingsState {
   mouseSensitivity: number;
   invertY: boolean;
   quality: SettingsQuality;
+  /**
+   * Physics-worker preference. 'auto' means "on wherever the browser supports
+   * Worker + WebAssembly" — see resolvePhysicsWorker. 'off' is the in-game kill
+   * switch that mirrors `?physicsWorker=0`.
+   */
+  physicsWorker: PhysicsWorkerPreference;
   bindings: Bindings;
   /** Flipped true once persisted state has rehydrated (or confirmed absent). */
   _hasHydrated: boolean;
@@ -52,6 +59,7 @@ export interface SettingsActions {
   setSensitivity: (value: number) => void;
   setInvertY: (value: boolean) => void;
   setQuality: (quality: SettingsQuality) => void;
+  setPhysicsWorker: (preference: PhysicsWorkerPreference) => void;
   /**
    * Bind a physical input to an action. Performs conflict detection: if the
    * input is already bound to another action, the two are SWAPPED rather than
@@ -75,6 +83,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   mouseSensitivity: 1.0,
   invertY: false,
   quality: 'high',
+  physicsWorker: 'auto',
   bindings: { ...DEFAULT_BINDINGS },
   _hasHydrated: false,
 };
@@ -183,6 +192,10 @@ export function migrateSettings(
       p.quality === 'low' || p.quality === 'med' || p.quality === 'high'
         ? p.quality
         : base.quality,
+    physicsWorker:
+      p.physicsWorker === 'auto' || p.physicsWorker === 'on' || p.physicsWorker === 'off'
+        ? p.physicsWorker
+        : base.physicsWorker,
     bindings: mergedBindings,
     // Never trust a persisted hydration flag.
     _hasHydrated: false,
@@ -213,6 +226,8 @@ export const useSettingsStore = create<SettingsStore>()(
       setInvertY: (value) => set({ invertY: value }),
 
       setQuality: (quality) => set({ quality }),
+
+      setPhysicsWorker: (preference) => set({ physicsWorker: preference }),
 
       bindAction: (action, binding) =>
         set((state) => {
@@ -247,6 +262,7 @@ export const useSettingsStore = create<SettingsStore>()(
           mouseSensitivity: DEFAULT_SETTINGS.mouseSensitivity,
           invertY: DEFAULT_SETTINGS.invertY,
           quality: DEFAULT_SETTINGS.quality,
+          physicsWorker: DEFAULT_SETTINGS.physicsWorker,
           bindings: { ...DEFAULT_BINDINGS },
         }),
 
@@ -274,6 +290,7 @@ export const useSettingsStore = create<SettingsStore>()(
         mouseSensitivity: state.mouseSensitivity,
         invertY: state.invertY,
         quality: state.quality,
+        physicsWorker: state.physicsWorker,
         bindings: state.bindings,
       }),
       onRehydrateStorage: () => (state) => {

--- a/src/ui/SettingsPanel.tsx
+++ b/src/ui/SettingsPanel.tsx
@@ -26,6 +26,7 @@ import {
   type SettingsQuality,
   type VolumeChannel,
 } from '../systems/settingsDerive';
+import type { PhysicsWorkerPreference } from '../utils/physicsWorkerFlag';
 
 interface SettingsPanelProps {
   /** Called when the player dismisses the panel (returns to the parent menu). */
@@ -104,6 +105,8 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose }) => {
   const setSensitivity = useSettingsStore((s) => s.setSensitivity);
   const setInvertY = useSettingsStore((s) => s.setInvertY);
   const setQuality = useSettingsStore((s) => s.setQuality);
+  const physicsWorker = useSettingsStore((s) => s.physicsWorker);
+  const setPhysicsWorker = useSettingsStore((s) => s.setPhysicsWorker);
   const bindAction = useSettingsStore((s) => s.bindAction);
   const unbindAction = useSettingsStore((s) => s.unbindAction);
   const resetToDefaults = useSettingsStore((s) => s.resetToDefaults);
@@ -273,6 +276,37 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onClose }) => {
         </div>
         <p className="settings-panel-note">
           Effect toggles apply immediately. Resolution changes apply on next map load.
+          Water surface displacement is off on Low.
+        </p>
+      </section>
+
+      <section className="settings-panel-section" aria-label="Physics">
+        <h3 className="settings-panel-section-title">Physics</h3>
+        <div className="settings-panel-row">
+          <label className="settings-panel-label">Physics worker</label>
+          <div className="settings-panel-quality-buttons">
+            {(
+              [
+                ['auto', 'Auto'],
+                ['on', 'On'],
+                ['off', 'Off'],
+              ] as [PhysicsWorkerPreference, string][]
+            ).map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                className={`settings-panel-quality-btn ${physicsWorker === value ? 'active' : ''}`}
+                onClick={() => setPhysicsWorker(value)}
+                aria-pressed={physicsWorker === value}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <p className="settings-panel-note">
+          Auto runs Rapier and the native water forces in a worker wherever the browser
+          supports it. Turn it off if the raft feels wrong; applies on next map load.
         </p>
       </section>
 

--- a/src/utils/physicsWorkerFlag.test.ts
+++ b/src/utils/physicsWorkerFlag.test.ts
@@ -1,0 +1,80 @@
+import {
+  isPhysicsWorkerEnabled,
+  resolvePhysicsWorker,
+  type PhysicsWorkerEnvironment,
+} from './physicsWorkerFlag';
+
+/** A browser that can host the worker path, so only the flags under test vary. */
+const capable = (over: Partial<PhysicsWorkerEnvironment> = {}): PhysicsWorkerEnvironment => ({
+  search: '',
+  hasWorker: true,
+  hasWasm: true,
+  ...over,
+});
+
+describe('resolvePhysicsWorker', () => {
+  it('defaults ON with no query params on a capable browser', () => {
+    expect(resolvePhysicsWorker(capable())).toEqual({
+      enabled: true,
+      reason: 'default-on',
+    });
+  });
+
+  it('is killed by ?physicsWorker=0 and legacy ?raftWorker=0', () => {
+    expect(resolvePhysicsWorker(capable({ search: '?physicsWorker=0' }))).toEqual({
+      enabled: false,
+      reason: 'query-off',
+    });
+    expect(resolvePhysicsWorker(capable({ search: '?raftWorker=0' }))).toEqual({
+      enabled: false,
+      reason: 'query-off',
+    });
+  });
+
+  it('lets the kill switch win even over an explicit opt-in preference', () => {
+    const decision = resolvePhysicsWorker(
+      capable({ search: '?physicsWorker=0', preference: 'on' }),
+    );
+    expect(decision.enabled).toBe(false);
+  });
+
+  it('falls back when the browser lacks Worker or WebAssembly', () => {
+    expect(resolvePhysicsWorker(capable({ hasWorker: false }))).toEqual({
+      enabled: false,
+      reason: 'no-worker',
+    });
+    expect(resolvePhysicsWorker(capable({ hasWasm: false }))).toEqual({
+      enabled: false,
+      reason: 'no-wasm',
+    });
+  });
+
+  it('honours the settings preference, and lets ?physicsWorker=1 override it', () => {
+    expect(resolvePhysicsWorker(capable({ preference: 'off' }))).toEqual({
+      enabled: false,
+      reason: 'setting-off',
+    });
+    expect(resolvePhysicsWorker(capable({ preference: 'on' }))).toEqual({
+      enabled: true,
+      reason: 'setting-on',
+    });
+    expect(
+      resolvePhysicsWorker(capable({ preference: 'off', search: '?physicsWorker=1' })),
+    ).toEqual({ enabled: true, reason: 'query-on' });
+  });
+
+  it('accepts a query string with or without the leading ?', () => {
+    expect(resolvePhysicsWorker(capable({ search: 'physicsWorker=0' })).enabled).toBe(false);
+  });
+});
+
+describe('isPhysicsWorkerEnabled', () => {
+  it('still accepts a bare search string (legacy call sites)', () => {
+    expect(isPhysicsWorkerEnabled({ ...capable(), search: '?physicsWorker=1' })).toBe(true);
+    expect(isPhysicsWorkerEnabled('?physicsWorker=0')).toBe(false);
+  });
+
+  it('is false when the environment cannot host a worker', () => {
+    expect(isPhysicsWorkerEnabled({ hasWorker: false, search: '' })).toBe(false);
+  });
+});

--- a/src/utils/physicsWorkerFlag.ts
+++ b/src/utils/physicsWorkerFlag.ts
@@ -1,13 +1,121 @@
 /**
  * Feature flag for the co-located Rapier + watershed_native physics worker path.
  *
- * Enabled via `?physicsWorker=1` (or legacy `?raftWorker=1`).
- * Default off so visual-smoke and CI stay on main-thread Rapier.
+ * The worker path is the DEFAULT on browsers that expose `Worker` + `WebAssembly`
+ * (see docs/reference/ADR_WASM_RAPIER_WATER_FORCES.md). Resolution order:
+ *
+ *   1. `?physicsWorker=0` (or legacy `?raftWorker=0`) — hard kill switch, always wins.
+ *   2. Missing `Worker` / `WebAssembly` — cannot run the worker path at all.
+ *   3. `?physicsWorker=1` — explicit opt-in (e.g. when the setting says off).
+ *   4. Settings preference `'on'` / `'off'`.
+ *   5. Default: on.
+ *
+ * A WASM *load* failure is handled one layer down: the worker falls back to the
+ * TypeScript force math (`getWorkerWasm` returns null), and RaftVehicle keeps the
+ * main-thread Rapier body authoritative if the worker itself never becomes ready.
  */
-export function isPhysicsWorkerEnabled(search?: string): boolean {
+
+/** Player-facing preference stored in the settings panel. */
+export type PhysicsWorkerPreference = 'auto' | 'on' | 'off';
+
+export type PhysicsWorkerReason =
+  | 'query-off'
+  | 'query-on'
+  | 'setting-off'
+  | 'setting-on'
+  | 'default-on'
+  | 'no-worker'
+  | 'no-wasm';
+
+export interface PhysicsWorkerDecision {
+  enabled: boolean;
+  reason: PhysicsWorkerReason;
+}
+
+export interface PhysicsWorkerEnvironment {
+  /** Query string (with or without a leading '?'). Defaults to window.location.search. */
+  search?: string;
+  /** Override capability detection (tests). */
+  hasWorker?: boolean;
+  hasWasm?: boolean;
+  /** Settings-panel preference. Defaults to 'auto'. */
+  preference?: PhysicsWorkerPreference;
+}
+
+/** Human-readable explanation for the debug panel. */
+export const PHYSICS_WORKER_REASON_LABELS: Record<PhysicsWorkerReason, string> = {
+  'query-off': 'disabled by ?physicsWorker=0',
+  'query-on': 'forced by ?physicsWorker=1',
+  'setting-off': 'disabled in settings',
+  'setting-on': 'enabled in settings',
+  'default-on': 'default on',
+  'no-worker': 'Worker unavailable',
+  'no-wasm': 'WebAssembly unavailable',
+};
+
+function readParams(search?: string): URLSearchParams {
   const raw =
-    search ??
-    (typeof window !== 'undefined' ? window.location.search : '');
-  const params = new URLSearchParams(raw.startsWith('?') ? raw : `?${raw}`);
-  return params.get('physicsWorker') === '1' || params.get('raftWorker') === '1';
+    search ?? (typeof window !== 'undefined' ? window.location.search : '');
+  return new URLSearchParams(raw.startsWith('?') ? raw : `?${raw}`);
+}
+
+/** First of `physicsWorker` / `raftWorker` that is present, normalised to '1' | '0' | null. */
+function readQueryOverride(params: URLSearchParams): '1' | '0' | null {
+  for (const key of ['physicsWorker', 'raftWorker']) {
+    const value = params.get(key);
+    if (value === '1' || value === 'true') return '1';
+    if (value === '0' || value === 'false') return '0';
+  }
+  return null;
+}
+
+function detectWorkerSupport(): boolean {
+  return typeof Worker !== 'undefined';
+}
+
+function detectWasmSupport(): boolean {
+  return typeof WebAssembly !== 'undefined' && typeof WebAssembly.instantiate === 'function';
+}
+
+/**
+ * Resolve whether the physics worker path should run, and why.
+ * Pure — every environment input can be injected, so this is unit-testable.
+ */
+export function resolvePhysicsWorker(
+  env: PhysicsWorkerEnvironment = {},
+): PhysicsWorkerDecision {
+  const params = readParams(env.search);
+  const override = readQueryOverride(params);
+
+  // 1. Kill switch always wins, even over capability detection.
+  if (override === '0') return { enabled: false, reason: 'query-off' };
+
+  // 2. Capability gate.
+  const hasWorker = env.hasWorker ?? detectWorkerSupport();
+  if (!hasWorker) return { enabled: false, reason: 'no-worker' };
+  const hasWasm = env.hasWasm ?? detectWasmSupport();
+  if (!hasWasm) return { enabled: false, reason: 'no-wasm' };
+
+  // 3. Explicit opt-in beats the stored preference.
+  if (override === '1') return { enabled: true, reason: 'query-on' };
+
+  // 4. Settings preference.
+  const preference = env.preference ?? 'auto';
+  if (preference === 'off') return { enabled: false, reason: 'setting-off' };
+  if (preference === 'on') return { enabled: true, reason: 'setting-on' };
+
+  // 5. Default on.
+  return { enabled: true, reason: 'default-on' };
+}
+
+/**
+ * Convenience boolean. Kept as the historical entry point so callers that don't
+ * care about the reason stay unchanged.
+ */
+export function isPhysicsWorkerEnabled(
+  searchOrEnv?: string | PhysicsWorkerEnvironment,
+): boolean {
+  const env: PhysicsWorkerEnvironment =
+    typeof searchOrEnv === 'string' ? { search: searchOrEnv } : (searchOrEnv ?? {});
+  return resolvePhysicsWorker(env).enabled;
 }

--- a/src/vehicles/RaftVehicle.tsx
+++ b/src/vehicles/RaftVehicle.tsx
@@ -10,11 +10,13 @@ import { buildRaftWorkerWaterForceConfig } from '../physics/physicsWorkerConfig'
 import {
   getPhysicsWorkerTickParams,
   setPhysicsWorkerActive,
+  setPhysicsWorkerDecision,
   setPhysicsWorkerDiagnostics,
 } from '../physics/physicsWorkerRegistry';
 import type { RapierWorkerProxy } from '../physics/RapierWorkerProxy';
 import type { Vec3Tuple, WorkerRaftState } from '../physics/rapierWorkerProtocol';
-import { isPhysicsWorkerEnabled } from '../utils/physicsWorkerFlag';
+import { resolvePhysicsWorker } from '../utils/physicsWorkerFlag';
+import { useSettingsStore } from '../systems/useSettingsStore';
 import { usePlayerControls } from '../hooks/usePlayerControls';
 import { WATER_PHYSICS, PADDLE, SHED } from './RaftVehicle/constants';
 import { useRaftPhysicsState } from './RaftVehicle/hooks/useRaftPhysicsState';
@@ -26,7 +28,19 @@ const RaftVehicle = forwardRef((props, forwardedRef) => {
   const raftMaterialRef = useRef<any>(null);
   const { camera } = useThree();
   const { world } = useRapier();
-  const useWorkerPhysics = isPhysicsWorkerEnabled();
+  // Default-on: the worker runs unless the browser can't host it, the player
+  // turned it off, or ?physicsWorker=0 is set. Read once per mount — switching
+  // mid-session would strand the Rapier body between two authorities.
+  const physicsWorkerPreference = useSettingsStore((s) => s.physicsWorker);
+  const workerDecision = React.useMemo(
+    () => resolvePhysicsWorker({ preference: physicsWorkerPreference }),
+    [physicsWorkerPreference],
+  );
+  const useWorkerPhysics = workerDecision.enabled;
+
+  useEffect(() => {
+    setPhysicsWorkerDecision(workerDecision.enabled, workerDecision.reason);
+  }, [workerDecision]);
 
   const controls = usePlayerControls();
   const raftVehicle = useRef(new RaftVehicleClass());


### PR DESCRIPTION
Implements the three phases of the water-physics productization issue (#354).

## Phase A — default-on worker + kill switch

`resolvePhysicsWorker()` (`src/utils/physicsWorkerFlag.ts`) replaces the opt-in-only flag. Precedence:

| # | Input | Result |
|---|-------|--------|
| 1 | `?physicsWorker=0` / `?raftWorker=0` | off — kill switch, wins over everything |
| 2 | no `Worker` / no `WebAssembly` | off — `no-worker` / `no-wasm` |
| 3 | `?physicsWorker=1` | on — overrides the stored setting |
| 4 | Settings → Physics (`auto`/`on`/`off`) | per preference |
| 5 | nothing set | **on** — `default-on` |

- Settings panel gains an auto/on/off physics-worker toggle; persisted and backfilled by `migrateSettings`.
- Two independent fallbacks are unchanged and still exercised: worker init failure keeps the main-thread Rapier body authoritative, and a failed `watershed_native.wasm` load runs the TS force math inside the same worker tick.
- DebugPanel gets a **Physics worker** section — worker state + the reason it resolved that way, active force path (`wasm`/`fallback`), last force-batch cost in µs, and the live SWE grid. The worker now reports `computeMicros` on its diagnostics payload.
- No shadow mode: with parity pinned by tests (below) and the path/µs readout in the panel, a dual-compute release seemed like more risk than signal. Happy to add it if you want the belt-and-braces round.

## Phase B — quality-gated SWE budgets

New `src/systems/sweQuality.ts`:

| Preset | Grid | Cell | Step rate | Displacement |
|--------|------|------|-----------|--------------|
| low | — | — | off | 0 |
| medium | 32×24 | 0.75 m | 30 Hz | 0.14 |
| high | 48×32 | 0.5 m | 60 Hz | 0.22 |
| ultra | 64×40 | 0.5 m | 60 Hz | 0.26 |

- `WaterForceSystem` reallocates grid + upload texture when the budget changes, steps at most `stepHz` per second, and publishes `displacementScale` through the height-field snapshot to `FlowingWater`.
- `injectSWEDisturbance` no-ops while the budget is disabled and the pending queue is capped, so splash events can't accumulate work nobody drains.
- Force math is deliberately **not** gated — buoyancy/drag/flow are gameplay-affecting and run identically at every preset.

## Phase C — split the C++ before it grows

`main.cpp` (~420 LOC) → `forces.cpp` / `swe.cpp` / `bindings.cpp`, with shared declarations in `watershed_native.h`. `getVersion()` bumped to **3**. CMake `SOURCES` and the `build_colab.sh` `em++` invocation updated; all compile/link flags stay in `CMakeLists.txt`. No pthreads / SharedArrayBuffer requirement introduced for the default path.

## Tests

- `src/utils/physicsWorkerFlag.test.ts` — full precedence table, including kill-switch-over-preference and capability gating.
- `src/systems/sweQuality.test.ts` — budgets, monotonic cost, and disturbance gating.
- `src/physics/__tests__/waterForceParity.test.ts` — pins the TS fallback to committed fixtures (runs in plain `pnpm test`) and, under `WATERSHED_WASM_INTEGRATION=1`, asserts native ≈ TS per fixture plus batch-vs-scalar agreement. New script: `pnpm test:wasm:parity`.

Verified locally: `pnpm typecheck`, `pnpm test` (557 passed, 5 skipped), `pnpm build`. `pnpm test:visual-smoke` reports "Visual smoke passed" with the required capture green; the three best-effort top-down shots fail on a start-button click in this container, and I confirmed the identical failure on `origin/main` — pre-existing, not from this change. The native halves of the WASM tests need a machine with Emscripten to have run `pnpm build:wasm`.

Docs updated: ADR (default-on precedence table, dual fallback, SWE budgets, module layout), `WASM.md`, `WASM_WATER_FORCES.md`, `SYSTEMS.md`, `CLAUDE.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019wBgYjuU9xtThS7Fpqnj8u)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Physics processing now defaults to the worker path when supported, with Auto, On, and Off settings.
  - Added clearer fallback behavior and diagnostics for physics processing.
  - Water simulation quality now adapts to graphics presets, including reduced displacement on Low quality.
  - Debug information now shows physics path, timing, worker status, and water displacement details.

- **Documentation**
  - Expanded guidance for physics behavior, water simulation quality, native integration, and fallback handling.

- **Tests**
  - Added coverage for worker selection, water-force parity, and quality-based water simulation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->