### PR TITLE
deploy: let --dry-run run without DEPLOY_TOKEN or network

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -136,20 +136,21 @@ def main():
         print("Please run your build command first (e.g. `npm run build`).")
         sys.exit(1)
 
-    if not DEPLOY_TOKEN:
-        print(
-            "ERROR: DEPLOY_TOKEN is not set. Export the deploy token before deploying:\n"
-            '  export DEPLOY_TOKEN="<your_token_from_vps_env>"',
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    if not args.dry_run:
+        if not DEPLOY_TOKEN:
+            print(
+                "ERROR: DEPLOY_TOKEN is not set. Export the deploy token before deploying:\n"
+                '  export DEPLOY_TOKEN="<your_token_from_vps_env>"',
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
-    try:
-        health = requests.get(f"{CONTABO_BASE_URL}/api/deploy/health", timeout=10)
-        if health.status_code == 200:
-            print(f"Contabo deploy service: {health.json().get('status', 'unknown')}")
-    except Exception:
-        print("Warning: Could not contact storage.noahcohn.com (continuing anyway).")
+        try:
+            health = requests.get(f"{CONTABO_BASE_URL}/api/deploy/health", timeout=10)
+            if health.status_code == 200:
+                print(f"Contabo deploy service: {health.json().get('status', 'unknown')}")
+        except Exception:
+            print("Warning: Could not contact storage.noahcohn.com (continuing anyway).")
 
     success = deploy_bundle(build_path, dry_run=args.dry_run)
 


### PR DESCRIPTION
## Summary
Whole-stack pipeline-health pass (install → typecheck → test → build → WASM integrity → deploy dry-run). One config-hygiene fix found and applied; everything else is reported, not changed.

- `deploy.py`'s `--dry-run` required `DEPLOY_TOKEN` to be set and pinged the Contabo health endpoint before ever reaching `deploy_bundle()`, even though dry-run explicitly stops before any upload/auth. Gated both the token check and the health-check network call behind `not args.dry_run`, so dry-run now runs with no secret and no network dependency. The real (non-dry-run) path is unchanged: it still requires `DEPLOY_TOKEN` and fails loud if unset.

## Pipeline-health findings (no code changes beyond the fix above)

**Green:**
- `pnpm install` — clean, `pnpm-lock.yaml` unchanged, no drift.
- `pnpm test` — 597 passed, 5 skipped, 0 failed (exit 0).
- `pnpm run build` — succeeds (exit 0). `build/index.html` uses relative `./assets/...` paths (`base: './'` honored). `watershed_native.js`/`.wasm` and `rapier.wasm` are copied into `build/` root byte-identical to the committed `public/` versions (Vite copies `public/` verbatim). Emscripten toolchain isn't installed in this environment, so `npm run build:wasm` prints `Emscripten not found — skipping WASM compile` and falls back to the pre-built `public/watershed_native.wasm` — expected in a non-emsdk environment, not a regression.
- WASM integrity: `WatershedWasm.ts` loads `watershed_native.js` via `resolvePublicAsset()`, which respects `__WATERSHED_ASSET_BASE__` (`'./'`) — consistent with the build's relative-path layout. The graceful-fallback path is intact: `getWorkerWasm()` (`src/physics/workerWasm.ts`) catches load failure and returns `null` so Rapier falls back to TS math; all direct `getWasm()` call sites (`GameHUD.tsx`, `WasmWaterForceTest.tsx`, `WaterForceSystem.tsx`) attach `.catch()`.
- `deploy.py` dry-run: `build_zip()` walks `build/` via `rglob("*")` — no hardcoded asset names — and correctly includes `watershed_native.js`/`.wasm` in the manifest. Confirmed `DEPLOY_TOKEN` is read from `os.environ` only, no secret printed or committed, and the real deploy path still fails loud without it.
- `.gitignore` already covers `build/` and `node_modules/`; no untracked build artifacts after a full build.

**Drifted (reported, not fixed per task scope — `src/components/` is mid typecheck-conversion, out of bounds for this pass):**
- `pnpm typecheck` fails (exit 2), one error:
  ```
  src/components/TrackManager.tsx(547,52): error TS2740: Type 'Material' is missing the
  following properties from type 'MeshStandardMaterial': isMeshStandardMaterial, color,
  roughness, metalness, and 28 more.
  ```
  Root cause: `TrackManager.tsx`'s `rockMaterial` is built via `useMemo` that can return either a `THREE.MeshStandardMaterial` (fallback branch) or `createRiverSurfaceMaterial(...)` (try branch), whose return type is the widened `THREE.Material` (`src/materials/river/createRiverSurfaceMaterial.ts`). That widens `rockMaterial`'s inferred type, which then fails to satisfy `PooledObstaclesProps.rockMaterial?: THREE.MeshStandardMaterial` (`src/components/Environment/types.ts:152`) at the `<PooledObstacles rockMaterial={rockMaterial} />` call site. Likely fallout from the recent TSL material-host work (#256 path A / PR #363) — needs a real fix in `src/components/`, left untouched per task instructions.

## Test plan
- [x] `pnpm install` — clean
- [x] `pnpm typecheck` — reproduced and documented the one failure above (not fixed, out of scope)
- [x] `pnpm test` — 597 passed / 5 skipped
- [x] `pnpm run build` — succeeds, verified relative asset paths and WASM bundling in `build/`
- [x] `python3 deploy.py --dry-run` — verified works with `DEPLOY_TOKEN` unset after the fix, and that `deploy_bundle()`'s manifest includes the WASM assets
- [x] `python3 deploy.py` (no `--dry-run`, no token) — still fails loud requiring `DEPLOY_TOKEN`, confirming the real deploy path is untouched


---
_Generated by [Claude Code](https://claude.ai/code/session_01ERAFNcvYtpFHFebHfoM6WG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dry-run deployments no longer require a deployment token.
  * Dry-run deployments no longer contact the deployment service for health checks.
  * Regular deployments continue to validate credentials and service availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->