### PR TITLE
Survival v2: spatial portage/caches, slipperiness → Rapier friction, raft paddle coupling

### DIFF
--- a/docs/reference/SURVIVAL_LAYER.md
+++ b/docs/reference/SURVIVAL_LAYER.md
@@ -1,6 +1,9 @@
 # Survival Layer (Track A)
 
-Living design note for the survival gameplay foundation. Track B (WebGPU / TSL) is intentionally deferred until this MVP is stable.
+Living design note for the survival gameplay foundation.
+
+**v2 (this pass)** adds spatial portage/cache waypoints, `slipperiness` → Rapier contact
+friction, and raft paddle coupling. The MVP pieces below are unchanged.
 
 ## Goals
 
@@ -19,6 +22,9 @@ State lives in **pure TS modules** (`src/systems/survival/`) and **runSession** 
 | `survival/survivalState.ts` | Wetness + core temp tick + gameplay modifiers |
 | `survival/checkpointTable.ts` | `resolveRespawnSegment()` pure resolver |
 | `maps/survivalMetadata.ts` | Per-map checkpoints, caches, portage routes |
+| `portageCache.ts` | Cache/portage state machine + waypoint geometry |
+| `surfaceFriction.ts` | `slipperiness` → Rapier contact friction |
+| `components/Survival/SurvivalMarkers.tsx` | World markers + proximity interaction |
 | `runSession.ts` | Run-scoped survival instance + `tickRunSurvival()` |
 
 ## State transitions
@@ -46,7 +52,73 @@ ambient(biome) + insulation(loadout) - wetnessColdDrag ──lerp──► coreT
 - **Cold biomes** (`glacier`, `glacialMelt`): low ambient → core temp drops unless expedition kit.
 - **Exposure stress** (0–1): derived from core temp, biome cold bias, and wetness.
 
-### Gameplay modifiers (runner)
+## Spatial portage & caches (v2)
+
+A cache slot or portage route is **spatial** when its authored definition carries a
+`position` (and optional `radius`, default 6 m). Both forms coexist:
+
+| Form | Interaction | Where |
+|------|-------------|-------|
+| Spatial | Steer within the waypoint radius (XZ distance; height ignored) | `meander`, `hydro` |
+| Segment-scoped | Entering the segment is the whole interaction | `delta` |
+
+`SurvivalMarkers` draws a ground ring plus a beacon per live waypoint and polls the
+player at 10 Hz. Interaction is proximity-only — no interact key. The player is moving
+at speed; "steer through the marker" is the verb the rest of the game already uses.
+
+### Cache loop
+
+```
+unplaced ──(enter radius)──► placed ──(enter radius again, later)──► retrieved
+                               │
+                               └──(wipeout on that segment)──► lost
+```
+
+- **Stashing** costs the placement slot (`maxCachePlacements`, default 1).
+- **Retrieving** awards `retrievalBonus` *and* survival relief — the only mid-run way
+  to undo wetness:
+
+| Effect | Amount | Constant |
+|--------|--------|----------|
+| Wetness removed | −0.45 | `CACHE_WETNESS_RECOVERY` |
+| Core temp restored | +0.25 | `CACHE_WARMTH_RECOVERY` |
+
+That is the decision the system exists for: spend a scoring slot early for insurance
+against a cold reach later, or bank the bonus and run dry.
+
+### Portage requirement
+
+A route becomes `required` → `in_progress` when its segment enters an elevated
+forecast state (`HighFlow` / `Flooded` / `WashedOut`, via `requiresPortageForSegment`).
+
+**A spatial route completes only by reaching its waypoint.** Surviving the flooded
+line instead of walking around it is a `failed` route and a `PORTAGE FAILED` penalty
+(`PORTAGE_FAIL_PENALTY`, 200) — that's what prices the choice. Segment-scoped routes
+keep the legacy rule (survive the segment = pass).
+
+Failure is sticky: a wipeout mid-portage fails the route and reaching the waypoint
+afterwards does not resurrect it.
+
+## Surface friction (v2)
+
+`slipperiness` (0–1) now drives **Rapier contact friction** on the canyon collision
+mesh, not just water drag. Ownership, which must not be double-counted:
+
+| System | Owns | Reads slipperiness? |
+|--------|------|---------------------|
+| `surfaceFriction.ts` → `TrackSegmentMeshes` | Solid contact (feet on floor, hull on wall) | Yes |
+| `WaterFlowForces` | Water-borne lateral drag + downstream slide bias | Yes |
+
+They act on disjoint interactions (contact vs fluid), so both may read the same value.
+What must not happen is a second contact-friction scaler elsewhere, or a fluid-drag
+term inside `surfaceFriction.ts`.
+
+Mapping: the flood state sets the baseline (`WashedOut` 0.35, `Flooded` 0.55,
+`HighFlow` 0.8, else `biomeProfile.wallFriction`), then slipperiness interpolates that
+toward `ICE_MIN_FRICTION` (0.04 — never 0, which makes Rapier jitter). Slipperiness is
+monotonic downward: it can only ever make a surface slicker.
+
+## Gameplay modifiers (runner)
 
 Applied in `RunnerPhysicsStep.ts` via `tickRunSurvival()`:
 
@@ -56,6 +128,21 @@ Applied in `RunnerPhysicsStep.ts` via `tickRunSurvival()`:
 | Stamina regen | −up to 35% at max stress | −25% at full wet |
 | Movement speed | −up to 8% at max stress | — |
 | Loadout | insulation + mass | regen/drain baselines |
+
+## Gameplay modifiers (raft) — v2
+
+The raft has no sprint, so wetness and exposure land on the paddle economy instead.
+`raftPhysicsRuntime` ticks survival each frame (`inWater` = the raft is actually
+floating) and applies:
+
+| Modifier | Effect | Bound at worst case |
+|----------|--------|---------------------|
+| `paddleCostMultiplier` | Each stroke costs more stamina | < 2× |
+| `paddleRegenMultiplier` | Stamina refills slower | ≥ 0 |
+
+Curves are deliberately gentler than the runner's sprint penalties: the raft cannot
+choose to stop paddling mid-rapid, so a harsh curve reads as unfair rather than tense.
+The HUD WET / EXPOSURE bars are already vehicle-agnostic and show in raft mode.
 
 ## Checkpoint graph (meander)
 
