### PR TITLE
Split emscripten shared header into common.h/forces.h/swe.h

### DIFF
--- a/SYSTEMS.md
+++ b/SYSTEMS.md
@@ -512,10 +512,10 @@ gameplay-affecting and must run identically at every preset.
 
 ### `src/systems/WatershedWasm.ts` + `emscripten/`
 
-**Layout:** `emscripten/watershed_native.h` (shared declarations) + `forces.cpp` (water force
-math) + `swe.cpp` (solver + heap grids) + `bindings.cpp` (Embind surface, `getVersion()` — 3).
-All compile/link flags live in `CMakeLists.txt`; `build.sh` and the `SOURCES` list are the only
-places a new translation unit must be registered.
+**Layout:** `emscripten/common.h` (shared constants/types) + `forces.h`/`forces.cpp` (water force
+math) + `swe.h`/`swe.cpp` (solver + heap grids) + `bindings.cpp` (the only `<emscripten/bind.h>`
+include; Embind surface, `getVersion()` — 4). All compile/link flags live in `CMakeLists.txt`;
+`build.sh` and the `SOURCES` list are the only places a new translation unit must be registered.
 
 **Purpose:** Optional C++/WASM acceleration layer for computationally intensive physics:
 Archimedes buoyancy, drag force, river-current flow force, and a linearised

