### PR TITLE
Pin @react-three/postprocessing to 3.0.4 (three@0.168 peer conflict)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@dimforge/rapier3d-compat": "0.19.2",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.4.0",
-    "@react-three/postprocessing": "^3.0.4",
+    "@react-three/postprocessing": "3.0.4",
     "@react-three/rapier": "^2.2.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",
@@ -65,7 +65,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@dimforge/rapier3d-compat": "0.19.2"
+      "@dimforge/rapier3d-compat": "0.19.2",
+      "@react-three/postprocessing": "3.0.4"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@dimforge/rapier3d-compat': 0.19.2
+  '@react-three/postprocessing': 3.0.4
 
 importers:
 
@@ -21,7 +22,7 @@ importers:
         specifier: ^9.4.0
         version: 9.4.2(@types/react@19.2.7)(immer@9.0.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.168.0)
       '@react-three/postprocessing':
-        specifier: ^3.0.4
+        specifier: 3.0.4
         version: 3.0.4(@react-three/fiber@9.4.2(@types/react@19.2.7)(immer@9.0.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.168.0))(@types/three@0.168.0)(react@19.2.3)(three@0.168.0)
       '@react-three/rapier':
         specifier: ^2.2.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`@react-three/postprocessing@3.0.5` (published Aug 9 2026) raised its `three` peer requirement to `>= 0.182.0`. The project still uses `three@^0.168.0`.

Cloud deploy runs plain `npm install`, which ignores `pnpm-lock.yaml` and resolves `^3.0.4` to 3.0.5 — npm then refuses the install due to the peer conflict. WASM builds succeed, but Vite never installs and `build/` is missing.

## Fix (Option A)

- Pin `@react-three/postprocessing` to exact `3.0.4` (remove caret)
- Add a `pnpm.overrides` entry as belt-and-suspenders
- Refresh `pnpm-lock.yaml` for the override config

GitHub Actions already uses `pnpm install --frozen-lockfile`; this change also makes `npm install` succeed when the lockfile is not used.

## Verification

- `pnpm install --frozen-lockfile` ✓
- `pnpm build` ✓
- Simulated `npm install` with pinned `package.json` resolves `@react-three/postprocessing@3.0.4` ✓

## Follow-up (optional)

Longer term, Option B (bump `three` to `^0.182.0` and smoke-test shaders/post-FX) is cleaner. Separately, the cloud environment install step should prefer `pnpm install --frozen-lockfile` to honor the declared `packageManager`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7745dd66-127f-4003-a722-19d830cc2ba0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7745dd66-127f-4003-a722-19d830cc2ba0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