@@ -82,16 +169,22 @@ HUD shows `LOADOUT <shortLabel>` (top-left) plus WET / EXPOSURE bars (bottom-lef
 
 ## Testing
 
-- `src/systems/__tests__/survivalState.test.ts` — wetness dry cycle, cold biome, modifier bounds.
-- `src/systems/__tests__/checkpointTable.test.ts` — meander checkpoint graph.
+- `survivalState.test.ts` — wetness dry cycle, cold biome, modifier bounds.
+- `checkpointTable.test.ts` — meander checkpoint graph.
+- `portageCache.test.ts` — segment-scoped state machine.
+- `portageSpatial.test.ts` — waypoint geometry, spatial cache loop, portage
+  requirement, authored map metadata, raft paddle coupling.
+- `surfaceFriction.test.ts` — slipperiness → friction mapping.
 
 ## Future (post-MVP)
 
-- Raft wetness / paddle stamina coupling.
+- **Playtest pass on the authored waypoint positions** — they are first-pass values
+  aligned with the checkpoint table, not yet validated in-engine.
 - FlowForecast mid-run cache restock synergy.
 - Speed-based wind audio (plan.md).
-- `safeZone` OOB replacement for fixed `y < -80` wipeout.
-- Track B: NodeMaterial water/canyon under WebGL before WebGPU toggle.
+- `safeZone` OOB replacement for fixed `y < -80` wipeout (phase D, not started).
+- Wetness SFX muffling — `sfxWetnessMultiplier` is computed but not yet wired to the
+  audio bus (waiting on issue #301).
 
 ## Related
 

--- a/src/LEVEL_DESIGN.md
+++ b/src/LEVEL_DESIGN.md
@@ -138,8 +138,12 @@ player with a calm, visually rich recovery (alpine) before the main descent.
 - Adds a `0.18 × flowSpeed × slipperiness` slide bias along the downstream tangent each frame.
 - Net feel: high speed, minimal control, survive-the-chute tension.
 
-> **TODO:** Wire `slipperiness` into a Rapier `ContactMaterial` friction override so
-> wall impacts also feel slippery (friction ≈ `biomeProfile.wallFriction = 0.18`).
+`slipperiness` also drives **Rapier contact friction** on the segment's collision mesh
+(`systems/surfaceFriction.ts` → `TrackSegmentMeshes`), so wall and floor impacts feel
+slippery too: the flood state sets the baseline, then slipperiness interpolates it
+toward `ICE_MIN_FRICTION` (0.04). Water-borne lateral drag (above) and contact friction
+act on disjoint interactions and must not be double-counted — see
+[`SURVIVAL_LAYER.md`](../docs/reference/SURVIVAL_LAYER.md#surface-friction-v2).
 
 ### Visual Style
 

--- a/src/components/Survival/SurvivalMarkers.tsx
+++ b/src/components/Survival/SurvivalMarkers.tsx
@@ -1,0 +1,217 @@
+/**
+ * SurvivalMarkers — world markers + interaction for spatial caches and portage routes.
+ *
+ * This is the piece that turns the portage/cache state machine into something the
+ * player can actually walk to. It renders one marker per authored waypoint on the
+ * active map and drives the state machine from proximity:
+ *
+ *   - **Cache slot, unplaced** → entering the radius stashes the cache (score slot
+ *     spent now, insurance banked for later).
+ *   - **Cache slot, placed** → entering the radius retrieves it: score bonus plus
+ *     the wetness/warmth relief in `applyCacheRecovery()`.
+ *   - **Portage route** → only shown while the segment's forecast state actually
+ *     demands it. Reaching it completes the route; leaving the segment without it
+ *     is a `PORTAGE FAILED` penalty (see `useExperienceLifecycle`).
+ *
+ * Interaction is proximity-only by design — no interact key. The player is moving
+ * at speed down a river; a prompt they must read and press is the wrong verb, and
+ * "steer through the marker" is the same verb the rest of the game uses.
+ *
+ * Markers are cheap (one instanced-free mesh each, a handful per map) and only
+ * exist while a run session has authored waypoints.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { getMapSurvivalMetadata } from '../../maps/survivalMetadata';
+import {
+  DEFAULT_WAYPOINT_RADIUS,
+  findCacheSlotAt,
+  findPortageRouteAt,
+  portageRouteStatus,
+  type CacheSlotDefinition,
+  type CacheSlotStatus,
+  type PortageRouteDefinition,
+} from '../../systems/portageCache';
+import {
+  applyCacheRecovery,
+  dispatchPortageCacheEvent,
+  getPortageCacheState,
+  getRunSession,
+} from '../../systems/runSession';
+import { awardCacheRetrievalBonus } from '../../systems/ScoreSystem';
+import { useGameStore } from '../../systems/GameState';
+import type { VehicleRigidBodyRef } from '../../experience/types';
+
+/** How often to test the player against waypoints (seconds). 10 Hz is plenty. */
+const PROXIMITY_INTERVAL = 0.1;
+
+const CACHE_COLOR_UNPLACED = '#f5c542';
+const CACHE_COLOR_PLACED = '#6dde7a';
+const PORTAGE_COLOR = '#9fd6ff';
+
+export interface SurvivalMarkersProps {
+  vehicleRef: React.RefObject<VehicleRigidBodyRef | null>;
+}
+
+interface MarkerVisual {
+  key: string;
+  position: [number, number, number];
+  radius: number;
+  color: string;
+  label: string;
+}
+
+/** Emit a HUD toast without coupling this component to the HUD implementation. */
+function announce(label: string, detail: Record<string, unknown> = {}): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent('survival-marker', { detail: { label, ...detail } }),
+  );
+}
+
+export function SurvivalMarkers({ vehicleRef }: SurvivalMarkersProps) {
+  const session = getRunSession();
+  const mapId = session?.mapId;
+  const currentSegmentIndex = useGameStore((s) => s.currentSegmentIndex);
+
+  const metadata = useMemo(
+    () => (mapId ? getMapSurvivalMetadata(mapId) : {}),
+    [mapId],
+  );
+
+  /** Authored waypoints only — segment-scoped entries have no marker to draw. */
+  const spatialCaches = useMemo<CacheSlotDefinition[]>(
+    () => (metadata.cacheSlots ?? []).filter((slot) => Boolean(slot.position)),
+    [metadata],
+  );
+  const spatialRoutes = useMemo<PortageRouteDefinition[]>(
+    () => (metadata.portageRoutes ?? []).filter((route) => Boolean(route.position)),
+    [metadata],
+  );
+
+  // Re-render markers when slot statuses change; the state machine itself lives
+  // outside React, so this mirrors just enough of it to draw.
+  const [slotStatuses, setSlotStatuses] = useState<Record<string, CacheSlotStatus>>({});
+  const elapsedRef = useRef(0);
+
+  useEffect(() => {
+    const runState = getPortageCacheState();
+    if (!runState) return;
+    const next: Record<string, CacheSlotStatus> = {};
+    for (const slot of runState.cacheSlots) next[slot.id] = slot.status;
+    setSlotStatuses(next);
+  }, [mapId]);
+
+  useFrame((_state, delta) => {
+    if (spatialCaches.length === 0 && spatialRoutes.length === 0) return;
+
+    elapsedRef.current += delta;
+    if (elapsedRef.current < PROXIMITY_INTERVAL) return;
+    elapsedRef.current = 0;
+
+    const body = vehicleRef.current;
+    const position = body?.translation?.();
+    if (!position) return;
+
+    const runState = getPortageCacheState();
+    if (!runState) return;
+
+    // --- caches ---
+    const nearCache = findCacheSlotAt(spatialCaches, position);
+    if (nearCache) {
+      const slot = runState.cacheSlots.find((entry) => entry.id === nearCache.id);
+
+      if (slot?.status === 'unplaced') {
+        dispatchPortageCacheEvent({ type: 'PLACE_CACHE', slotId: nearCache.id });
+        setSlotStatuses((prev) => ({ ...prev, [nearCache.id]: 'placed' }));
+        announce('CACHE STASHED', { slotId: nearCache.id, cacheLabel: nearCache.label });
+      } else if (slot?.status === 'placed') {
+        dispatchPortageCacheEvent({ type: 'RETRIEVE_CACHE', slotId: nearCache.id });
+        awardCacheRetrievalBonus(slot.segmentIndex);
+        applyCacheRecovery();
+        setSlotStatuses((prev) => ({ ...prev, [nearCache.id]: 'retrieved' }));
+        announce('CACHE RETRIEVED', { slotId: nearCache.id, cacheLabel: nearCache.label });
+      }
+    }
+
+    // --- portage routes ---
+    const nearRoute = findPortageRouteAt(spatialRoutes, position);
+    if (nearRoute) {
+      const status = portageRouteStatus(runState, nearRoute.segmentIndex);
+      if (status === 'required' || status === 'in_progress') {
+        dispatchPortageCacheEvent({
+          type: 'REACH_PORTAGE_WAYPOINT',
+          segmentIndex: nearRoute.segmentIndex,
+        });
+        announce('PORTAGE CLEARED', { segmentIndex: nearRoute.segmentIndex });
+      }
+    }
+  });
+
+  const markers = useMemo<MarkerVisual[]>(() => {
+    const runState = getPortageCacheState();
+    const visuals: MarkerVisual[] = [];
+
+    for (const slot of spatialCaches) {
+      const status = slotStatuses[slot.id]
+        ?? runState?.cacheSlots.find((entry) => entry.id === slot.id)?.status
+        ?? 'unplaced';
+      // Retrieved and lost caches leave nothing behind to walk to.
+      if (status !== 'unplaced' && status !== 'placed') continue;
+      visuals.push({
+        key: `cache-${slot.id}`,
+        position: slot.position!,
+        radius: slot.radius ?? DEFAULT_WAYPOINT_RADIUS,
+        color: status === 'placed' ? CACHE_COLOR_PLACED : CACHE_COLOR_UNPLACED,
+        label: slot.label,
+      });
+    }
+
+    for (const route of spatialRoutes) {
+      const status = portageRouteStatus(runState ?? { cacheSlots: [], portageRoutes: [] }, route.segmentIndex);
+      // Only draw a portage line the player currently owes — an idle route would
+      // read as "go this way" on a segment that is perfectly runnable.
+      if (status !== 'required' && status !== 'in_progress') continue;
+      visuals.push({
+        key: `portage-${route.segmentIndex}`,
+        position: route.position!,
+        radius: route.radius ?? DEFAULT_WAYPOINT_RADIUS,
+        color: PORTAGE_COLOR,
+        label: route.label,
+      });
+    }
+
+    return visuals;
+  }, [spatialCaches, spatialRoutes, slotStatuses, currentSegmentIndex]);
+
+  if (markers.length === 0) return null;
+
+  return (
+    <group name="survival-markers">
+      {markers.map((marker) => (
+        <group key={marker.key} position={marker.position}>
+          {/* Ground ring — reads as "stand here" from above and at speed. */}
+          <mesh rotation={[-Math.PI / 2, 0, 0]}>
+            <ringGeometry args={[marker.radius * 0.75, marker.radius, 24]} />
+            <meshBasicMaterial
+              color={marker.color}
+              transparent
+              opacity={0.35}
+              side={THREE.DoubleSide}
+              depthWrite={false}
+            />
+          </mesh>
+          {/* Beacon — visible over the canyon lip before the ring is in view. */}
+          <mesh position={[0, 3, 0]}>
+            <cylinderGeometry args={[0.25, 0.25, 6, 8]} />
+            <meshBasicMaterial color={marker.color} transparent opacity={0.5} depthWrite={false} />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}
+
+export default SurvivalMarkers;

--- a/src/components/TrackManager.tsx
+++ b/src/components/TrackManager.tsx
@@ -541,6 +541,10 @@ const TrackManager = forwardRef<TrackManagerRef, TrackManagerProps>(function Tra
           weatherWetnessRef={weatherWetnessRef}
           usePooledStaticObstacles
           {...(segment || {})}
+          slipperiness={
+            (mapManagerRef.current?.getChunkConfig?.(segment?.id ?? 0)?.slipperiness ?? 0) +
+            (segment?.slipperinessAdd ?? 0)
+          }
         />
       ))}
 

--- a/src/components/TrackSegment/TrackSegmentMeshes.tsx
+++ b/src/components/TrackSegment/TrackSegmentMeshes.tsx
@@ -63,6 +63,10 @@ import { resolveMaterialBackend } from '../../rendering/materialBackend';
 import PondFog from './PondFog';
 import { hasFiniteCoordinates, SLOT_CANYON_STRATA } from './utils';
 import type { TrackSegmentMeshesProps } from './types';
+import {
+    resolveSegmentFriction,
+    resolveSegmentRestitution,
+} from '../../systems/surfaceFriction';
 
 type WallMaterial = THREE.Material & {
   uniforms?: Record<string, { value: unknown }>;
@@ -80,6 +84,7 @@ export function TrackSegmentMeshes({
     flowSpeed,
     type,
     segmentState,
+    slipperiness = 0,
     placementData,
     biome,
     waterfallPos,
@@ -440,16 +445,15 @@ export function TrackSegmentMeshes({
                 key={`rb-collision-${segmentId}`}
                 type="fixed"
                 colliders="trimesh"
-                friction={
-                    segmentState === 'WashedOut'
-                        ? 0.35
-                        : segmentState === 'Flooded'
-                        ? 0.55
-                        : segmentState === 'HighFlow'
-                          ? 0.8
-                          : biomeProfile.wallFriction
-                }
-                restitution={biomeProfile.id === 'slotCanyon' ? 0.02 : 0.1}
+                friction={resolveSegmentFriction({
+                    baseFriction: biomeProfile.wallFriction,
+                    slipperiness,
+                    segmentState,
+                })}
+                restitution={resolveSegmentRestitution(
+                    biomeProfile.id === 'slotCanyon' ? 0.02 : 0.1,
+                    slipperiness,
+                )}
             >
                 <mesh geometry={collisionGeometry} visible={false} />
             </RigidBody>

--- a/src/components/TrackSegment/index.tsx
+++ b/src/components/TrackSegment/index.tsx
@@ -25,6 +25,7 @@ export default function TrackSegment({
   showDebug = false,
   waterLevel = WATER_LEVEL,
   segmentState = 'Normal',
+  slipperiness = 0,
   particleCount,
   particleDensity,
   raftRef,
@@ -164,6 +165,7 @@ export default function TrackSegment({
       isSlotCanyon={isSlotCanyon}
       waterLevel={waterLevel}
       segmentState={segmentState}
+      slipperiness={slipperiness}
       particleCount={particleCount}
       particleDensity={particleDensity}
       raftRef={raftRef}

--- a/src/components/TrackSegment/types.ts
+++ b/src/components/TrackSegment/types.ts
@@ -291,6 +291,8 @@ export interface TrackSegmentProps {
   showDebug?: boolean;
   waterLevel?: number;
   segmentState?: SegmentState;
+  /** Authored surface slipperiness 0–1 (+ forecast slipperinessAdd). Drives Rapier contact friction. */
+  slipperiness?: number;
   particleCount?: number;
   particleDensity?: number;
   raftRef?: RefObject<{
@@ -340,6 +342,8 @@ export interface TrackSegmentMeshesProps {
   isSlotCanyon: boolean;
   waterLevel: number;
   segmentState: SegmentState;
+  /** Authored surface slipperiness 0–1 (+ forecast slipperinessAdd). Drives Rapier contact friction. */
+  slipperiness?: number;
   particleCount?: number;
   particleDensity?: number;
   raftRef?: TrackSegmentProps['raftRef'];

--- a/src/experience/InnerExperience.tsx
+++ b/src/experience/InnerExperience.tsx
@@ -15,6 +15,7 @@ import HeadlessSkySphere from './HeadlessSkySphere';
 import SceneLighting, { isTightCanyonSegment, waterfallFxIntensityForSegment } from './SceneLighting';
 import VehicleMount from './VehicleMount';
 import PillarDustVFX from '../components/Obstacles/PillarDustVFX';
+import SurvivalMarkers from '../components/Survival/SurvivalMarkers';
 import PillarFragmentPool from '../components/Obstacles/PillarFragmentPool';
 import GhostReplayer from '../components/GhostReplayer';
 import { WaterReflectionLayer, WaterPhysicsEffects } from './WaterStack';
@@ -95,6 +96,9 @@ export default function InnerExperience({
             flowSpeed={state.biomeMaterials.water.flowSpeed}
             wasmWaterTest={state.wasmWaterTest}
           />
+
+          {/* Spatial portage / cache markers for the active map (survival v2). */}
+          <SurvivalMarkers vehicleRef={state.vehicleRef} />
 
           <PillarFragmentPool castShadow={lodQuality !== 'high'} />
           <PillarDustVFX />

--- a/src/experience/hooks/useExperienceLifecycle.ts
+++ b/src/experience/hooks/useExperienceLifecycle.ts
@@ -18,7 +18,11 @@ import { useGameStore, batchFrameUpdate } from '../../systems/GameState';
 import { tickGhostRecording } from '../../systems/GhostRecorder';
 import { isElevatedRisk } from '../../systems/flowForecast';
 import { getMapSurvivalMetadata } from '../../maps/survivalMetadata';
-import { countLostCaches, requiresPortageForSegment } from '../../systems/portageCache';
+import {
+  countLostCaches,
+  portageRouteStatus,
+  requiresPortageForSegment,
+} from '../../systems/portageCache';
 import { dispatchPortageCacheEvent, getRunSession } from '../../systems/runSession';
 import { resolveRespawnSegment } from '../../systems/survival';
 import type { DebugStageController } from '../../debug/debugStages';
@@ -163,12 +167,18 @@ export function useExperienceLifecycle({
           awardFloodSurviveBonus(previous.surviveBonus, previous.state);
         }
         if (previous && previous.segmentIndex !== index) {
-          dispatchPortageCacheEvent({
+          const afterExit = dispatchPortageCacheEvent({
             type: 'EXIT_SEGMENT',
             segmentIndex: previous.segmentIndex,
             survived: !useGameStore.getState().isWipeout,
           });
-          if (previous.requiresPortage && useGameStore.getState().isWipeout) {
+          // A required portage fails by being skipped, not only by wiping out —
+          // running the flooded line instead of walking around it is the choice
+          // the penalty is pricing.
+          const routeStatus = afterExit
+            ? portageRouteStatus(afterExit, previous.segmentIndex)
+            : null;
+          if (previous.requiresPortage && routeStatus === 'failed') {
             applyPortageFailPenalty();
           }
         }

--- a/src/maps/survivalMetadata.ts
+++ b/src/maps/survivalMetadata.ts
@@ -6,6 +6,17 @@ import type { MapRegistryId } from './registry';
 import type { CacheSlotDefinition, PortageRouteDefinition } from '../systems/portageCache';
 import type { CheckpointDefinition } from '../systems/survival';
 
+/**
+ * Per-map survival authoring.
+ *
+ * Cache slots and portage routes may be **spatial** (they carry a `position`, so
+ * SurvivalMarkers draws them and proximity drives the state machine) or
+ * **segment-scoped** (no position — entering the segment is the interaction).
+ * Both forms coexist; see docs/reference/SURVIVAL_LAYER.md.
+ *
+ * Positions are first-pass authoring aligned with the checkpoint table below and
+ * want a playtest pass on a GPU machine before they're treated as final.
+ */
 export interface MapSurvivalMetadata {
   maxCachePlacements?: number;
   cacheSlots?: CacheSlotDefinition[];
@@ -37,12 +48,19 @@ const SURVIVAL_BY_MAP: Partial<Record<MapRegistryId, MapSurvivalMetadata>> = {
         segmentIndex: 10,
         label: 'Rim shelf above the trestle',
         retrievalBonus: 250,
+        // Bank-side shelf, off the main current line — reaching it costs speed.
+        position: [18, -14, -235],
+        radius: 9,
       },
     ],
     portageRoutes: [
       {
         segmentIndex: 11,
         label: 'High-line portage past the trestle',
+        // The dry line around the trestle. Wide radius: this is a route to steer
+        // through at speed, not a spot to stop on.
+        position: [22, -12, -258],
+        radius: 12,
       },
     ],
   },
@@ -61,10 +79,25 @@ const SURVIVAL_BY_MAP: Partial<Record<MapRegistryId, MapSurvivalMetadata>> = {
         radius: 30,
       },
     ],
+    maxCachePlacements: 1,
+    cacheSlots: [
+      {
+        id: 'hydro-catwalk-9',
+        segmentIndex: 9,
+        label: 'Catwalk cache above the outfall',
+        retrievalBonus: 275,
+        position: [14, -18, -520],
+        radius: 9,
+      },
+    ],
     portageRoutes: [
       {
         segmentIndex: 13,
         label: 'Portage ledge above the catwalk gate',
+        // Dam-release set-piece: when the forecast opens the gates, this ledge is
+        // the only line that isn't a wall of water.
+        position: [16, -14, -690],
+        radius: 12,
       },
     ],
   },
@@ -104,6 +137,8 @@ const SURVIVAL_BY_MAP: Partial<Record<MapRegistryId, MapSurvivalMetadata>> = {
         retrievalBonus: 300,
       },
     ],
+    // Delta keeps the segment-scoped (non-spatial) form on purpose: it exercises
+    // the legacy path, where entering the segment is the whole interaction.
     portageRoutes: [
       {
         segmentIndex: 11,

--- a/src/materials/river/createRiverSurfaceMaterial.ts
+++ b/src/materials/river/createRiverSurfaceMaterial.ts
@@ -51,7 +51,22 @@ export function isRiverNodeSurface(material: THREE.Material | null | undefined):
  *
  * A non-standard source material (Basic/Phong/ShaderMaterial) has no node
  * equivalent here, so it stays on the GLSL path even when TSL is requested.
+ *
+ * The overload preserves `MeshStandardMaterial` for standard sources so call sites
+ * can keep passing the result to consumers that read standard-material properties.
+ * `MeshStandardNodeMaterial` mirrors that property surface (map, roughness,
+ * metalness, …), so the narrowing holds at runtime on both backends.
  */
+export function createRiverSurfaceMaterial(
+  backend: MaterialBackend,
+  source: THREE.MeshStandardMaterial,
+  options?: RiverSurfaceOptions,
+): THREE.MeshStandardMaterial;
+export function createRiverSurfaceMaterial(
+  backend: MaterialBackend,
+  source: THREE.Material,
+  options?: RiverSurfaceOptions,
+): THREE.Material;
 export function createRiverSurfaceMaterial(
   backend: MaterialBackend,
   source: THREE.Material,

--- a/src/systems/MapSystem.types.ts
+++ b/src/systems/MapSystem.types.ts
@@ -272,9 +272,12 @@ export interface SegmentProgressionConfig {
   vortex?: VortexConfig;
   /**
    * Surface slipperiness 0–1. 0 = normal grip, 1 = frictionless ice.
-   * Consumed by WaterFlowForces / RaftVehicle to reduce lateral drag and
-   * add a persistent downstream slide bias when > 0.
-   * TODO: wire into Rapier contact material override per segment.
+   *
+   * Two consumers, on disjoint interactions (never double-count them):
+   * - WaterFlowForces / RaftVehicle — reduces water lateral drag and adds a
+   *   downstream slide bias.
+   * - systems/surfaceFriction.ts — sets Rapier contact friction on the segment
+   *   collision mesh, so wall and floor impacts feel slippery too.
    */
   slipperiness?: number;
 }

--- a/src/systems/__tests__/portageSpatial.test.ts
+++ b/src/systems/__tests__/portageSpatial.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Spatial portage + cache loop (survival v2 phase A) and the raft paddle
+ * coupling (phase C).
+ *
+ * The state machine is pure, so the whole loop — stash, retrieve, skip the
+ * portage, wipe out with a cache down — is testable without a scene.
+ */
+
+import {
+  DEFAULT_WAYPOINT_RADIUS,
+  createPortageCacheRunState,
+  findCacheSlotAt,
+  findPortageRouteAt,
+  isWithinWaypoint,
+  portageRouteStatus,
+  reducePortageCacheState,
+  placeCache,
+  totalCacheRetrievalBonus,
+  type CacheSlotDefinition,
+  type PortageRouteDefinition,
+} from '../portageCache';
+import { getMapSurvivalMetadata } from '../../maps/survivalMetadata';
+import {
+  createSurvivalState,
+  getLoadoutDefinition,
+  getSurvivalModifiers,
+} from '../survival';
+
+const SPATIAL_CACHE: CacheSlotDefinition = {
+  id: 'ridge',
+  segmentIndex: 10,
+  label: 'Rim shelf',
+  retrievalBonus: 250,
+  position: [18, -14, -235],
+  radius: 9,
+};
+
+const SPATIAL_ROUTE: PortageRouteDefinition = {
+  segmentIndex: 11,
+  label: 'High line',
+  position: [22, -12, -258],
+  radius: 12,
+};
+
+const SPATIAL_FIXTURE = { cacheSlots: [SPATIAL_CACHE], portageRoutes: [SPATIAL_ROUTE] };
+
+describe('waypoint geometry', () => {
+  it('tests distance in the XZ plane so height offsets do not block a shelf', () => {
+    expect(isWithinWaypoint(SPATIAL_CACHE, { x: 18, y: 200, z: -235 })).toBe(true);
+    expect(isWithinWaypoint(SPATIAL_CACHE, { x: 18, y: -14, z: -250 })).toBe(false);
+  });
+
+  it('treats a definition with no position as unreachable', () => {
+    expect(isWithinWaypoint({ radius: 50 }, { x: 0, y: 0, z: 0 })).toBe(false);
+  });
+
+  it('defaults the radius when the author omits one', () => {
+    const slot: CacheSlotDefinition = { ...SPATIAL_CACHE, radius: undefined };
+    const justInside = { x: 18 + DEFAULT_WAYPOINT_RADIUS - 0.5, y: 0, z: -235 };
+    const justOutside = { x: 18 + DEFAULT_WAYPOINT_RADIUS + 0.5, y: 0, z: -235 };
+    expect(isWithinWaypoint(slot, justInside)).toBe(true);
+    expect(isWithinWaypoint(slot, justOutside)).toBe(false);
+  });
+
+  it('picks the nearest slot when radii overlap', () => {
+    const near: CacheSlotDefinition = { ...SPATIAL_CACHE, id: 'near', position: [0, 0, 0], radius: 20 };
+    const far: CacheSlotDefinition = { ...SPATIAL_CACHE, id: 'far', position: [10, 0, 0], radius: 20 };
+    expect(findCacheSlotAt([near, far], { x: 1, y: 0, z: 0 })?.id).toBe('near');
+    expect(findCacheSlotAt([near, far], { x: 9, y: 0, z: 0 })?.id).toBe('far');
+  });
+
+  it('returns null when the player is nowhere near a waypoint', () => {
+    expect(findCacheSlotAt([SPATIAL_CACHE], { x: 0, y: 0, z: 0 })).toBeNull();
+    expect(findPortageRouteAt([SPATIAL_ROUTE], { x: 0, y: 0, z: 0 })).toBeNull();
+  });
+});
+
+describe('spatial cache loop', () => {
+  it('does not auto-retrieve a spatial cache on segment enter', () => {
+    let state = placeCache(createPortageCacheRunState(SPATIAL_FIXTURE), 'ridge', 1);
+    state = reducePortageCacheState(state, {
+      type: 'ENTER_SEGMENT',
+      segmentIndex: 10,
+      requiresPortage: false,
+    });
+
+    expect(state.cacheSlots[0].status).toBe('placed');
+    expect(totalCacheRetrievalBonus(state)).toBe(0);
+  });
+
+  it('retrieves on reaching the waypoint and banks the bonus', () => {
+    let state = placeCache(createPortageCacheRunState(SPATIAL_FIXTURE), 'ridge', 1);
+    state = reducePortageCacheState(state, { type: 'RETRIEVE_CACHE', slotId: 'ridge' });
+
+    expect(state.cacheSlots[0].status).toBe('retrieved');
+    expect(totalCacheRetrievalBonus(state)).toBe(250);
+  });
+
+  it('ignores retrieval of a cache that was never stashed', () => {
+    const state = reducePortageCacheState(createPortageCacheRunState(SPATIAL_FIXTURE), {
+      type: 'RETRIEVE_CACHE',
+      slotId: 'ridge',
+    });
+    expect(state.cacheSlots[0].status).toBe('unplaced');
+    expect(totalCacheRetrievalBonus(state)).toBe(0);
+  });
+
+  it('still auto-retrieves a segment-scoped (non-spatial) cache', () => {
+    const legacy = { cacheSlots: [{ ...SPATIAL_CACHE, position: undefined }] };
+    let state = placeCache(createPortageCacheRunState(legacy), 'ridge', 1);
+    state = reducePortageCacheState(state, {
+      type: 'ENTER_SEGMENT',
+      segmentIndex: 10,
+      requiresPortage: false,
+    });
+    expect(state.cacheSlots[0].status).toBe('retrieved');
+  });
+});
+
+describe('spatial portage requirement', () => {
+  const enterFlooded = () =>
+    reducePortageCacheState(createPortageCacheRunState(SPATIAL_FIXTURE), {
+      type: 'ENTER_SEGMENT',
+      segmentIndex: 11,
+      requiresPortage: true,
+    });
+
+  it('marks the route in progress on entering an elevated segment', () => {
+    expect(portageRouteStatus(enterFlooded(), 11)).toBe('in_progress');
+  });
+
+  it('completes only when the player actually reaches the waypoint', () => {
+    let state = enterFlooded();
+    state = reducePortageCacheState(state, {
+      type: 'REACH_PORTAGE_WAYPOINT',
+      segmentIndex: 11,
+    });
+    expect(portageRouteStatus(state, 11)).toBe('completed');
+
+    state = reducePortageCacheState(state, {
+      type: 'EXIT_SEGMENT',
+      segmentIndex: 11,
+      survived: true,
+    });
+    expect(portageRouteStatus(state, 11)).toBe('completed');
+  });
+
+  it('fails a skipped portage even when the player survived the rapid', () => {
+    let state = enterFlooded();
+    state = reducePortageCacheState(state, {
+      type: 'EXIT_SEGMENT',
+      segmentIndex: 11,
+      survived: true,
+    });
+    expect(portageRouteStatus(state, 11)).toBe('failed');
+  });
+
+  it('keeps the legacy pass-by-surviving rule for segment-scoped routes', () => {
+    const legacy = { portageRoutes: [{ ...SPATIAL_ROUTE, position: undefined }] };
+    let state = reducePortageCacheState(createPortageCacheRunState(legacy), {
+      type: 'ENTER_SEGMENT',
+      segmentIndex: 11,
+      requiresPortage: true,
+    });
+    state = reducePortageCacheState(state, {
+      type: 'EXIT_SEGMENT',
+      segmentIndex: 11,
+      survived: true,
+    });
+    expect(portageRouteStatus(state, 11)).toBe('completed');
+  });
+
+  it('does not resurrect a route that already failed', () => {
+    let state = enterFlooded();
+    state = reducePortageCacheState(state, { type: 'WIPEOUT', segmentIndex: 11 });
+    expect(portageRouteStatus(state, 11)).toBe('failed');
+
+    state = reducePortageCacheState(state, {
+      type: 'REACH_PORTAGE_WAYPOINT',
+      segmentIndex: 11,
+    });
+    expect(portageRouteStatus(state, 11)).toBe('failed');
+  });
+});
+
+describe('authored map metadata', () => {
+  it('gives meander a spatial cache and portage route to play', () => {
+    const meander = getMapSurvivalMetadata('meander');
+    expect(meander.cacheSlots?.[0].position).toBeDefined();
+    expect(meander.portageRoutes?.[0].position).toBeDefined();
+  });
+
+  it('gives the hydro dam-release set-piece a portage line and a cache', () => {
+    const hydro = getMapSurvivalMetadata('hydro');
+    expect(hydro.portageRoutes?.[0].position).toBeDefined();
+    expect(hydro.cacheSlots?.[0].position).toBeDefined();
+  });
+
+  it('keeps a segment-scoped map authored so the legacy path stays exercised', () => {
+    const delta = getMapSurvivalMetadata('delta');
+    expect(delta.portageRoutes?.[0].position).toBeUndefined();
+  });
+
+  it('authors every cache within its own segment ordering', () => {
+    for (const mapId of ['meander', 'hydro', 'delta'] as const) {
+      for (const slot of getMapSurvivalMetadata(mapId).cacheSlots ?? []) {
+        expect(slot.segmentIndex, `${mapId}/${slot.id}`).toBeGreaterThanOrEqual(0);
+        expect(slot.retrievalBonus, `${mapId}/${slot.id}`).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('raft paddle survival coupling', () => {
+  const loadout = getLoadoutDefinition('balanced');
+
+  it('sits at the loadout baseline when dry and thermally neutral', () => {
+    const mods = getSurvivalModifiers({ wetness: 0, coreTemp: 0.9 }, 'canyonSummer', loadout);
+    expect(mods.paddleCostMultiplier).toBeCloseTo(loadout.staminaDrainMultiplier, 5);
+    expect(mods.paddleRegenMultiplier).toBeCloseTo(loadout.staminaRegenMultiplier, 5);
+  });
+
+  it('starts a fresh run within a few percent of baseline', () => {
+    // A fresh state is coreTemp 1, which computeExposureStress reads as a touch
+    // of heat stress (pre-existing Track A behavior, visible on the HUD bar).
+    // The paddle economy should barely notice it.
+    const mods = getSurvivalModifiers(createSurvivalState(), 'canyonSummer', loadout);
+    expect(mods.paddleCostMultiplier / loadout.staminaDrainMultiplier).toBeLessThan(1.05);
+    expect(mods.paddleRegenMultiplier / loadout.staminaRegenMultiplier).toBeGreaterThan(0.95);
+  });
+
+  it('makes strokes cost more and refill slower when soaked', () => {
+    const dry = getSurvivalModifiers({ wetness: 0, coreTemp: 1 }, 'canyonSummer', loadout);
+    const soaked = getSurvivalModifiers({ wetness: 1, coreTemp: 1 }, 'canyonSummer', loadout);
+
+    expect(soaked.paddleCostMultiplier).toBeGreaterThan(dry.paddleCostMultiplier);
+    expect(soaked.paddleRegenMultiplier).toBeLessThan(dry.paddleRegenMultiplier);
+  });
+
+  it('compounds wetness with cold exposure on a glacier reach', () => {
+    const warm = getSurvivalModifiers({ wetness: 0.8, coreTemp: 1 }, 'canyonSummer', loadout);
+    const frozen = getSurvivalModifiers({ wetness: 0.8, coreTemp: 0.2 }, 'glacier', loadout);
+
+    expect(frozen.paddleCostMultiplier).toBeGreaterThan(warm.paddleCostMultiplier);
+    expect(frozen.paddleRegenMultiplier).toBeLessThan(warm.paddleRegenMultiplier);
+  });
+
+  it('keeps the modifiers inside playable bounds at worst case', () => {
+    const worst = getSurvivalModifiers({ wetness: 1, coreTemp: 0 }, 'glacier', loadout);
+    // Never free, never punishing enough to make a rapid unwinnable.
+    expect(worst.paddleCostMultiplier).toBeGreaterThan(1);
+    expect(worst.paddleCostMultiplier).toBeLessThan(2);
+    expect(worst.paddleRegenMultiplier).toBeGreaterThanOrEqual(0);
+    expect(worst.paddleRegenMultiplier).toBeLessThan(1);
+  });
+
+  it('reflects the loadout baseline in both paddle modifiers', () => {
+    const expedition = getLoadoutDefinition('expedition');
+    const state = { wetness: 0.5, coreTemp: 0.5 };
+    const balancedMods = getSurvivalModifiers(state, 'glacier', loadout);
+    const expeditionMods = getSurvivalModifiers(state, 'glacier', expedition);
+
+    expect(expeditionMods.paddleCostMultiplier / balancedMods.paddleCostMultiplier).toBeCloseTo(
+      expedition.staminaDrainMultiplier / loadout.staminaDrainMultiplier,
+      5,
+    );
+  });
+});

--- a/src/systems/__tests__/surfaceFriction.test.ts
+++ b/src/systems/__tests__/surfaceFriction.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Slipperiness → Rapier contact friction (survival v2 phase B).
+ *
+ * These lock the mapping the canyon collision mesh uses. The companion rule —
+ * that water-borne lateral drag stays in WaterFlowForces and is NOT re-applied
+ * here — is documented in surfaceFriction.ts and enforced by review, not code.
+ */
+
+import {
+  FORECAST_FRICTION,
+  ICE_MIN_FRICTION,
+  forecastFrictionOverride,
+  resolveSegmentFriction,
+  resolveSegmentRestitution,
+} from '../surfaceFriction';
+
+const ROCK_FRICTION = 1.0;
+
+describe('resolveSegmentFriction', () => {
+  it('returns the biome friction untouched on a normal, non-slippery segment', () => {
+    expect(resolveSegmentFriction({ baseFriction: ROCK_FRICTION })).toBe(ROCK_FRICTION);
+    expect(
+      resolveSegmentFriction({ baseFriction: ROCK_FRICTION, segmentState: 'Normal' }),
+    ).toBe(ROCK_FRICTION);
+  });
+
+  it('drops toward the ice floor as slipperiness rises', () => {
+    const glacier = resolveSegmentFriction({ baseFriction: ROCK_FRICTION, slipperiness: 0.9 });
+    expect(glacier).toBeLessThan(0.2);
+    expect(glacier).toBeGreaterThan(ICE_MIN_FRICTION);
+
+    const full = resolveSegmentFriction({ baseFriction: ROCK_FRICTION, slipperiness: 1 });
+    expect(full).toBeCloseTo(ICE_MIN_FRICTION, 6);
+  });
+
+  it('never returns exactly zero friction — Rapier jitters on frictionless contact', () => {
+    expect(resolveSegmentFriction({ baseFriction: 0.2, slipperiness: 1 })).toBeGreaterThan(0);
+  });
+
+  it('is monotonic: more slipperiness is never more grip', () => {
+    let previous = Infinity;
+    for (const slip of [0, 0.25, 0.5, 0.75, 1]) {
+      const friction = resolveSegmentFriction({ baseFriction: ROCK_FRICTION, slipperiness: slip });
+      expect(friction).toBeLessThanOrEqual(previous);
+      previous = friction;
+    }
+  });
+
+  it('applies flood-state friction floors, matching the shipped values', () => {
+    expect(resolveSegmentFriction({ baseFriction: ROCK_FRICTION, segmentState: 'WashedOut' }))
+      .toBe(FORECAST_FRICTION.WashedOut);
+    expect(resolveSegmentFriction({ baseFriction: ROCK_FRICTION, segmentState: 'Flooded' }))
+      .toBe(FORECAST_FRICTION.Flooded);
+    expect(resolveSegmentFriction({ baseFriction: ROCK_FRICTION, segmentState: 'HighFlow' }))
+      .toBe(FORECAST_FRICTION.HighFlow);
+  });
+
+  it('lets ice slicken an already-flooded segment, never re-grip it', () => {
+    const floodedIce = resolveSegmentFriction({
+      baseFriction: ROCK_FRICTION,
+      segmentState: 'Flooded',
+      slipperiness: 0.8,
+    });
+    expect(floodedIce).toBeLessThan(FORECAST_FRICTION.Flooded);
+  });
+
+  it('does not let a grippy biome undo a flood state', () => {
+    const flooded = resolveSegmentFriction({ baseFriction: 2, segmentState: 'Flooded' });
+    expect(flooded).toBe(FORECAST_FRICTION.Flooded);
+  });
+
+  it('clamps out-of-range and non-finite inputs', () => {
+    expect(resolveSegmentFriction({ baseFriction: ROCK_FRICTION, slipperiness: 5 }))
+      .toBeCloseTo(ICE_MIN_FRICTION, 6);
+    expect(resolveSegmentFriction({ baseFriction: ROCK_FRICTION, slipperiness: -3 }))
+      .toBe(ROCK_FRICTION);
+    expect(resolveSegmentFriction({ baseFriction: ROCK_FRICTION, slipperiness: NaN }))
+      .toBe(ROCK_FRICTION);
+    expect(resolveSegmentFriction({ baseFriction: NaN })).toBe(1);
+  });
+});
+
+describe('forecastFrictionOverride', () => {
+  it('is null for normal or unknown states', () => {
+    expect(forecastFrictionOverride()).toBeNull();
+    expect(forecastFrictionOverride('Normal')).toBeNull();
+    expect(forecastFrictionOverride('Wobbly')).toBeNull();
+  });
+});
+
+describe('resolveSegmentRestitution', () => {
+  it('leaves rock restitution alone and nudges ice to skip', () => {
+    expect(resolveSegmentRestitution(0.1, 0)).toBe(0.1);
+    expect(resolveSegmentRestitution(0.1, 1)).toBeGreaterThan(0.1);
+    expect(resolveSegmentRestitution(0.1, 1)).toBeLessThan(0.25);
+  });
+});

--- a/src/systems/portageCache.ts
+++ b/src/systems/portageCache.ts
@@ -8,14 +8,22 @@ export type CacheSlotStatus = 'unplaced' | 'placed' | 'retrieved' | 'lost';
 
 export type PortageRouteStatus = 'idle' | 'required' | 'in_progress' | 'completed' | 'failed';
 
-export interface CacheSlotDefinition {
+/** World-space waypoint an authored survival feature can occupy. */
+export interface SurvivalWaypoint {
+  /** World position [x, y, z]. Omit for a segment-scoped (non-spatial) feature. */
+  position?: [number, number, number];
+  /** Interaction radius in metres. Defaults to DEFAULT_WAYPOINT_RADIUS. */
+  radius?: number;
+}
+
+export interface CacheSlotDefinition extends SurvivalWaypoint {
   id: string;
   segmentIndex: number;
   label: string;
   retrievalBonus: number;
 }
 
-export interface PortageRouteDefinition {
+export interface PortageRouteDefinition extends SurvivalWaypoint {
   segmentIndex: number;
   label: string;
 }
@@ -25,11 +33,15 @@ export interface CacheSlotState {
   segmentIndex: number;
   status: CacheSlotStatus;
   retrievalBonus: number;
+  /** True when the slot has an authored world position (spatial interaction). */
+  spatial: boolean;
 }
 
 export interface PortageRouteState {
   segmentIndex: number;
   status: PortageRouteStatus;
+  /** True when the route has an authored waypoint the player must actually reach. */
+  spatial: boolean;
 }
 
 export interface PortageCacheRunState {
@@ -41,12 +53,19 @@ export type PortageCacheEvent =
   | { type: 'PLACE_CACHE'; slotId: string }
   | { type: 'ENTER_SEGMENT'; segmentIndex: number; requiresPortage: boolean }
   | { type: 'EXIT_SEGMENT'; segmentIndex: number; survived: boolean }
-  | { type: 'WIPEOUT'; segmentIndex: number };
+  | { type: 'WIPEOUT'; segmentIndex: number }
+  /** Player reached a spatial cache waypoint and picked the cache up. */
+  | { type: 'RETRIEVE_CACHE'; slotId: string }
+  /** Player walked the authored portage line for this segment. */
+  | { type: 'REACH_PORTAGE_WAYPOINT'; segmentIndex: number };
 
 export const DEFAULT_MAX_CACHE_PLACEMENTS = 1;
 
 export const CACHE_LOST_PENALTY = 300;
 export const PORTAGE_FAIL_PENALTY = 200;
+
+/** Interaction radius for an authored waypoint that doesn't specify one. */
+export const DEFAULT_WAYPOINT_RADIUS = 6;
 
 function cloneState(state: PortageCacheRunState): PortageCacheRunState {
   return {
@@ -65,10 +84,12 @@ export function createPortageCacheRunState(options: {
       segmentIndex: slot.segmentIndex,
       status: 'unplaced',
       retrievalBonus: slot.retrievalBonus,
+      spatial: Boolean(slot.position),
     })),
     portageRoutes: (options.portageRoutes ?? []).map((route) => ({
       segmentIndex: route.segmentIndex,
       status: 'idle',
+      spatial: Boolean(route.position),
     })),
   };
 }
@@ -115,8 +136,15 @@ export function reducePortageCacheState(
     }
 
     case 'ENTER_SEGMENT': {
+      // Segment-scoped slots are collected by entering the segment. Spatial slots
+      // have an authored waypoint and are collected by RETRIEVE_CACHE instead —
+      // otherwise the marker would pop the moment the segment streams in.
       for (const slot of next.cacheSlots) {
-        if (slot.segmentIndex === event.segmentIndex && slot.status === 'placed') {
+        if (
+          !slot.spatial &&
+          slot.segmentIndex === event.segmentIndex &&
+          slot.status === 'placed'
+        ) {
           slot.status = 'retrieved';
         }
       }
@@ -137,7 +165,27 @@ export function reducePortageCacheState(
       const route = next.portageRoutes.find((entry) => entry.segmentIndex === event.segmentIndex);
       if (!route) return next;
       if (route.status === 'in_progress' || route.status === 'required') {
-        route.status = event.survived ? 'completed' : 'failed';
+        // A spatial route is only completed by actually reaching its waypoint
+        // (REACH_PORTAGE_WAYPOINT sets 'completed' before we get here). Surviving
+        // the rapid you were supposed to portage around is a fail, not a pass —
+        // that is what makes the choice cost something.
+        route.status = !route.spatial && event.survived ? 'completed' : 'failed';
+      }
+      return next;
+    }
+
+    case 'RETRIEVE_CACHE': {
+      const slot = next.cacheSlots.find((entry) => entry.id === event.slotId);
+      if (slot && slot.status === 'placed') {
+        slot.status = 'retrieved';
+      }
+      return next;
+    }
+
+    case 'REACH_PORTAGE_WAYPOINT': {
+      const route = next.portageRoutes.find((entry) => entry.segmentIndex === event.segmentIndex);
+      if (route && route.status !== 'failed') {
+        route.status = 'completed';
       }
       return next;
     }
@@ -186,4 +234,90 @@ export function pendingRetrievalBonus(state: PortageCacheRunState, segmentIndex:
   return state.cacheSlots
     .filter((slot) => slot.segmentIndex === segmentIndex && slot.status === 'retrieved')
     .reduce((sum, slot) => sum + slot.retrievalBonus, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Spatial helpers — pure geometry, no THREE dependency so they stay testable.
+// ---------------------------------------------------------------------------
+
+export interface WorldPoint {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/** Squared XZ distance — vertical offset is ignored so a rim shelf still triggers. */
+function planarDistanceSq(point: WorldPoint, position: [number, number, number]): number {
+  const dx = point.x - position[0];
+  const dz = point.z - position[2];
+  return dx * dx + dz * dz;
+}
+
+/** True when `point` is inside the waypoint's interaction radius (XZ plane). */
+export function isWithinWaypoint(waypoint: SurvivalWaypoint, point: WorldPoint): boolean {
+  if (!waypoint.position) return false;
+  const radius = waypoint.radius ?? DEFAULT_WAYPOINT_RADIUS;
+  return planarDistanceSq(point, waypoint.position) <= radius * radius;
+}
+
+/**
+ * The cache slot whose waypoint contains `point`, or null. When several overlap,
+ * the nearest wins so a dense authoring cluster still behaves predictably.
+ */
+export function findCacheSlotAt<T extends CacheSlotDefinition>(
+  slots: ReadonlyArray<T>,
+  point: WorldPoint,
+): T | null {
+  let best: T | null = null;
+  let bestDistSq = Infinity;
+
+  for (const slot of slots) {
+    if (!slot.position || !isWithinWaypoint(slot, point)) continue;
+    const distSq = planarDistanceSq(point, slot.position);
+    if (distSq < bestDistSq) {
+      best = slot;
+      bestDistSq = distSq;
+    }
+  }
+
+  return best;
+}
+
+/** The portage route whose waypoint contains `point`, or null. */
+export function findPortageRouteAt<T extends PortageRouteDefinition>(
+  routes: ReadonlyArray<T>,
+  point: WorldPoint,
+): T | null {
+  for (const route of routes) {
+    if (isWithinWaypoint(route, point)) return route;
+  }
+  return null;
+}
+
+/** Routes the player still owes on this segment (required or under way). */
+export function pendingPortageRoutes(
+  state: PortageCacheRunState,
+): ReadonlyArray<PortageRouteState> {
+  return state.portageRoutes.filter(
+    (route) => route.status === 'required' || route.status === 'in_progress',
+  );
+}
+
+/** Status of a single route, or null when the segment has no authored route. */
+export function portageRouteStatus(
+  state: PortageCacheRunState,
+  segmentIndex: number,
+): PortageRouteStatus | null {
+  return (
+    state.portageRoutes.find((route) => route.segmentIndex === segmentIndex)?.status ?? null
+  );
+}
+
+/** Cache slots that can still be interacted with (drawn as world markers). */
+export function activeCacheSlots(
+  state: PortageCacheRunState,
+): ReadonlyArray<CacheSlotState> {
+  return state.cacheSlots.filter(
+    (slot) => slot.status === 'unplaced' || slot.status === 'placed',
+  );
 }

--- a/src/systems/runSession.ts
+++ b/src/systems/runSession.ts
@@ -206,6 +206,34 @@ export function getJourneyResultsSummary(): JourneyResultsSummary | null {
   };
 }
 
+/**
+ * Dry gear + a hot drink. Retrieving a cache is the only mid-run way to undo
+ * wetness, which is what makes placing one before a cold reach a real decision:
+ * you trade a scoring bonus slot for insurance against the glacier leg.
+ */
+export const CACHE_WETNESS_RECOVERY = 0.45;
+export const CACHE_WARMTH_RECOVERY = 0.25;
+
+/**
+ * Apply a retrieved cache's survival relief. Returns the new survival state, or
+ * null when no run is active. Idempotence is the caller's job — retrieval is
+ * gated by the state machine, which only flips a slot to 'retrieved' once.
+ */
+export function applyCacheRecovery(): SurvivalState | null {
+  if (!activeSession) return null;
+  const survival = {
+    wetness: Math.max(0, activeSession.survival.wetness - CACHE_WETNESS_RECOVERY),
+    coreTemp: Math.min(1, activeSession.survival.coreTemp + CACHE_WARMTH_RECOVERY),
+  };
+  activeSession = { ...activeSession, survival };
+  return survival;
+}
+
+/** Live portage/cache state — read by the world markers. */
+export function getPortageCacheState(): PortageCacheRunState | null {
+  return activeSession?.portageCache ?? null;
+}
+
 export function dispatchPortageCacheEvent(event: PortageCacheEvent): PortageCacheRunState | null {
   if (!activeSession) return null;
   activeSession = {

--- a/src/systems/surfaceFriction.ts
+++ b/src/systems/surfaceFriction.ts
@@ -1,0 +1,87 @@
+/**
+ * surfaceFriction.ts — Segment surface friction resolution (pure).
+ *
+ * OWNERSHIP (read before tuning — these two systems must not double-count):
+ *
+ *   - **Rapier contact friction (this module)** owns *solid contact*: the runner's
+ *     feet on the canyon floor, hull scrapes along the walls. It is what makes an
+ *     ice chute feel like ice when you touch it.
+ *   - **`WaterFlowForces`** owns *water-borne lateral drag*: how hard the current
+ *     resists a sideways move while you are floating. It applies its own
+ *     `slipperiness` attenuation (lateral drag × (1 − slip × 0.8) plus a downstream
+ *     slide bias).
+ *
+ * They act on disjoint interactions — contact vs fluid — so both may read the same
+ * `slipperiness` without stacking. What must NOT happen is a second contact-friction
+ * scaler somewhere else, or a fluid-drag term added here.
+ *
+ * Consumed by `TrackSegmentMeshes` for the collision trimesh. Closes the
+ * "wire slipperiness into Rapier" TODO in MapSystem.types.ts / LEVEL_DESIGN.md.
+ */
+
+/** Friction of a fully frictionless (slipperiness = 1) surface. Never exactly 0 —
+ *  Rapier bodies with zero friction can slide forever and jitter against walls. */
+export const ICE_MIN_FRICTION = 0.04;
+
+/**
+ * Flood-state friction floors, applied before slipperiness. Wet rock and washed-out
+ * debris are already slick; these mirror the values TrackSegmentMeshes shipped with.
+ */
+export const FORECAST_FRICTION: Record<string, number> = {
+  WashedOut: 0.35,
+  Flooded: 0.55,
+  HighFlow: 0.8,
+};
+
+export interface SegmentFrictionInput {
+  /** Biome contact friction (`biomeProfile.wallFriction`). */
+  baseFriction: number;
+  /** Authored surface slipperiness 0–1 (+ forecast `slipperinessAdd`). */
+  slipperiness?: number;
+  /** FlowForecast segment state ('Normal' | 'HighFlow' | 'Flooded' | 'WashedOut'). */
+  segmentState?: string;
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+/** Flood-state override for this segment, or null when the state is normal. */
+export function forecastFrictionOverride(segmentState?: string): number | null {
+  if (!segmentState) return null;
+  const override = FORECAST_FRICTION[segmentState];
+  return override === undefined ? null : override;
+}
+
+/**
+ * Resolve the Rapier contact friction for a segment's collision mesh.
+ *
+ * Order: flood state sets the baseline (wet rock overrides the biome), then
+ * slipperiness interpolates that baseline toward `ICE_MIN_FRICTION`.
+ *
+ * Slipperiness is monotonic downward by construction — it can only ever make a
+ * surface slicker, never grippier, so authoring ice on a flooded segment can't
+ * accidentally hand the player back their grip.
+ */
+export function resolveSegmentFriction(input: SegmentFrictionInput): number {
+  const base = Number.isFinite(input.baseFriction) ? input.baseFriction : 1;
+  const flooded = forecastFrictionOverride(input.segmentState);
+  const baseline = flooded ?? base;
+  const slip = clamp01(input.slipperiness ?? 0);
+  if (slip <= 0) return baseline;
+  return baseline + (ICE_MIN_FRICTION - baseline) * slip;
+}
+
+/**
+ * Restitution for a segment's collision mesh. Ice is glassier than rock, so a
+ * slippery surface also nudges bounce up slightly — the chute should skip the
+ * player along a wall rather than stopping them dead.
+ */
+export function resolveSegmentRestitution(
+  baseRestitution: number,
+  slipperiness?: number,
+): number {
+  const slip = clamp01(slipperiness ?? 0);
+  return baseRestitution + (0.25 - baseRestitution) * slip * 0.5;
+}

--- a/src/systems/survival/survivalState.ts
+++ b/src/systems/survival/survivalState.ts
@@ -32,6 +32,13 @@ export interface SurvivalModifiers {
   exposureStress: number;
   /** Wetness-based SFX attenuation (1 = dry, lower = muffled). */
   sfxWetnessMultiplier: number;
+  /**
+   * Raft paddle stroke cost multiplier (≥1). Cold, stiff hands and a soaked
+   * jacket make each stroke cost more stamina.
+   */
+  paddleCostMultiplier: number;
+  /** Raft paddle stamina regen multiplier (≤1). Shivering recovers slower. */
+  paddleRegenMultiplier: number;
 }
 
 export const SURVIVAL_INITIAL: SurvivalState = {
@@ -62,6 +69,18 @@ const WETNESS_DRY_BASE = 0.08;
 const WETNESS_WIND_DRY_SCALE = 0.025;
 const TEMP_LERP_RATE = 0.35;
 const WETNESS_COLD_PENALTY = 0.18;
+
+/**
+ * Raft paddle coupling. The raft has no sprint, so wetness/exposure land on the
+ * paddle economy instead: strokes cost more and the bar refills slower. Bounds
+ * are deliberately gentler than the runner's sprint penalties — the raft cannot
+ * choose to stop paddling in a rapid, so a harsh curve reads as unfair rather
+ * than tense.
+ */
+const PADDLE_COST_WETNESS = 0.2;
+const PADDLE_COST_EXPOSURE = 0.35;
+const PADDLE_REGEN_WETNESS = 0.18;
+const PADDLE_REGEN_EXPOSURE = 0.4;
 
 function clamp01(value: number): number {
   return Math.min(1, Math.max(0, value));
@@ -146,11 +165,21 @@ export function getSurvivalModifiers(
 
   const sfxWetnessMultiplier = 1 - state.wetness * 0.35;
 
+  // Raft paddle economy — see the PADDLE_* constants above.
+  const paddleCostMultiplier =
+    loadout.staminaDrainMultiplier *
+    (1 + state.wetness * PADDLE_COST_WETNESS + exposureStress * PADDLE_COST_EXPOSURE);
+  const paddleRegenMultiplier =
+    loadout.staminaRegenMultiplier *
+    clamp01(1 - state.wetness * PADDLE_REGEN_WETNESS - exposureStress * PADDLE_REGEN_EXPOSURE);
+
   return {
     staminaDrainMultiplier: staminaDrainMul,
     staminaRegenMultiplier: staminaRegenMul,
     movementMultiplier: movementMul,
     exposureStress,
     sfxWetnessMultiplier,
+    paddleCostMultiplier,
+    paddleRegenMultiplier,
   };
 }

--- a/src/vehicles/RaftVehicle/hooks/raftPhysicsRuntime.ts
+++ b/src/vehicles/RaftVehicle/hooks/raftPhysicsRuntime.ts
@@ -19,6 +19,8 @@ import {
   tickLaunchScoring,
   hasActiveLaunch,
 } from '../../../systems/LaunchScoringSession';
+import { tickRunSurvival } from '../../../systems/runSession';
+import { isBiomeId, type BiomeId } from '../../../configs/biomes';
 
 export interface RaftPhysicsRuntimeDeps {
   buoyancyState: { current: any };
@@ -215,6 +217,34 @@ const handleTipping = (body: any, delta: number): boolean => {
 };
 
 /**
+ * Survival coupling for the raft (Track A v2).
+ *
+ * The runner ticks survival from RunnerPhysicsStep; the raft is the other half of
+ * that loop. `inWater` is the raft actually floating rather than a height test —
+ * a raft riding a wave crest is still soaking its occupant.
+ *
+ * Returns the live modifiers so the paddle economy can read them; null when no
+ * run session is active (free-play / editor), in which case stamina behaves
+ * exactly as it did before survival existed.
+ */
+const tickRaftSurvival = (body: any, delta: number) => {
+  const vel = body?.linvel?.();
+  const windSpeed = vel ? Math.sqrt(vel.x * vel.x + vel.z * vel.z) : 0;
+  const storeBiome = useGameStore.getState().currentBiome;
+  const biomeId: BiomeId = isBiomeId(storeBiome) ? storeBiome : 'canyonSummer';
+
+  return tickRunSurvival({
+    dt: delta,
+    biomeId,
+    inWater: deps.buoyancyState.current.isFloating === true,
+    windSpeed,
+  });
+};
+
+/** Paddle-economy multipliers from the last survival tick (1 = unaffected). */
+const paddleModifiers = { cost: 1, regen: 1 };
+
+/**
  * Update stamina state each frame (regen, exhaustion tracking)
  */
 const updateStamina = (delta: number) => {
@@ -226,9 +256,12 @@ const updateStamina = (delta: number) => {
     return;
   }
 
-  // Regenerate stamina
+  // Regenerate stamina — wetness and cold exposure slow the refill.
   if (st.current < STAMINA.MAX) {
-    st.current = Math.min(STAMINA.MAX, st.current + STAMINA.REGEN_RATE * delta);
+    st.current = Math.min(
+      STAMINA.MAX,
+      st.current + STAMINA.REGEN_RATE * paddleModifiers.regen * delta,
+    );
   }
 
   // Clear exhaustion when recovered enough
@@ -248,7 +281,8 @@ const consumeStamina = (): number => {
     return 0;
   }
 
-  st.current = Math.max(0, st.current - STAMINA.COST);
+  // Cold, stiff hands and a soaked jacket make each stroke cost more.
+  st.current = Math.max(0, st.current - STAMINA.COST * paddleModifiers.cost);
   st.regenDelay = STAMINA.REGEN_DELAY;
 
   if (st.current < STAMINA.EXHAUSTED_THRESHOLD) {
@@ -613,6 +647,8 @@ const updateWorkerPhysicsFrame = (body: any, delta: number) => {
     applyTippingForce,
     dampenRotation,
     handleTipping,
+    tickRaftSurvival,
+    paddleModifiers,
     updateStamina,
     consumeStamina,
     applyBrake,

--- a/src/vehicles/RaftVehicle/hooks/useRaftControls.ts
+++ b/src/vehicles/RaftVehicle/hooks/useRaftControls.ts
@@ -123,6 +123,14 @@ export function useRaftControls({
     }
 
     timeRef.current += delta;
+
+    // Survival (wetness / core temp) ticks before stamina so this frame's paddle
+    // economy already reflects it. No run session (free play, editor) → null, and
+    // the modifiers stay at 1.
+    const survivalMods = runtime.tickRaftSurvival(body, delta);
+    runtime.paddleModifiers.cost = survivalMods?.paddleCostMultiplier ?? 1;
+    runtime.paddleModifiers.regen = survivalMods?.paddleRegenMultiplier ?? 1;
+
     runtime.updateStamina(delta);
 
     if (stunState.current.active) {


### PR DESCRIPTION
Implements phases A–C of survival v2. Phase D (safe-zone OOB) is untouched and still open.

## ⚠️ Also fixes a typecheck break on `main`

`main` is currently red: `createRiverSurfaceMaterial` widened its return to `THREE.Material` in #363, which stopped narrowing for call sites passing a `MeshStandardMaterial` (`TrackManager` → `PooledObstacles`). It only surfaced once #363 merged alongside a concurrent change. Fixed here with an overload so a standard source returns a standard material again — worth merging for that alone if the rest needs more review time. Sorry for the breakage.

## Phase A — spatial portage & caches

Cache slots and portage routes may now carry an authored `position` + `radius`. Both forms coexist:

| Form | Interaction | Maps |
|------|-------------|------|
| Spatial | Steer within the waypoint radius (XZ; height ignored) | `meander`, `hydro` |
| Segment-scoped | Entering the segment is the whole interaction | `delta` (kept deliberately, so the legacy path stays exercised) |

`SurvivalMarkers` draws a ground ring + beacon per live waypoint and drives the state machine from proximity at 10 Hz. **No interact key** — the player is moving at speed down a river, and "steer through the marker" is the verb the rest of the game already uses.

Two rules make the choice cost something:

- **A spatial portage completes only by reaching its waypoint.** Surviving the flooded line instead of walking around it is a `failed` route and a `PORTAGE FAILED` penalty. Failure is sticky — a wipeout mid-portage can't be undone by reaching the waypoint afterwards.
- **Retrieval grants survival relief, not just score**: −0.45 wetness, +0.25 core temp. That's the only mid-run way to undo wetness, so stashing a cache before a cold reach is real insurance bought with a scoring slot.

## Phase B — slipperiness → Rapier friction

New pure `surfaceFriction.ts`, wired through `TrackManager` → `TrackSegment` → the collision trimesh. Flood state sets the baseline (`WashedOut` 0.35 / `Flooded` 0.55 / `HighFlow` 0.8 / else biome), then slipperiness interpolates it toward `ICE_MIN_FRICTION` = 0.04 — never 0, since frictionless Rapier contacts jitter and slide forever.

Ownership is documented in the module, `SURVIVAL_LAYER.md`, `LEVEL_DESIGN.md`, and `MapSystem.types.ts`: **contact friction here, fluid drag in `WaterFlowForces`**, acting on disjoint interactions so the two never double-count. Retires the TODOs in both files.

## Phase C — raft survival coupling

`SurvivalModifiers` gains `paddleCostMultiplier` / `paddleRegenMultiplier`; `raftPhysicsRuntime` now ticks survival each frame (`inWater` = the raft actually floating, not a height test) and applies them to stroke cost and regen. Curves are deliberately gentler than the runner's sprint penalties — the raft can't choose to stop paddling mid-rapid, so a harsh curve reads as unfair rather than tense. The HUD WET/EXPOSURE bars were already vehicle-agnostic and show in raft mode.

## Verification

`pnpm typecheck`, `pnpm test` (631 passed, 5 skipped — 34 new cases), `pnpm build`, and `pnpm test:visual-smoke` all green.

**The authored waypoint positions are unplaytested.** They're first-pass values aligned with the existing checkpoint table, and this container can't drive an in-run session (the smoke harness can't click Start here — pre-existing, reproduced on `main` in earlier sessions). The state machine, geometry, and modifiers are covered by unit tests; whether the meander rim shelf is actually reachable at speed needs someone on a GPU machine. Flagged as a follow-up in `SURVIVAL_LAYER.md`.

One pre-existing quirk noted while testing, not changed: a fresh survival state is `coreTemp: 1`, which `computeExposureStress` reads as slight heat stress, so every run starts with ~0.1 exposure on the HUD. Left alone since changing it would shift runner balance.

---
_Generated by [Claude Code](https://claude.ai/code/session_019wBgYjuU9xtThS7Fpqnj8u)_