--- a/WASM.md
+++ b/WASM.md
@@ -28,10 +28,12 @@ TypeScript bindings are in `src/systems/WatershedWasm.ts`.
 
 ```
 emscripten/
-├── watershed_native.h # Shared declarations, constants, value types
+├── common.h          # Shared constants, Vec3, clampf — Embind-free
+├── forces.h          # WaterForceResult + water-force declarations — Embind-free
 ├── forces.cpp        # Buoyancy / drag / flow / batched water forces
+├── swe.h             # Shallow-water solver + heap grid declarations — Embind-free
 ├── swe.cpp           # Shallow-water solver + heap grid helpers
-├── bindings.cpp      # getVersion() + the Embind surface (the ABI)
+├── bindings.cpp      # getVersion() + the ONLY <emscripten/bind.h> include (the ABI)
 ├── build.sh          # Bash build script (wraps CMake)
 └── CMakeLists.txt    # CMake build configuration — ALL compile/link flags live here
 
@@ -103,20 +105,24 @@ and callable after `await getWasm()`.
 
 ### `getVersion(): number`
 
-Returns the module ABI version integer. Bump in `bindings.cpp` whenever the
-exported surface or a batch stride changes.
+Returns the module ABI version integer (currently 4). Bump in `bindings.cpp`
+whenever the exported surface or a batch stride changes. `WatershedWasm.ts`
+asserts with `>=` so a future minor bump never breaks existing callers.
 
 | Version | Change |
 |---------|--------|
 | 1 | Initial buoyancy / drag / flow surface |
 | 2 | Batched `computeWaterForcesBatch` + SWE grid helpers |
 | 3 | Split into `forces.cpp` / `swe.cpp` / `bindings.cpp` (no signature changes) |
+| 4 | Split shared header into `common.h` / `forces.h` / `swe.h`; reordered Embind `value_object` registration ahead of the functions that use them; added `static_assert` non-polymorphic guards (no signature changes) |
 
 ### Adding a translation unit
 
 Add the `.cpp` to `set(SOURCES …)` in `CMakeLists.txt` **and** to the `em++`
-invocation in `build_colab.sh`, declare its exports in `watershed_native.h`, and
-bind them in `bindings.cpp`. Never put compile or link flags in a shell script.
+invocation in `build_colab.sh`, declare its exports in a Embind-free header
+(`common.h`, or a new `<unit>.h` that includes it), and bind them in
+`bindings.cpp` — the only file allowed to include `<emscripten/bind.h>`. Never
+put compile or link flags in a shell script.
 
 ### `computeBuoyancy(submergedVolume, waterDensity, gravity): number`
 

--- a/docs/reference/ADR_WASM_RAPIER_WATER_FORCES.md
+++ b/docs/reference/ADR_WASM_RAPIER_WATER_FORCES.md
@@ -238,12 +238,13 @@ one growing translation unit:
 
 | File | Owns |
 |------|------|
-| `emscripten/watershed_native.h` | Shared constants, `Vec3` / `WaterForceResult`, declarations |
-| `emscripten/forces.cpp` | Buoyancy, drag, flow, `calculateWaterForce`, `computeWaterForcesBatch` |
-| `emscripten/swe.cpp` | `stepShallowWater`, `allocateGrid` / `freeGrid` |
-| `emscripten/bindings.cpp` | `getVersion()` and the Embind surface — the ABI |
+| `emscripten/common.h` | Shared constants, `Vec3`, `clampf` — Embind-free |
+| `emscripten/forces.h` / `forces.cpp` | `WaterForceResult`; buoyancy, drag, flow, `calculateWaterForce`, `computeWaterForcesBatch` |
+| `emscripten/swe.h` / `swe.cpp` | `stepShallowWater`, `allocateGrid` / `freeGrid` |
+| `emscripten/bindings.cpp` | `getVersion()` and the Embind surface — the ABI; the only file including `<emscripten/bind.h>` |
 
-`getVersion()` is 3 as of the split. All compile/link flags stay in `CMakeLists.txt`.
+`getVersion()` is 4 as of the header split (registration order + static_assert guards added).
+All compile/link flags stay in `CMakeLists.txt`.
 
 ## Consequences
 

--- a/docs/reference/WASM_WATER_FORCES.md
+++ b/docs/reference/WASM_WATER_FORCES.md
@@ -2,9 +2,9 @@
 
 Architecture decision: see [ADR_WASM_RAPIER_WATER_FORCES.md](./ADR_WASM_RAPIER_WATER_FORCES.md).
 
-Watershed's native module lives in `emscripten/` — `forces.cpp` (water force math),
-`swe.cpp` (shallow-water solver + heap grids), `bindings.cpp` (the Embind ABI), with
-shared declarations in `watershed_native.h`. It builds to:
+Watershed's native module lives in `emscripten/` — `forces.h`/`forces.cpp` (water force math),
+`swe.h`/`swe.cpp` (shallow-water solver + heap grids), `bindings.cpp` (the only file including
+`<emscripten/bind.h>`; the Embind ABI), with shared constants/types in `common.h`. It builds to:
 
 - `public/watershed_native.js`
 - `public/watershed_native.wasm`

--- a/emscripten/bindings.cpp
+++ b/emscripten/bindings.cpp
@@ -6,6 +6,9 @@
  * changing a signature (or a batch stride) means bumping getVersion() below and
  * updating WASM.md.
  *
+ * This is the only translation unit that includes <emscripten/bind.h> — every
+ * other header (common.h, forces.h, swe.h) stays Embind-free.
+ *
  * Build:
  *   cd emscripten && ./build.sh
  *   (or) npm run build:wasm
@@ -15,32 +18,39 @@
  *   public/watershed_native.wasm — WASM binary
  */
 
-#include "watershed_native.h"
+#include "forces.h"
+#include "swe.h"
 
 #include <emscripten/bind.h>
+#include <type_traits>
 
 // ---------------------------------------------------------------------------
 // Version history
 //   1 — initial buoyancy/drag/flow surface
 //   2 — batched computeWaterForcesBatch + SWE grid helpers
 //   3 — split into forces.cpp / swe.cpp / bindings.cpp (no signature changes)
+//   4 — split shared header into common.h / forces.h / swe.h; reordered
+//       Embind value_object registration ahead of the functions that use
+//       them; added static_assert non-polymorphic guards (no signature
+//       changes)
 // ---------------------------------------------------------------------------
 int getVersion() noexcept {
-    return 3;
+    return 4;
 }
 
-EMSCRIPTEN_BINDINGS(watershed_native) {
-    emscripten::function("getVersion",       &getVersion);
-    emscripten::function("calculateBuoyancyAndDrag", &calculateBuoyancyAndDrag);
-    emscripten::function("calculateWaterForce", &calculateWaterForce);
-    emscripten::function("computeWaterForcesBatch", &computeWaterForcesBatch);
-    emscripten::function("computeBuoyancy",  &computeBuoyancy);
-    emscripten::function("computeDragForce", &computeDragForce);
-    emscripten::function("computeFlowForce", &computeFlowForce);
-    emscripten::function("stepShallowWater", &stepShallowWater);
-    emscripten::function("allocateGrid",     &allocateGrid);
-    emscripten::function("freeGrid",         &freeGrid);
+// ---------------------------------------------------------------------------
+// RTTI safety: every type crossing the Embind boundary must be concrete and
+// non-polymorphic (Embind needs RTTI to resolve base-class pointers, which
+// this module doesn't have — it's built with -fno-rtti).
+// ---------------------------------------------------------------------------
+static_assert(!std::is_polymorphic_v<Vec3>,
+              "Vec3 must be non-polymorphic to cross the Embind boundary");
+static_assert(!std::is_polymorphic_v<WaterForceResult>,
+              "WaterForceResult must be non-polymorphic to cross the Embind boundary");
 
+EMSCRIPTEN_BINDINGS(watershed_native) {
+    // Value types must be registered before any function()/class_ that
+    // returns or accepts them.
     emscripten::value_object<Vec3>("Vec3")
         .field("x", &Vec3::x)
         .field("y", &Vec3::y)
@@ -55,4 +65,15 @@ EMSCRIPTEN_BINDINGS(watershed_native) {
         .field("flow", &WaterForceResult::flow)
         .field("turbulence", &WaterForceResult::turbulence)
         .field("submergedRatio", &WaterForceResult::submergedRatio);
+
+    emscripten::function("getVersion",       &getVersion);
+    emscripten::function("calculateBuoyancyAndDrag", &calculateBuoyancyAndDrag);
+    emscripten::function("calculateWaterForce", &calculateWaterForce);
+    emscripten::function("computeWaterForcesBatch", &computeWaterForcesBatch);
+    emscripten::function("computeBuoyancy",  &computeBuoyancy);
+    emscripten::function("computeDragForce", &computeDragForce);
+    emscripten::function("computeFlowForce", &computeFlowForce);
+    emscripten::function("stepShallowWater", &stepShallowWater);
+    emscripten::function("allocateGrid",     &allocateGrid);
+    emscripten::function("freeGrid",         &freeGrid);
 }

--- a/emscripten/common.h
+++ b/emscripten/common.h
@@ -1,0 +1,41 @@
+/**
+ * common.h — shared value types, constants, and math helpers.
+ *
+ * Included by forces.h and swe.h (and transitively by forces.cpp / swe.cpp /
+ * bindings.cpp). Embind-free by design: <emscripten/bind.h> is quarantined
+ * to bindings.cpp only, so this header must never pull it in.
+ */
+
+#ifndef WATERSHED_COMMON_H
+#define WATERSHED_COMMON_H
+
+#include <cstdint>
+
+// ---------------------------------------------------------------------------
+// Compile-time constants
+// ---------------------------------------------------------------------------
+static constexpr float WATER_DENSITY_DEFAULT = 1000.0f;  // kg/m³  (fresh water)
+static constexpr float GRAVITY_DEFAULT       = 9.80665f; // m/s² (standard gravity)
+static constexpr float DAMPING_COEFF         = 0.1f;     // velocity damping per second
+
+/** Batch ABI stride, in floats. Mirrored by WATER_FORCE_*_STRIDE in WatershedWasm.ts. */
+static constexpr int WATER_FORCE_INPUT_STRIDE  = 8;
+static constexpr int WATER_FORCE_OUTPUT_STRIDE = 8;
+
+// ---------------------------------------------------------------------------
+// Value types crossing the Embind boundary
+// ---------------------------------------------------------------------------
+
+/** 3-component float vector (returned by computeFlowForce). */
+struct Vec3 {
+    float x = 0.f, y = 0.f, z = 0.f;
+};
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+inline float clampf(float v, float lo, float hi) noexcept {
+    return v < lo ? lo : (v > hi ? hi : v);
+}
+
+#endif  // WATERSHED_COMMON_H

--- a/emscripten/forces.cpp
+++ b/emscripten/forces.cpp
@@ -7,7 +7,7 @@
  * Change one, change the other.
  */
 
-#include "watershed_native.h"
+#include "forces.h"
 
 #include <emscripten/emscripten.h>
 #include <cmath>
@@ -180,7 +180,7 @@ WaterForceResult calculateWaterForce(float posX, float posY, float posZ,
     return result;
 }
 
-// Batch ABI for workers — strides documented in watershed_native.h.
+// Batch ABI for workers — strides documented in common.h.
 void computeWaterForcesBatch(uintptr_t inputPtr,
                              uintptr_t outputPtr,
                              int sampleCount,

--- a/emscripten/forces.h
+++ b/emscripten/forces.h
@@ -1,38 +1,14 @@
 /**
- * watershed_native.h — shared declarations for the Watershed WASM module.
+ * forces.h — public declarations for water-force math.
  *
- * Translation units:
- *   forces.cpp    — buoyancy, drag, flow, per-body and batched water forces
- *   swe.cpp       — shallow-water solver + WASM heap grid helpers
- *   bindings.cpp  — getVersion() + the Embind surface
- *
- * All compile/link flags live in CMakeLists.txt — build.sh is a thin wrapper.
+ * Implemented in forces.cpp. Embind-free — bindings.cpp includes this header
+ * and registers the Embind surface separately.
  */
 
-#ifndef WATERSHED_NATIVE_H
-#define WATERSHED_NATIVE_H
+#ifndef WATERSHED_FORCES_H
+#define WATERSHED_FORCES_H
 
-#include <cstdint>
-
-// ---------------------------------------------------------------------------
-// Compile-time constants
-// ---------------------------------------------------------------------------
-static constexpr float WATER_DENSITY_DEFAULT = 1000.0f;  // kg/m³  (fresh water)
-static constexpr float GRAVITY_DEFAULT       = 9.80665f; // m/s² (standard gravity)
-static constexpr float DAMPING_COEFF         = 0.1f;     // velocity damping per second
-
-/** Batch ABI stride, in floats. Mirrored by WATER_FORCE_*_STRIDE in WatershedWasm.ts. */
-static constexpr int WATER_FORCE_INPUT_STRIDE  = 8;
-static constexpr int WATER_FORCE_OUTPUT_STRIDE = 8;
-
-// ---------------------------------------------------------------------------
-// Value types crossing the Embind boundary
-// ---------------------------------------------------------------------------
-
-/** 3-component float vector (returned by computeFlowForce). */
-struct Vec3 {
-    float x = 0.f, y = 0.f, z = 0.f;
-};
+#include "common.h"
 
 struct WaterForceResult {
     float forceX = 0.f;
@@ -44,27 +20,6 @@ struct WaterForceResult {
     float turbulence = 0.f;
     float submergedRatio = 0.f;
 };
-
-// ---------------------------------------------------------------------------
-// Utility
-// ---------------------------------------------------------------------------
-inline float clampf(float v, float lo, float hi) noexcept {
-    return v < lo ? lo : (v > hi ? hi : v);
-}
-
-// ---------------------------------------------------------------------------
-// bindings.cpp
-// ---------------------------------------------------------------------------
-
-/**
- * Module ABI version. Bump whenever the exported surface or a batch stride
- * changes; WatershedWasm.ts documents what each version added.
- */
-int getVersion() noexcept;
-
-// ---------------------------------------------------------------------------
-// forces.cpp
-// ---------------------------------------------------------------------------
 
 /** Archimedes buoyancy: F_b = ρ · V_displaced · g (N). */
 float computeBuoyancy(float submergedVolume,
@@ -123,19 +78,4 @@ void computeWaterForcesBatch(uintptr_t inputPtr,
                              float turbulenceStrength,
                              float turbulenceFrequency) noexcept;
 
-// ---------------------------------------------------------------------------
-// swe.cpp
-// ---------------------------------------------------------------------------
-
-/** Advance the linearised shallow-water grid one CFL-clamped time step. */
-void stepShallowWater(uintptr_t hPtr, uintptr_t uPtr, uintptr_t wPtr,
-                      int width, int height,
-                      float dt, float g, float dx, float H);
-
-/** Allocate `count` zero-initialised floats in the WASM heap; returns a byte offset. */
-uintptr_t allocateGrid(int count);
-
-/** Free a pointer previously returned by allocateGrid. */
-void freeGrid(uintptr_t ptr);
-
-#endif  // WATERSHED_NATIVE_H
+#endif  // WATERSHED_FORCES_H

--- a/emscripten/swe.cpp
+++ b/emscripten/swe.cpp
@@ -7,7 +7,7 @@
  * solver must stay size-agnostic — never assume the 48x32 baseline.
  */
 
-#include "watershed_native.h"
+#include "swe.h"
 
 #include <cmath>
 #include <cstdlib>

--- a/emscripten/swe.h
+++ b/emscripten/swe.h
@@ -1,0 +1,24 @@
+/**
+ * swe.h — public declarations for the shallow-water solver + heap grid helpers.
+ *
+ * Implemented in swe.cpp. Embind-free — bindings.cpp includes this header
+ * and registers the Embind surface separately.
+ */
+
+#ifndef WATERSHED_SWE_H
+#define WATERSHED_SWE_H
+
+#include "common.h"
+
+/** Advance the linearised shallow-water grid one CFL-clamped time step. */
+void stepShallowWater(uintptr_t hPtr, uintptr_t uPtr, uintptr_t wPtr,
+                      int width, int height,
+                      float dt, float g, float dx, float H);
+
+/** Allocate `count` zero-initialised floats in the WASM heap; returns a byte offset. */
+uintptr_t allocateGrid(int count);
+
+/** Free a pointer previously returned by allocateGrid. */
+void freeGrid(uintptr_t ptr);
+
+#endif  // WATERSHED_SWE_H

--- a/src/systems/WatershedWasm.ts
+++ b/src/systems/WatershedWasm.ts
@@ -3,7 +3,7 @@
  *
  * Provides a typed, lazy-loaded interface to `public/watershed_native.js`,
  * which is compiled from `emscripten/{forces,swe,bindings}.cpp` via
- * `npm run build:wasm`. `getVersion()` returns the ABI version (currently 3).
+ * `npm run build:wasm`. `getVersion()` returns the ABI version (currently 4).
  *
  * Quick start
  * -----------


### PR DESCRIPTION
## Summary

Issue #354's Phase C prep. `emscripten/main.cpp` had already been split into `forces.cpp` / `swe.cpp` / `bindings.cpp` by a prior PR, but that split used a single shared `watershed_native.h` for every declaration, and the Embind registration block had a couple of latent correctness gaps. This PR finishes the layout described in the issue and closes those gaps ahead of the hull-sampling / multi-grid SWE work landing in these files:

- Replaced `emscripten/watershed_native.h` with three Embind-free headers:
  - `common.h` — shared constants, `Vec3`, `clampf`
  - `forces.h` — `WaterForceResult` + water-force declarations
  - `swe.h` — shallow-water solver + heap-grid declarations
- `forces.cpp` / `swe.cpp` now include only the header they need; `<emscripten/bind.h>` remains quarantined to `bindings.cpp` alone.
- Fixed `bindings.cpp`'s `EMSCRIPTEN_BINDINGS` block to register `value_object<Vec3>` / `value_object<WaterForceResult>` **before** the `function()` calls that return or accept them (previously registered after, violating the documented Embind ordering rule).
- Added `static_assert(!std::is_polymorphic_v<T>)` guards for both bound value types, per the RTTI-safety requirement (`-fno-rtti` is set at compile time).
- Bumped `getVersion()` 3 → 4 (no signature changes — purely the reorganization above) and updated the changelog comment in `bindings.cpp`.
- Updated `WASM.md`, `SYSTEMS.md`, `docs/reference/WASM_WATER_FORCES.md`, and `docs/reference/ADR_WASM_RAPIER_WATER_FORCES.md` to describe the new file layout and version bump. `src/systems/WatershedWasm.ts`'s doc comment now says "currently 4"; its `getVersion()` assertion was already `>=` (see `waterForceParity.test.ts`), so no change was needed there.
- `CMakeLists.txt` / `build.sh` / `build_colab.sh` needed no changes — the compile/link flag split (`-O3 -ffast-math -fno-exceptions -fno-rtti -msimd128 -mbulk-memory` at compile; `-s`/`--bind`/`-O3` at link) and the thread-free default (`WATERSHED_THREADS` off by default, no `-pthread`/`SHARED_MEMORY` in the default build) were already correct from the prior split.

## Test plan

- [x] `g++ -fsyntax-only` against `forces.cpp` and `swe.cpp` with a minimal `EMSCRIPTEN_KEEPALIVE` stub — both compile clean.
- [x] `g++ -fsyntax-only` against `bindings.cpp` with a minimal Embind stub (`value_object`, `function`, `EMSCRIPTEN_BINDINGS`) — confirms the static_asserts, member-pointer expressions, and reordered registration all type-check.
- [x] `./emscripten/build.sh` still exits 0 gracefully with no `emcc` on `PATH` (the no-Emscripten CI path).
- [x] `pnpm test` — 643 passed, 5 skipped (the skipped ones are the native-WASM integration/parity tests that require a built `.wasm`, same as on a machine without Emscripten).
- [x] `pnpm typecheck` — clean.
- [ ] Full Emscripten compile (`pnpm build:wasm`) — not run locally; no `emcc` available in this environment. The CI `build-with-emscripten` job will exercise this.


---
_Generated by [Claude Code](https://claude.ai/code/session_019Tuqqz4KjgUbBaGG5rJXZs)_